### PR TITLE
Upload assets to S3 [DO NOT MERGE]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'rack_strip_client_ip', '0.0.1'
 
 gem 'mongoid_paranoia', '0.2.1'
 
+gem 'aws-sdk', '~> 2'
+
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,14 @@ GEM
       multi_json
     arel (6.0.3)
     ast (2.3.0)
+    aws-sdk (2.10.10)
+      aws-sdk-resources (= 2.10.10)
+    aws-sdk-core (2.10.10)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.10.10)
+      aws-sdk-core (= 2.10.10)
+    aws-sigv4 (1.0.1)
     bson (3.2.6)
     builder (3.2.3)
     carrierwave (0.10.0)
@@ -87,6 +95,7 @@ GEM
       scss_lint
     hashie (3.4.3)
     i18n (0.7.0)
+    jmespath (1.3.1)
     json (1.8.3)
     jwt (1.5.2)
     kgio (2.10.0)
@@ -251,6 +260,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.0.0)
+  aws-sdk (~> 2)
   carrierwave (~> 0.10.0)
   carrierwave-mongoid (~> 0.8.1)
   database_cleaner

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -16,7 +16,12 @@ class MediaController < ApplicationController
     respond_to do |format|
       format.any do
         set_expiry(24.hours)
-        send_file(asset.file.path, disposition: 'inline')
+        if params[:stream_from_s3].present?
+          body = S3Uploader.new(asset).download
+          send_data(body.read, filename: File.basename(asset.file.path), disposition: 'inline')
+        else
+          send_file(asset.file.path, disposition: 'inline')
+        end
       end
     end
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -26,7 +26,9 @@ class Asset
       transition any => :clean
     end
 
-    after_transition to: :clean, do: :upload_to_s3
+    after_transition to: :clean do |asset, _|
+      asset.delay.upload_to_s3
+    end
 
     event :scanned_infected do
       transition any => :infected

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -26,6 +26,8 @@ class Asset
       transition any => :clean
     end
 
+    after_transition to: :clean, do: :upload_to_s3
+
     event :scanned_infected do
       transition any => :infected
     end
@@ -63,6 +65,10 @@ class Asset
     return true unless access_limited?
 
     user && user.organisation_slug == self.organisation_slug
+  end
+
+  def upload_to_s3
+    S3Uploader.new(self).upload
   end
 
 protected

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -4,9 +4,7 @@ class S3Uploader
   end
 
   def upload
-    s3_resource = Aws::S3::Resource.new
-    bucket = s3_resource.bucket(ENV['BUCKET_NAME'])
-    object = bucket.object(@asset.id.to_s)
+    object = Aws::S3::Object.new(bucket_name: ENV['BUCKET_NAME'], key: @asset.id.to_s)
     object.upload_file(@asset.file.path)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: @asset.id.to_s, file: @asset.file.path })

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -1,0 +1,8 @@
+class S3Uploader
+  def initialize(asset)
+    @asset = asset
+  end
+
+  def upload
+  end
+end

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -8,5 +8,8 @@ class S3Uploader
     bucket = s3_resource.bucket(ENV['BUCKET_NAME'])
     object = bucket.object(@asset.id.to_s)
     object.upload_file(@asset.file.path)
+  rescue => e
+    Airbrake.notify_or_ignore(e, params: { id: @asset.id.to_s, file: @asset.file.path })
+    raise
   end
 end

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -10,4 +10,9 @@ class S3Uploader
     Airbrake.notify_or_ignore(e, params: { id: @asset.id.to_s, file: @asset.file.path })
     raise
   end
+
+  def download
+    object = Aws::S3::Object.new(bucket_name: Rails.configuration.bucket_name, key: @asset.id.to_s)
+    object.get.body
+  end
 end

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -4,5 +4,9 @@ class S3Uploader
   end
 
   def upload
+    s3_resource = Aws::S3::Resource.new
+    bucket = s3_resource.bucket(ENV['BUCKET_NAME'])
+    object = bucket.object(@asset.id.to_s)
+    object.upload_file(@asset.file.path)
   end
 end

--- a/app/uploaders/s3_uploader.rb
+++ b/app/uploaders/s3_uploader.rb
@@ -4,7 +4,7 @@ class S3Uploader
   end
 
   def upload
-    object = Aws::S3::Object.new(bucket_name: ENV['BUCKET_NAME'], key: @asset.id.to_s)
+    object = Aws::S3::Object.new(bucket_name: Rails.configuration.bucket_name, key: @asset.id.to_s)
     object.upload_file(@asset.file.path)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: @asset.id.to_s, file: @asset.file.path })

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,1 @@
+Rails.application.config.bucket_name = ENV['BUCKET_NAME'] || false

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe MediaController, type: :controller do
         @asset = FactoryGirl.create(:clean_asset)
       end
 
-      def do_get
-        get :download, id: @asset.id.to_s, filename: @asset.file.file.identifier
+      def do_get(extra_params = {})
+        get :download, { id: @asset.id.to_s, filename: @asset.file.file.identifier }.merge(extra_params)
       end
 
       it "should be successful" do
@@ -36,6 +36,39 @@ RSpec.describe MediaController, type: :controller do
         do_get
 
         expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+      end
+
+      context "when stream_from_s3 param is present" do
+        let(:io) { StringIO.new('s3-object-data') }
+        let(:s3_uploader) { double(:s3_uploader) }
+
+        before do
+          allow(S3Uploader).to receive(:new).with(@asset).and_return(s3_uploader)
+          allow(s3_uploader).to receive(:download).and_return(io)
+        end
+
+        it "should be successful" do
+          do_get stream_from_s3: true
+          expect(response).to be_success
+        end
+
+        it "should send the file using send_data" do
+          expect(controller).to receive(:send_data).with('s3-object-data', filename: 'asset.png', disposition: "inline")
+          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_file
+
+          do_get stream_from_s3: true
+        end
+
+        it "should have the correct content type" do
+          do_get stream_from_s3: true
+          expect(response.headers["Content-Type"]).to eq("image/png")
+        end
+
+        it "should set the cache-control headers to 24 hours" do
+          do_get stream_from_s3: true
+
+          expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+        end
       end
 
       context "when the file name in the URL represents an old version" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -100,6 +100,21 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "when a file is scanned clean" do
+    before :each do
+      @asset = FactoryGirl.create(:asset)
+      allow_any_instance_of(VirusScanner).to receive(:clean?).and_return(true)
+    end
+
+    it 'uploads the file to s3' do
+      s3_uploader = double(:upload)
+      expect(S3Uploader).to receive(:new).with(@asset).and_return(s3_uploader)
+      expect(s3_uploader).to receive(:upload)
+
+      @asset.scan_for_viruses
+    end
+  end
+
   describe "virus_scanning the attached file" do
     before :each do
       @asset = FactoryGirl.create(:asset)

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -100,18 +100,38 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "when a file is scanned clean" do
-    before :each do
-      @asset = FactoryGirl.create(:asset)
-      allow_any_instance_of(VirusScanner).to receive(:clean?).and_return(true)
+  describe "#upload_to_s3" do
+    let(:asset) { FactoryGirl.create(:clean_asset) }
+    let(:s3_uploader) { double(upload: nil) }
+
+    before do
+      allow(S3Uploader).to receive(:new).and_return(s3_uploader)
     end
 
-    it 'uploads the file to s3' do
-      s3_uploader = double(:upload)
-      expect(S3Uploader).to receive(:new).with(@asset).and_return(s3_uploader)
+    it 'instantiates an instance of S3Uploader with self' do
+      expect(S3Uploader).to receive(:new).with(asset)
+
+      asset.upload_to_s3
+    end
+
+    it 'calls upload' do
       expect(s3_uploader).to receive(:upload)
 
-      @asset.scan_for_viruses
+      asset.upload_to_s3
+    end
+  end
+
+  describe "when a file is scanned clean" do
+    it 'queues the upload of the file to s3' do
+      asset = FactoryGirl.create(:asset)
+
+      expect {
+        asset.scanned_clean
+      }.to change(Delayed::Job, :count).by(1)
+
+      job = Delayed::Job.last
+      expect(job.payload_object.object).to eq(asset)
+      expect(job.payload_object.method_name).to eq(:upload_to_s3)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ SimpleCov.start 'rails'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:each) do
+    allow_any_instance_of(S3Uploader).to receive(:upload)
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -10,3 +10,4 @@ end
 RSpec.configuration.include FileHelpers, type: :model
 RSpec.configuration.include FileHelpers, type: :controller
 RSpec.configuration.include FileHelpers, type: :request
+RSpec.configuration.include FileHelpers, type: :uploader

--- a/spec/uploaders/s3_uploader_spec.rb
+++ b/spec/uploaders/s3_uploader_spec.rb
@@ -9,12 +9,11 @@ RSpec.describe S3Uploader, type: :uploader do
   before do
     allow(subject).to receive(:upload).and_call_original
     allow(Aws::S3::Object).to receive(:new).and_return(object)
-    allow(ENV).to receive(:[]).with('BUCKET_NAME').and_return('bucket-name')
   end
 
   describe '#upload' do
     it 'creates an object in the named bucket with the asset id as a key' do
-      expect(Aws::S3::Object).to receive(:new).with(bucket_name: 'bucket-name', key: asset.id.to_s)
+      expect(Aws::S3::Object).to receive(:new).with(bucket_name: Rails.configuration.bucket_name, key: asset.id.to_s)
 
       subject.upload
     end

--- a/spec/uploaders/s3_uploader_spec.rb
+++ b/spec/uploaders/s3_uploader_spec.rb
@@ -5,17 +5,16 @@ RSpec.describe S3Uploader, type: :uploader do
   subject { described_class.new(asset) }
 
   let(:object) { double(:object, upload_file: nil) }
-  let(:bucket) { double(:bucket, object: object) }
-  let(:s3_resource) { double(bucket: bucket) }
 
   before do
     allow(subject).to receive(:upload).and_call_original
-    allow(Aws::S3::Resource).to receive(:new).and_return(s3_resource)
+    allow(Aws::S3::Object).to receive(:new).and_return(object)
+    allow(ENV).to receive(:[]).with('BUCKET_NAME').and_return('bucket-name')
   end
 
   describe '#upload' do
-    it 'creates an object with the same id as the asset' do
-      expect(bucket).to receive(:object).with(asset.id.to_s)
+    it 'creates an object in the named bucket with the asset id as a key' do
+      expect(Aws::S3::Object).to receive(:new).with(bucket_name: 'bucket-name', key: asset.id.to_s)
 
       subject.upload
     end

--- a/spec/uploaders/s3_uploader_spec.rb
+++ b/spec/uploaders/s3_uploader_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe S3Uploader, type: :uploader do
+  let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+  subject { described_class.new(asset) }
+
+  let(:object) { double(:object, upload_file: nil) }
+  let(:bucket) { double(:bucket, object: object) }
+  let(:s3_resource) { double(bucket: bucket) }
+
+  before do
+    allow(subject).to receive(:upload).and_call_original
+    allow(Aws::S3::Resource).to receive(:new).and_return(s3_resource)
+  end
+
+  describe '#upload' do
+    it 'creates an object with the same id as the asset' do
+      expect(bucket).to receive(:object).with(asset.id.to_s)
+
+      subject.upload
+    end
+
+    it 'uploads the object to S3' do
+      expect(object).to receive(:upload_file).with(asset.file.path)
+
+      subject.upload
+    end
+  end
+end

--- a/spec/uploaders/s3_uploader_spec.rb
+++ b/spec/uploaders/s3_uploader_spec.rb
@@ -25,5 +25,21 @@ RSpec.describe S3Uploader, type: :uploader do
 
       subject.upload
     end
+
+    context 'when uploading raises an exception' do
+      before do
+        class AnException < StandardError; end
+
+        allow(object).to receive(:upload_file).and_raise(AnException)
+      end
+
+      it 'notifies Airbrake and re-raises the exception' do
+        expect(Airbrake).to receive(:notify_or_ignore).with(AnException, params: { id: asset.id, file: asset.file.path })
+
+        expect {
+          subject.upload
+        }.to raise_error(AnException)
+      end
+    end
   end
 end

--- a/spec/uploaders/s3_uploader_spec.rb
+++ b/spec/uploaders/s3_uploader_spec.rb
@@ -40,4 +40,21 @@ RSpec.describe S3Uploader, type: :uploader do
       end
     end
   end
+
+  describe '#download' do
+    let(:body) { StringIO.new }
+    let(:get_output_object) { double(:get_output_object, body: body) }
+
+    it 'creates an object in the named bucket with the asset id as a key' do
+      expect(Aws::S3::Object).to receive(:new).with(bucket_name: Rails.configuration.bucket_name, key: asset.id.to_s)
+
+      subject.upload
+    end
+
+    it 'downloads the object from S3 and returns its body' do
+      allow(object).to receive(:get).and_return(get_output_object)
+
+      expect(subject.download).to eq(body)
+    end
+  end
 end


### PR DESCRIPTION
We're hoping to change asset-manager so that it stores its assets in, and serves its assets from S3. As a first step, this PR implements uploading of assets that have passed virus checking to S3. 

The assets are uploaded to S3 while still being stored in the existing NFS store. Assets are still served from NFS so there should be no external change to how the API works with this PR. This allows us to work out how to integrate with S3 in production without altering the existing functionality. 

I've added an `S3Uploader` class to handle uploading the assets to a bucket when virus checking has successfully completed. To test this in development you need to set the following environment variables:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
 - `BUCKET_NAME`

