### PR TITLE
Use plek for errbit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ else
   gem 'gds-sso', '~> 11.2'
 end
 
-gem 'plek', '1.3.0'
+gem 'plek', '~> 2.0'
 gem 'logstasher', '0.4.8'
 gem 'rack_strip_client_ip', '0.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     astrolabe (1.3.1)
       parser (~> 2.2)
     bson (3.2.6)
-    builder (3.2.2)
+    builder (3.2.3)
     carrierwave (0.10.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -148,8 +148,7 @@ GEM
     origin (2.1.1)
     parser (2.3.3.1)
       ast (~> 2.2)
-    plek (1.3.0)
-      builder
+    plek (2.0.0)
     powerpack (0.1.1)
     rack (1.6.4)
     rack-accept (0.4.5)
@@ -271,7 +270,7 @@ DEPENDENCIES
   mongoid (~> 4.0)
   mongoid_paranoia (= 0.2.1)
   nokogiri (= 1.6.6.4)
-  plek (= 1.3.0)
+  plek (~> 2.0)
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.7.1)
   rspec-rails (~> 3.3.0)
@@ -281,4 +280,4 @@ DEPENDENCIES
   unicorn (= 5.0.1)
 
 BUNDLED WITH
-   1.10.6
+   1.13.0

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,8 +1,10 @@
 if ENV["ERRBIT_API_KEY"].present?
+  errbit_uri = Plek.find_uri("errbit")
+
   Airbrake.configure do |config|
     config.api_key = ENV["ERRBIT_API_KEY"]
-    config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
-    config.secure = true
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
     config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
   end
 end


### PR DESCRIPTION
This allows the errbit configuration to be tailored more to the environment, which is useful for end to end tests.