### PR TITLE
Change private host ENV VAR to be more explicit.

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -27,7 +27,7 @@ protected
   end
 
   def requested_via_private_vhost?
-    request.host == ENV['PRIVATE_ASSET_HOST']
+    request.host == ENV['PRIVATE_ASSET_MANAGER_HOST']
   end
 
   def asset_present_and_clean?


### PR DESCRIPTION
This was driven by a need for clarity in the puppet config, to avoid confusion with the external asset host var.
