### PR TITLE
Use a relative URL for redirection

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -50,6 +50,7 @@ protected
       :action => :download,
       id: params[:id],
       filename: asset.filename,
+      only_path: true,
     )
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -50,7 +50,7 @@ describe MediaController do
         it "redirects to the new file name" do
           get :download, id: @asset.id, filename: old_file_name
 
-          response.should redirect_to("/media/#{@asset.id}/asset.png")
+          response.location.should =~ %r(\A/media/#{@asset.id}/asset.png)
         end
       end
 


### PR DESCRIPTION
Without this, requests to assets.digital.cabinet.office.gov.uk are redirected to assets-origin.production.alphagov.co.uk, which is not publically available.