### PR TITLE
Restore assets

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,6 +38,16 @@ class AssetsController < ApplicationController
     end
   end
 
+  def restore
+    @asset = Asset.unscoped.find(params.fetch(:id))
+
+    if @asset.restore
+      render :json => AssetPresenter.new(@asset, view_context).as_json(:status => :success)
+    else
+      error 422, @asset.errors.full_messages
+    end
+  end
+
   private
   def restrict_request_format
     request.format = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :assets, :only => [:show, :create, :update, :destroy]
+  post "/assets/:id/restore", to: "assets#restore"
 
   get "/media/:id/:filename" => "media#download", :constraints => { :filename => /.*/ }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -216,5 +216,12 @@ RSpec.describe Asset, type: :model do
       asset.destroy
       expect(asset.deleted_at).not_to be_nil
     end
+
+    it "can be restored" do
+      asset.destroy
+      expect(asset.deleted_at).not_to be_nil
+      asset.restore
+      expect(asset.deleted_at).to be_nil
+    end
   end
 end

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -99,4 +99,47 @@ RSpec.describe "Asset requests", type: :request do
       expect(body["_response_info"]["status"]).to eq("not found")
     end
   end
+
+  describe "deleting an asset" do
+    it "soft deletes an existing asset" do
+      asset = FactoryGirl.create(:clean_asset)
+
+      delete "/assets/#{asset.id}"
+      body = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(body["_response_info"]["status"]).to eq("success")
+      expect(body["id"]).to eq("http://www.example.com/assets/#{asset.id}")
+      expect(body["name"]).to eq("asset.png")
+      expect(body["content_type"]).to eq("image/png")
+      expect(body["file_url"]).to eq("http://assets.digital.cabinet-office.gov.uk/media/#{asset.id}/asset.png")
+      expect(body["state"]).to eq("clean")
+
+      get "/assets/#{asset.id}"
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "restoring an asset" do
+    it "restores a soft deleted asset" do
+      asset = FactoryGirl.create(:clean_asset)
+
+      post "/assets/#{asset.id}/restore"
+
+      body = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(body["_response_info"]["status"]).to eq("success")
+      expect(body["id"]).to eq("http://www.example.com/assets/#{asset.id}")
+      expect(body["name"]).to eq("asset.png")
+      expect(body["content_type"]).to eq("image/png")
+      expect(body["file_url"]).to eq("http://assets.digital.cabinet-office.gov.uk/media/#{asset.id}/asset.png")
+      expect(body["state"]).to eq("clean")
+
+      get "/assets/#{asset.id}"
+
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
Part of: https://trello.com/c/Vn2SpooI/279-document-attachments-still-visible-when-document-is-unpublished-large

Soft deleted assets can be restored via the `/assets/:id/restore` route.
This allows withdrawn content with soft deleted assets to be unwithdrawn and their assets restored.