### PR TITLE
Enable "stream from S3" functionality via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ Newly uploaded assets return 404 until they've been scanned for viruses. Scannin
 bundle exec rake jobs:work
 ```
 
+### Assets on S3
+
+This functionality is *very* experimental and should not be switched on in production until performance tests have been carried out to ensure there has been no degradation in performance.
+
+As long as the S3 bucket is configured, all assets are uploaded to the S3 bucket via a separate `Delayed::Job` triggered if virus scanning succeeds. Assets are still saved to the NFS mount as per the original behaviour.
+
+The following environment variables are only needed if you want to enable this functionality, i.e. they are all optional.
+
+#### Standard AWS environment variables
+
+* `AWS_ACCESS_KEY_ID`
+* `AWS_SECRET_ACCESS_KEY`
+* `AWS_REGION`
+
+#### Application-specific environment variables
+
+* `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
+* `STREAM_ALL_ASSETS_FROM_S3` - causes *all* assets to be served from S3 via the app
+
+#### Request parameter
+
+Assets can be streamed from S3 even if `STREAM_ALL_ASSETS_FROM_S3` is not set by adding `stream_from_s3=true` as a request parameter key-value pair to the query string.
+
 ### Testing
 
 `bundle exec rspec`

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,7 +29,8 @@ class MediaController < ApplicationController
 protected
 
   def stream_from_s3?
-    params[:stream_from_s3].present?
+    config = AssetManager::Application.config
+    config.stream_all_assets_from_s3 || params[:stream_from_s3].present?
   end
 
   def filename_current?

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,4 +1,5 @@
 AssetManager::Application.config.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
+AssetManager::Application.config.stream_all_assets_from_s3 = ENV['STREAM_ALL_ASSETS_FROM_S3'].present?
 
 Aws.config.update(
   logger: Rails.logger

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -69,6 +69,40 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
+      context "when config.stream_all_assets_from_s3 is true" do
+        let(:io) { StringIO.new('s3-object-data') }
+        let(:cloud_storage) { double(:cloud_storage) }
+
+        before do
+          allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+          allow(cloud_storage).to receive(:load).with(asset).and_return(io)
+          allow(AssetManager::Application.config).to receive(:stream_all_assets_from_s3).and_return(true)
+        end
+
+        it "should be successful" do
+          do_get
+          expect(response).to be_success
+        end
+
+        it "should send the file using send_data" do
+          expect(controller).to receive(:send_data).with('s3-object-data', filename: 'asset.png', disposition: "inline")
+          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_file
+
+          do_get
+        end
+
+        it "should have the correct content type" do
+          do_get
+          expect(response.headers["Content-Type"]).to eq("image/png")
+        end
+
+        it "should set the cache-control headers to 24 hours" do
+          do_get
+
+          expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+        end
+      end
+
       context "when the file name in the URL represents an old version" do
         let(:old_file_name) { "an_old_filename.pdf" }
 


### PR DESCRIPTION
This allows us to make streaming from S3 the default behaviour in a given environment based on the presence of the new `STREAM_ALL_ASSETS_FROM_S3` environment variable.

I've also added some documentation about the whole "Assets on S3" functionality, mainly in order to document the various environment variables.

Note that this is based on #84 and includes a squash commit of those changes which will be removed before merging.