### PR TITLE
Set cache-control headers for asset API responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,10 @@ private
   def error(code, message)
     render :json => {:_response_info => {:status => message}}, :status => code
   end
+
+  def set_expiry(duration)
+    unless Rails.env.development?
+      expires_in duration, :public => true
+    end
+  end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -4,6 +4,7 @@ class AssetsController < ApplicationController
   def show
     @asset = Asset.find(params[:id])
 
+    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render :json => AssetPresenter.new(@asset, view_context)
   end
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -17,11 +17,4 @@ class MediaController < ApplicationController
     end
   end
 
-  protected
-
-  def set_expiry(duration)
-    unless Rails.env.development?
-      expires_in duration, :public => true
-    end
-  end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -91,6 +91,31 @@ describe AssetsController do
         body['_response_info']['status'].should == "not found"
       end
     end
+
+    describe "cache headers" do
+      it "sets the cache-control headers to 0 for an unscanned asset" do
+        asset = FactoryGirl.create(:asset, :state => 'unscanned')
+        get :show, id: asset.id
+
+        response.headers["Cache-Control"].should == "max-age=0, public"
+      end
+
+      it "sets the cache-control headers to 30 minutes for a clean asset" do
+        asset = FactoryGirl.create(:asset)
+        asset.scanned_clean!
+        get :show, id: asset.id
+
+        response.headers["Cache-Control"].should == "max-age=1800, public"
+      end
+
+      it "sets the cache-control headers to 30 minutes for an infected asset" do
+        asset = FactoryGirl.create(:asset)
+        asset.scanned_infected!
+        get :show, id: asset.id
+
+        response.headers["Cache-Control"].should == "max-age=1800, public"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Cache API responses for assets for 30 minutes, except where the asset has not been virus-scanned, where we set a cache-time of 0.
