### PR TITLE
Strip out the `Client-IP` header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ end
 
 gem 'plek', '1.3.0'
 gem 'logstasher', '0.4.8'
+gem 'rack_strip_client_ip', '0.0.1'
 
 group :assets do
   gem 'uglifier', '>= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack_strip_client_ip (0.0.1)
     rails (3.2.17)
       actionmailer (= 3.2.17)
       actionpack (= 3.2.17)
@@ -200,6 +201,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mongoid (= 2.4.12)
   plek (= 1.3.0)
+  rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.17)
   rspec-rails (= 2.12.2)
   simplecov-rcov (= 0.2.3)


### PR DESCRIPTION
We don't use this header anywhere in our stack, using `X-Forwarded-For` instead. If a request comes in with both headers set, and they don't match, Rails will take this as evidence that someone is trying to spoof their IP address to gain unauthorised access to something.

This is based on https://github.com/alphagov/static/pull/470.
