### PR TITLE
Bump gds-sso to 9.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,4 @@
 GEM
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   remote: https://rubygems.org/
   specs:
     actionmailer (3.2.17)


### PR DESCRIPTION
This is to fix an issue with transfer ot bearer tokens.  See
https://github.com/alphagov/signonotron2/pull/245 for details.

Also cleaned up redundant gemfury source line.
