### PR TITLE
Add lograge for processable logs in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,5 @@ group :development, :test do
 
   gem "factory_girl_rails", "~> 4.0"
 end
+
+gem 'lograge', '0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
     jwt (0.1.5)
       multi_json (>= 1.0)
     kgio (2.7.4)
+    lograge (0.1.2)
+      actionpack
+      activesupport
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -194,6 +197,7 @@ DEPENDENCIES
   exception_notification (= 2.6.1)
   factory_girl_rails (~> 4.0)
   gds-sso (= 3.0.0)
+  lograge (= 0.1.2)
   mongoid (= 2.4.12)
   plek (= 1.3.0)
   rails (= 3.2.13)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,9 @@ AssetManager::Application.configure do
   # the I18n.default_locale when a translation can not be found)
   config.i18n.fallbacks = true
 
+  # Enable lograge
+  config.lograge.enabled = true
+
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 


### PR DESCRIPTION
This means that logs are single line, not multiline, and so can be processed by eg Kibana sanely.

I think this is all that needs to be done, but maybe there's puppet config too?
