### PR TITLE
Explicitly skip authentication in MediaController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
 
+  before_filter :authenticate_user!
+  before_filter :require_signin_permission!
+
   rescue_from Mongoid::Errors::DocumentNotFound, :with => :error_404
   rescue_from BSON::InvalidObjectId, :with => :error_404
 

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,6 +1,4 @@
 class AssetsController < ApplicationController
-  before_filter :authenticate_user!
-  before_filter :require_signin_permission!
   before_filter :restrict_request_format
 
   def show

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,4 +1,6 @@
 class MediaController < ApplicationController
+  skip_before_filter :authenticate_user!
+  skip_before_filter :require_signin_permission!
   before_filter { set_expiry(24.hours) }
 
   def download


### PR DESCRIPTION
Makes it more explicit that authentication is not required for this
controller.  Also makes it less likely that future controllers will be
added without authentication by mistake.
