### PR TITLE
Add Cache-Control header to S3 object

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ private
 
   def set_expiry(duration)
     unless Rails.env.development?
-      expires_in duration, public: true
+      expires_in duration, **AssetManager.cache_control.options
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,8 @@ private
   end
 
   def set_expiry(duration)
-    expires_in duration, public: true unless Rails.env.development?
+    unless Rails.env.development?
+      expires_in duration, public: true
+    end
   end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,8 +29,7 @@ class MediaController < ApplicationController
 protected
 
   def stream_from_s3?
-    config = AssetManager::Application.config
-    config.stream_all_assets_from_s3 || params[:stream_from_s3].present?
+    AssetManager.stream_all_assets_from_s3 || params[:stream_from_s3].present?
   end
 
   def filename_current?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -15,7 +15,7 @@ class MediaController < ApplicationController
 
     respond_to do |format|
       format.any do
-        set_expiry(24.hours)
+        set_expiry(AssetManager.cache_control.max_age)
         if stream_from_s3?
           body = Services.cloud_storage.load(asset)
           send_data(body.read, filename: File.basename(asset.file.path), disposition: 'inline')

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -71,7 +71,7 @@ class Asset
   end
 
   def save_to_cloud_storage
-    Services.cloud_storage.save(self)
+    Services.cloud_storage.save(self, cache_control: AssetManager.cache_control.header)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
     raise

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,4 +36,5 @@ module AssetManager
 
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :stream_all_assets_from_s3
+  mattr_accessor :cache_control
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,4 +33,7 @@ module AssetManager
 
     config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
   end
+
+  mattr_accessor :aws_s3_bucket_name
+  mattr_accessor :stream_all_assets_from_s3
 end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,5 @@
-AssetManager::Application.config.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
-AssetManager::Application.config.stream_all_assets_from_s3 = ENV['STREAM_ALL_ASSETS_FROM_S3'].present?
+AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
+AssetManager.stream_all_assets_from_s3 = ENV['STREAM_ALL_ASSETS_FROM_S3'].present?
 
 Aws.config.update(
   logger: Rails.logger

--- a/config/initializers/cache_control.rb
+++ b/config/initializers/cache_control.rb
@@ -1,0 +1,6 @@
+require 'cache_control_configuration'
+
+AssetManager.cache_control = CacheControlConfiguration.new(
+  max_age: 24.hours,
+  public: true
+)

--- a/lib/cache_control_configuration.rb
+++ b/lib/cache_control_configuration.rb
@@ -1,0 +1,13 @@
+class CacheControlConfiguration
+  def initialize(attributes = {})
+    @attributes = attributes
+  end
+
+  def max_age
+    @attributes[:max_age]
+  end
+
+  def options
+    @attributes.except(:max_age)
+  end
+end

--- a/lib/cache_control_configuration.rb
+++ b/lib/cache_control_configuration.rb
@@ -10,4 +10,13 @@ class CacheControlConfiguration
   def options
     @attributes.except(:max_age)
   end
+
+  def header
+    response = ActionDispatch::Response.new
+    @attributes.each do |key, value|
+      response.cache_control[key] = value
+    end
+    response.prepare!
+    response['Cache-Control']
+  end
 end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -19,8 +19,8 @@ class S3Storage
     @bucket_name = bucket_name
   end
 
-  def save(asset)
-    object_for(asset).upload_file(asset.file.path)
+  def save(asset, options = {})
+    object_for(asset).upload_file(asset.file.path, options)
   end
 
   def load(asset)

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,7 +2,6 @@ require 's3_storage'
 
 module Services
   def self.cloud_storage
-    aws_s3_bucket_name = AssetManager::Application.config.aws_s3_bucket_name
-    @cloud_storage ||= S3Storage.build(aws_s3_bucket_name)
+    @cloud_storage ||= S3Storage.build(AssetManager.aws_s3_bucket_name)
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe MediaController, type: :controller do
         before do
           allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
           allow(cloud_storage).to receive(:load).with(asset).and_return(io)
-          allow(AssetManager::Application.config).to receive(:stream_all_assets_from_s3).and_return(true)
+          allow(AssetManager).to receive(:stream_all_assets_from_s3).and_return(true)
         end
 
         it "should be successful" do

--- a/spec/lib/cache_control_configuration_spec.rb
+++ b/spec/lib/cache_control_configuration_spec.rb
@@ -18,4 +18,22 @@ RSpec.describe CacheControlConfiguration do
       expect(subject.options).to eq(public: true)
     end
   end
+
+  describe '#header' do
+    context 'when attributes are supplied to constructor' do
+      let(:attributes) { { max_age: 1.hour, public: true, must_revalidate: true } }
+
+      it 'returns Cache-Control header value c.f. expires_in' do
+        expect(subject.header).to eq('max-age=3600, public, must-revalidate')
+      end
+    end
+
+    context 'when only max_age attribute is supplied to constructor' do
+      let(:attributes) { { max_age: 1.hour } }
+
+      it "returns Cache-Control header value with default visibility" do
+        expect(subject.header).to include('private')
+      end
+    end
+  end
 end

--- a/spec/lib/cache_control_configuration_spec.rb
+++ b/spec/lib/cache_control_configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe CacheControlConfiguration do
+  subject { described_class.new(attributes) }
+
+  describe '#max_age' do
+    let(:attributes) { { max_age: 1.hour } }
+
+    it 'returns max_age attribute value' do
+      expect(subject.max_age).to eq(1.hour)
+    end
+  end
+
+  describe '#options' do
+    let(:attributes) { { max_age: 1.hour, public: true } }
+
+    it 'returns all attributes and their values except for max_age' do
+      expect(subject.options).to eq(public: true)
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -15,9 +15,15 @@ RSpec.describe S3Storage do
 
   describe '#save' do
     it 'uploads file to S3 bucket' do
-      expect(s3_object).to receive(:upload_file).with(asset.file.path)
+      expect(s3_object).to receive(:upload_file).with(asset.file.path, anything)
 
       subject.save(asset)
+    end
+
+    it 'passes options to Aws::S3::Object#upload_file' do
+      expect(s3_object).to receive(:upload_file).with(anything, cache_control: 'cache-control-header')
+
+      subject.save(asset, cache_control: 'cache-control-header')
     end
 
     context 'when bucket name is blank' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -120,13 +120,22 @@ RSpec.describe Asset, type: :model do
   describe "#save_to_cloud_storage" do
     let(:asset) { FactoryGirl.create(:clean_asset) }
     let(:cloud_storage) { double(:cloud_storage) }
+    let(:cache_control) { instance_double(CacheControlConfiguration) }
 
     before do
       allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+      allow(AssetManager).to receive(:cache_control).and_return(cache_control)
+      allow(cache_control).to receive(:header).and_return('cache-control-header')
     end
 
     it 'saves the asset to cloud storage' do
-      expect(cloud_storage).to receive(:save).with(asset)
+      expect(cloud_storage).to receive(:save).with(asset, anything)
+
+      asset.save_to_cloud_storage
+    end
+
+    it 'sets the Cache-Control header on the asset stored in the cloud' do
+      expect(cloud_storage).to receive(:save).with(anything, cache_control: 'cache-control-header')
 
       asset.save_to_cloud_storage
     end

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Media requests", type: :request do
       let(:asset) { FactoryGirl.create(:clean_asset) }
 
       before do
-        allow(AssetManager::Application.config).to receive(:aws_s3_bucket_name).and_return(nil)
+        allow(AssetManager).to receive(:aws_s3_bucket_name).and_return(nil)
       end
 
       it "should respond with internal server error status" do


### PR DESCRIPTION
We want to be able to redirect Asset Manager requests to the assets stored in an S3 bucket. However, we want as much of the externally-visible behaviour to remain the same and so we need to set the 'Cache-Control' header to the same value as in `MediaController#download`, i.e. the value generated by [`ActionController::ConditionalGet#expires_in`][1] using `ApplicationController#set_expiry`.

Closes #96.

[1]: http://api.rubyonrails.org/v4.2.7.1/classes/ActionController/ConditionalGet.html#method-i-expires_in