### PR TITLE
Improve readme

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,34 @@ for various applications.
 Initially, this will only be an API, and the asset serving mechanism,
 but it may well develop an admin interface in time.
 
-## Prerequisites
+### Dependencies
+
+- MongoDB
+- Delayed Job
+- govuk_clamscan
 
 Virus scanning expects `govuk_clamscan` to exist on the PATH,
 and be a symlink to either `clamscan` or `clamdscan`, which are
 part of `clamav`.
+
+### Development
+
+To launch the application, run `./startup.sh` in the `asset_manager` directory on the VM.
+
+The application runs on port `3037` by default. If you're using the GDS VM it's exposed on http://asset-manager.dev.gov.uk.
+
+You can also run it via bowl on the GDS dev VM:
+
+```
+bowl asset_manager
+```
+
+Newly uploaded assets will return 404 until they've been scanned for viruses. Scanning for viruses is done asynchronously via Delayed Job. Run Delayed Job queue processor:
+
+```
+bundle exec rake jobs:work
+```
+
+### Testing
+
+`bundle exec rspec`

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ bundle exec rake jobs:work
 ### Testing
 
 `bundle exec rspec`
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
It took me a while to understand why I could see my uploaded assets in dev environtment, so here's an improved readme that should save time for other developers looking at this.

I've also added a MIT licence because this repo didn't seem to have any.

In addition to this PR the repo could benefit from adding a one line description on GitHub (someone with admin access to the repo should be able to do that)