### PR TITLE
Use govuk_setenv in startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3037
+govuk_setenv asset-manager bundle exec rails s -p 3037


### PR DESCRIPTION
Not having GOVUK_APP_ROOT set correctly in your environment can prevent Nginx from serving asset files. This is particularly tricky when it defaults to `Rails.root` which may be the same path but with symlinks resolved.

@alext suggested this fix to ensure the environment is set correctly.
