### PR TITLE
Tweak store path generation to improve directory distribution

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -6,7 +6,9 @@ class AssetUploader < CarrierWave::Uploader::Base
 
   def store_dir
     id = model.id.to_s
-    "#{store_base_dir}/assets/#{id[0..1]}/#{id[2..3]}/#{id}"
+    # We use chars 2-5 of the timestamp portion of the BSON id (see http://docs.mongodb.org/manual/core/object-id/)
+    # to achieve a good distribution of directories
+    "#{store_base_dir}/assets/#{id[2..3]}/#{id[4..5]}/#{id}"
   end
 
   def cache_dir

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -21,7 +21,7 @@ describe "Media requests" do
     it "should set the X-Accel-Redirect header" do
       response.should be_success
       id = @asset.id.to_s
-      response.headers["X-Accel-Redirect"].should == "/raw/#{id[0..1]}/#{id[2..3]}/#{id}/#{@asset.file.identifier}"
+      response.headers["X-Accel-Redirect"].should == "/raw/#{id[2..3]}/#{id[4..5]}/#{id}/#{@asset.file.identifier}"
     end
   end
 end


### PR DESCRIPTION
Use the middle 2 bytes of the timestamp in the mongo id (see http://docs.mongodb.org/manual/core/object-id/).
