### PR TITLE
Improve test-prod parity for storage dirs

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -6,12 +6,16 @@ class AssetUploader < CarrierWave::Uploader::Base
 
   def store_dir
     id = model.id.to_s
-    path = id.match(/\A(..)(..)/)[1..2].join(File::SEPARATOR)
-    "#{ENV['GOVUK_APP_ROOT']}/uploads/assets/#{path}/#{id}"
+    "#{store_base_dir}/assets/#{id[0..1]}/#{id[2..3]}/#{id}"
   end
 
   def cache_dir
-    "/tmp/uploads"
+    "#{store_base_dir}/tmp"
+  end
+
+  # Split out the base storage dir so that it can be overridden in tests.
+  def store_base_dir
+    "#{ENV['GOVUK_APP_ROOT']}/uploads"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -14,13 +14,14 @@ describe "Media requests" do
 
       get "/media/#{@asset.id}/asset.png", nil, {
         "HTTP_X_SENDFILE_TYPE" => "X-Accel-Redirect",
-        "HTTP_X_ACCEL_MAPPING" => "#{Rails.root}/tmp/test_uploads/asset/=/raw/"
+        "HTTP_X_ACCEL_MAPPING" => "#{Rails.root}/tmp/test_uploads/assets/=/raw/"
       }
     end
 
     it "should set the X-Accel-Redirect header" do
       response.should be_success
-      response.headers["X-Accel-Redirect"].should == "/raw/#{@asset.id}/#{@asset.file.identifier}"
+      id = @asset.id.to_s
+      response.headers["X-Accel-Redirect"].should == "/raw/#{id[0..1]}/#{id[2..3]}/#{id}/#{@asset.file.identifier}"
     end
   end
 end

--- a/spec/support/carrier_wave.rb
+++ b/spec/support/carrier_wave.rb
@@ -1,14 +1,9 @@
-CarrierWave::Uploader::Base.descendants.each do |klass|
-  next if klass.anonymous?
-  klass.class_eval do
-    def cache_dir
-      "#{Rails.root}/tmp/test_uploads/tmp"
-    end
-
-    def store_dir
-      "#{Rails.root}/tmp/test_uploads/#{model.class.to_s.underscore}/#{model.id}"
-    end
+AssetUploader.class_eval do
+  def store_base_dir
+    "#{Rails.root}/tmp/test_uploads"
   end
+
+  enable_processing = false
 end
 
 def clean_upload_directory!
@@ -18,5 +13,3 @@ end
 RSpec.configuration.after(:suite) do
   clean_upload_directory!
 end
-
-AssetUploader.enable_processing = false


### PR DESCRIPTION
We now only override the base storage dir, not the full storage path.  This enables the path calculation logic to be covered by tests.

This also fixes a bug where the path segments would skip over any non-digit chars (i.e. a-f) in the id.  As a result, there is a manual fixup task to be done after deployment to fix the storage dirs for any assets that have a non-digit in the first 4 chars of their id.
