### PR TITLE
Soft delete assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'plek', '1.3.0'
 gem 'logstasher', '0.4.8'
 gem 'rack_strip_client_ip', '0.0.1'
 
+gem 'mongoid_paranoia', '0.2.1'
+
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
     mongoid-grid_fs (2.2.1)
       mime-types (>= 1.0, < 3.0)
       mongoid (>= 3.0, < 6.0)
+    mongoid_paranoia (0.2.1)
+      mongoid (>= 4)
+      mongoid-compatibility
     moped (2.0.7)
       bson (~> 3.0)
       connection_pool (~> 2.0)
@@ -247,6 +250,7 @@ DEPENDENCIES
   gds-sso (~> 11.2)
   logstasher (= 0.4.8)
   mongoid (~> 4.0)
+  mongoid_paranoia (= 0.2.1)
   nokogiri (= 1.6.6.4)
   plek (= 1.3.0)
   rack_strip_client_ip (= 0.0.1)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -28,7 +28,17 @@ class AssetsController < ApplicationController
     end
   end
 
-private
+  def destroy
+    @asset = Asset.find(params.fetch(:id))
+
+    if @asset.destroy
+      render :json => AssetPresenter.new(@asset, view_context).as_json(:status => :success)
+    else
+      error 422, @asset.errors.full_messages
+    end
+  end
+
+  private
   def restrict_request_format
     request.format = :json
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,6 +2,7 @@ require 'virus_scanner'
 
 class Asset
   include Mongoid::Document
+  include Mongoid::Paranoia
   include Mongoid::Timestamps
 
   field :file, type: String

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :assets, :only => [:show, :create, :update]
+  resources :assets, :only => [:show, :create, :update, :destroy]
 
   get "/media/:id/:filename" => "media#download", :constraints => { :filename => /.*/ }
 

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -112,6 +112,56 @@ RSpec.describe AssetsController, type: :controller do
     end
   end
 
+  describe "DELETE destroy" do
+    context "a valid asset" do
+      before do
+        @asset = FactoryGirl.create(:asset)
+        @atts = {
+          :file => load_fixture_file("asset2.jpg"),
+        }
+      end
+
+      it "deletes the asset" do
+        delete :destroy, id: @asset.id
+
+        expect((get :show, id: @asset.id).status).to eq(404)
+      end
+
+      it "returns a success status" do
+        delete :destroy, id: @asset.id
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "an asset that doesn't exist" do
+      it "responds with 404" do
+        delete :destroy, id: "12345"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when Asset#destroy fails" do
+      let(:asset) { FactoryGirl.create(:asset) }
+      let(:errors) { ActiveModel::Errors.new(asset) }
+
+      before do
+        errors.add(:base, "Something went wrong")
+        allow_any_instance_of(Asset).to receive(:destroy).and_return(false)
+        allow_any_instance_of(Asset).to receive(:errors).and_return(errors)
+        delete :destroy, id: asset.id
+      end
+
+      it "responds with 422" do
+        expect(response.status).to eq(422)
+      end
+
+      it "returns the asset errors" do
+        expect(response.body).to match(/Something went wrong/)
+      end
+    end
+  end
+
   describe "GET show" do
     context "an asset which exists" do
       before do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -142,5 +142,16 @@ RSpec.describe MediaController, type: :controller do
         expect(response).to be_success
       end
     end
+
+    context "with a soft deleted file" do
+      before do
+        @asset = FactoryGirl.create(:deleted_asset)
+        get :download, :id => @asset.id.to_s, :filename => @asset.file.file.identifier
+      end
+
+      it "response should be 404" do
+        expect(response.status).to eq(404)
+      end
+    end
   end
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -18,6 +18,10 @@ FactoryGirl.define do
     organisation_slug 'example-organisation'
   end
 
+  factory :deleted_asset, :parent => :asset do
+    deleted_at Time.now
+  end
+
   factory :user do
     sequence(:name) { |n| "Winston #{n}"}
     permissions { ["signin"] }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -204,4 +204,17 @@ RSpec.describe Asset, type: :model do
       expect(asset.accessible_by?(nil)).to be_falsey
     end
   end
+
+  describe "soft deletion" do
+    let(:asset) { Asset.new(:file => load_fixture_file("asset.png")) }
+
+    it "includes the Mongoid::Paranoia library" do
+      expect(asset).to be_a(Mongoid::Paranoia)
+    end
+
+    it "adds a deleted_at timestamp to the record" do
+      asset.destroy
+      expect(asset.deleted_at).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Part of https://trello.com/c/zLrCEavw/263-delete-attachments-feature-medium

Adds the route DELETE #destroy for assets.
Assets are soft deleted using the `mongoid_paranoia` gem. Requests to show a soft deleted asset or download media belonging to a soft deleted asset will respond with 404 as this is the default behaviour for rescued `Mongoid::Errors::DocumentNotFound` [in the application controller](https://github.com/alphagov/asset-manager/blob/master/app/controllers/application_controller.rb#L10).