### PR TITLE
Fix issue with filename history

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -31,10 +31,9 @@ class Asset
   end
 
   def file=(file)
+    old_filename = filename
     super(file).tap {
-      if file
-        filename_history.push(File.basename(file.original_filename))
-      end
+      filename_history.push(old_filename) if old_filename
     }
   end
 
@@ -43,7 +42,7 @@ class Asset
   end
 
   def filename
-    file.file.identifier
+    file.file.try(:identifier)
   end
 
   def scan_for_viruses


### PR DESCRIPTION
https://trello.com/c/iSqthcCg/71-bug-404-error-when-opening-attachment

As we were testing something with SpecialistPublisher, we saw that files with spaces in their names were always 404ing. After some investigation by myself and @evilstreak, we saw that the code merged in https://github.com/alphagov/asset-manager/pull/31 was generating a filename_history before Carrierwave had a chance to convert spaces to underscores, so the URL would always look for the_document.pdf and the filename history had 'the document.pdf'.

As we were looking into this, we also noticed that any file uploaded before the merge would have a blank filename history which would cause them to 404. 

The commits in this PR only update filename history when the file is replaced and the `valid_filenames` method looks in both the history and the current filename.
