### PR TITLE
Fix stubbing of Services.cloud_storage

### DIFF
--- a/spec/support/cloud_storage.rb
+++ b/spec/support/cloud_storage.rb
@@ -1,8 +1,10 @@
 require 'services'
 
 RSpec.configure do |config|
-  config.before(:each, disable_cloud_storage_stub: false) do
-    cloud_storage = double(:cloud_storage).as_null_object
-    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+  config.before do |example|
+    unless example.metadata[:disable_cloud_storage_stub]
+      cloud_storage = double(:cloud_storage).as_null_object
+      allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+    end
   end
 end


### PR DESCRIPTION
It appears as if this `before` block was never getting executed, probably because the metadata value was `nil` rather than `false` by default.

This had gone unnoticed, because as long as the `AWS_S3_BUCKET_NAME` environment variable is not set, `Services.cloud_storage` will return an instance of `S3Storage::Null` which does not attempt to connect to AWS for real.

However, if this environment variable is set, then `Services.cloud_storage` will return an instance of `S3Storage` and this instance will be memo-ized.

When a couple of the "Media requests" spec examples run, they rely on setting the bucket name to `nil` supposedly to get `Services.cloud_storage` to return an instance of `S3Storage::Null`,
but, if the instance of `S3Storage` has been memo-ized as the result of a previous spec example, then the relevant "Media requests" spec examples will attempt to connect to AWS for real and fail or give spurious results.