### PR TITLE
Set up env vars for secrets

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,1 +1,8 @@
-# To be overwritten on deployment
+if ENV["ERRBIT_API_KEY"].present?
+  Airbrake.configure do |config|
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
+    config.secure = true
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+  end
+end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,8 +1,6 @@
 GDS::SSO.config do |config|
-  config.user_model   = 'User'
-
-  config.oauth_id     = 'abcdefghjasndjkasndassetmanager'
-  config.oauth_secret = 'secret'
-
+  config.user_model   = "User"
+  config.oauth_id     = ENV["OAUTH_ID"]
+  config.oauth_secret = ENV["OAUTH_SECRET"]
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
This sets up env vars so they can be used instead of them being replaced at deploy time.

This should not be merged until the following are merged and deployed:

- [x] https://github.gds/gds/deployment/pull/1133
- [x] https://github.com/alphagov/govuk-puppet/pull/5015