### PR TITLE
Store assets on S3 as well as NFS and optionally serve from S3 on public URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'rack_strip_client_ip', '0.0.1'
 
 gem 'mongoid_paranoia', '0.2.1'
 
+gem 'aws-sdk'
+
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,14 @@ GEM
       multi_json
     arel (6.0.3)
     ast (2.3.0)
+    aws-sdk (2.10.10)
+      aws-sdk-resources (= 2.10.10)
+    aws-sdk-core (2.10.10)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.10.10)
+      aws-sdk-core (= 2.10.10)
+    aws-sigv4 (1.0.1)
     bson (3.2.6)
     builder (3.2.3)
     carrierwave (0.10.0)
@@ -87,6 +95,7 @@ GEM
       scss_lint
     hashie (3.4.3)
     i18n (0.7.0)
+    jmespath (1.3.1)
     json (1.8.3)
     jwt (1.5.2)
     kgio (2.10.0)
@@ -251,6 +260,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.0.0)
+  aws-sdk
   carrierwave (~> 0.10.0)
   carrierwave-mongoid (~> 0.8.1)
   database_cleaner

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -16,7 +16,12 @@ class MediaController < ApplicationController
     respond_to do |format|
       format.any do
         set_expiry(24.hours)
-        send_file(asset.file.path, disposition: 'inline')
+        if params[:stream_from_s3].present?
+          body = Services.cloud_storage.load(asset)
+          send_data(body.read, filename: File.basename(asset.file.path), disposition: 'inline')
+        else
+          send_file(asset.file.path, disposition: 'inline')
+        end
       end
     end
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,4 +1,5 @@
 require 'virus_scanner'
+require 'services'
 
 class Asset
   include Mongoid::Document
@@ -25,6 +26,8 @@ class Asset
     event :scanned_clean do
       transition any => :clean
     end
+
+    after_transition to: :clean, do: :save_to_cloud_storage
 
     event :scanned_infected do
       transition any => :infected
@@ -63,6 +66,10 @@ class Asset
     return true unless access_limited?
 
     user && user.organisation_slug == self.organisation_slug
+  end
+
+  def save_to_cloud_storage
+    Services.cloud_storage.save(self)
   end
 
 protected

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -27,7 +27,9 @@ class Asset
       transition any => :clean
     end
 
-    after_transition to: :clean, do: :save_to_cloud_storage
+    after_transition to: :clean do |asset, _|
+      asset.delay.save_to_cloud_storage
+    end
 
     event :scanned_infected do
       transition any => :infected

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -72,6 +72,9 @@ class Asset
 
   def save_to_cloud_storage
     Services.cloud_storage.save(self)
+  rescue => e
+    Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
+    raise
   end
 
 protected

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,3 @@
+Aws.config.update(
+  logger: Rails.logger
+)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -7,4 +7,9 @@ class S3Storage
     object = Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
     object.upload_file(asset.file.path)
   end
+
+  def load(asset)
+    object = Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
+    object.get.body
+  end
 end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,4 +1,17 @@
 class S3Storage
+  class Null
+    def save(_asset)
+    end
+
+    def load(_asset)
+      StringIO.new
+    end
+  end
+
+  def self.build(bucket_name)
+    bucket_name.present? ? new(bucket_name) : Null.new
+  end
+
   def initialize(bucket_name)
     @bucket_name = bucket_name
   end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,4 +1,10 @@
 class S3Storage
+  def initialize(bucket_name)
+    @bucket_name = bucket_name
+  end
+
   def save(asset)
+    object = Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
+    object.upload_file(asset.file.path)
   end
 end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -4,12 +4,16 @@ class S3Storage
   end
 
   def save(asset)
-    object = Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
-    object.upload_file(asset.file.path)
+    object_for(asset).upload_file(asset.file.path)
   end
 
   def load(asset)
-    object = Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
-    object.get.body
+    object_for(asset).get.body
+  end
+
+private
+
+  def object_for(asset)
+    Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
   end
 end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,0 +1,4 @@
+class S3Storage
+  def save(asset)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,7 @@
+require 's3_storage'
+
+module Services
+  def self.cloud_storage
+    @cloud_storage ||= S3Storage.new
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,6 +2,6 @@ require 's3_storage'
 
 module Services
   def self.cloud_storage
-    @cloud_storage ||= S3Storage.new(ENV['AWS_S3_BUCKET_NAME'])
+    @cloud_storage ||= S3Storage.build(ENV['AWS_S3_BUCKET_NAME'])
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,6 +2,6 @@ require 's3_storage'
 
 module Services
   def self.cloud_storage
-    @cloud_storage ||= S3Storage.new
+    @cloud_storage ||= S3Storage.new(ENV['AWS_S3_BUCKET_NAME'])
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 's3_storage'
+
+RSpec.describe S3Storage do
+  let(:asset) { FactoryGirl.build(:asset) }
+
+  describe '#save' do
+    it 'does nothing' do
+      subject.save(asset)
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe S3Storage do
   let(:asset) { FactoryGirl.build(:asset) }
   let(:s3_object_params) { { bucket_name: bucket_name, key: asset.id.to_s } }
 
-  describe '#save' do
-    before do
-      allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
-    end
+  before do
+    allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
+  end
 
+  describe '#save' do
     it 'uploads file to S3 bucket' do
       expect(s3_object).to receive(:upload_file).with(asset.file.path)
 
@@ -26,7 +26,6 @@ RSpec.describe S3Storage do
     let(:io) { StringIO.new('s3-object-data') }
 
     before do
-      allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
       allow(s3_object).to receive(:get).and_return(get_object_output)
       allow(get_object_output).to receive(:body).and_return(io)
     end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 's3_storage'
 
 RSpec.describe S3Storage do
-  subject { described_class.new(bucket_name) }
+  subject { described_class.build(bucket_name) }
 
   let(:bucket_name) { 'bucket-name' }
   let(:s3_object) { instance_double(Aws::S3::Object) }
@@ -19,6 +19,16 @@ RSpec.describe S3Storage do
 
       subject.save(asset)
     end
+
+    context 'when bucket name is blank' do
+      let(:bucket_name) { '' }
+
+      it 'does not upload file to S3 bucket' do
+        expect(Aws::S3::Object).not_to receive(:new)
+
+        subject.save(asset)
+      end
+    end
   end
 
   describe '#load' do
@@ -32,6 +42,20 @@ RSpec.describe S3Storage do
 
     it 'downloads file from S3 bucket' do
       expect(subject.load(asset)).to eq(io)
+    end
+
+    context 'when bucket name is blank' do
+      let(:bucket_name) { '' }
+
+      it 'does not download file from S3 bucket' do
+        expect(Aws::S3::Object).not_to receive(:new)
+
+        subject.load(asset)
+      end
+
+      it 'returns empty StringIO' do
+        expect(subject.load(asset).read).to eq('')
+      end
     end
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -2,10 +2,21 @@ require 'rails_helper'
 require 's3_storage'
 
 RSpec.describe S3Storage do
+  subject { described_class.new(bucket_name) }
+
+  let(:bucket_name) { 'bucket-name' }
+  let(:s3_object) { instance_double(Aws::S3::Object) }
   let(:asset) { FactoryGirl.build(:asset) }
+  let(:s3_object_params) { { bucket_name: bucket_name, key: asset.id.to_s } }
 
   describe '#save' do
-    it 'does nothing' do
+    before do
+      allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
+    end
+
+    it 'uploads file to S3 bucket' do
+      expect(s3_object).to receive(:upload_file).with(asset.file.path)
+
       subject.save(asset)
     end
   end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -20,4 +20,19 @@ RSpec.describe S3Storage do
       subject.save(asset)
     end
   end
+
+  describe '#load' do
+    let(:get_object_output) { instance_double(Aws::S3::Types::GetObjectOutput) }
+    let(:io) { StringIO.new('s3-object-data') }
+
+    before do
+      allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
+      allow(s3_object).to receive(:get).and_return(get_object_output)
+      allow(get_object_output).to receive(:body).and_return(io)
+    end
+
+    it 'downloads file from S3 bucket' do
+      expect(subject.load(asset)).to eq(io)
+    end
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -100,6 +100,22 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "when an asset is marked as clean" do
+    let(:asset) { FactoryGirl.create(:asset) }
+    let(:cloud_storage) { double(:cloud_storage) }
+
+    before do
+      allow_any_instance_of(VirusScanner).to receive(:clean?).and_return(true)
+      allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+    end
+
+    it 'saves the asset to cloud storage' do
+      expect(cloud_storage).to receive(:save).with(asset)
+
+      asset.scan_for_viruses
+    end
+  end
+
   describe "virus_scanning the attached file" do
     let(:asset) { FactoryGirl.create(:asset) }
 

--- a/spec/support/s3_storage.rb
+++ b/spec/support/s3_storage.rb
@@ -1,0 +1,8 @@
+require 'services'
+
+RSpec.configure do |config|
+  config.before do
+    cloud_storage = double(:cloud_storage).as_null_object
+    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+  end
+end


### PR DESCRIPTION
This is the first step in changing the Asset Manager to store its assets in and serve its assets from AWS S3, i.e. to avoid using NFS.

This PR means that whenever an asset is successfully virus scanned a new asynchronous job is kicked off to upload the asset to S3. The fact that it's a separate job should mean that the current external behaviour is unaffected; the assets are still stored on NFS as before.

Also if `stream_from_s3=true` is added to the query string of the public URL for an asset, then the asset will be streamed from S3 via the Asset Manager app. The default behaviour is unaffected.

Serving assets through the Rails app and not using `X-Sendfile` and nginx is naïve and may well not be practical for production use, but deploying these changes will allow us to check that we have all the appropriate infrastructure & credentials in place before we consider alternative options. This is explained in more detail in the relevant commit note.

The new behaviour requires the following standard environment variables to be set:

* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`
* `AWS_REGION`

And this application specific environment variable:

* `ASSET_MANAGER_S3_BUCKET_NAME`

Supersedes #63.
