### PR TITLE
Remove CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,6 @@
 require 'cloud_storage'
 
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :null_session
-
   include GDS::SSO::ControllerMethods
 
   before_filter :require_signin_permission!


### PR DESCRIPTION
This is an internal API and doesn't allow direct user access.

c.f. alphagov/publishing-api@40ba7fc1d163fd966500f542009de30b31412f14

Fixes #87.