### PR TITLE
Add Content-Disposition header to S3 object

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -18,9 +18,9 @@ class MediaController < ApplicationController
         set_expiry(AssetManager.cache_control.max_age)
         if stream_from_s3?
           body = Services.cloud_storage.load(asset)
-          send_data(body.read, filename: File.basename(asset.file.path), disposition: 'inline')
+          send_data(body.read, **AssetManager.content_disposition.options_for(asset))
         else
-          send_file(asset.file.path, disposition: 'inline')
+          send_file(asset.file.path, disposition: AssetManager.content_disposition.type)
         end
       end
     end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -71,7 +71,7 @@ class Asset
   end
 
   def save_to_cloud_storage
-    Services.cloud_storage.save(self, cache_control: AssetManager.cache_control.header)
+    Services.cloud_storage.save(self, cache_control: AssetManager.cache_control.header, content_disposition: AssetManager.content_disposition.header_for(self))
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
     raise

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -71,13 +71,20 @@ class Asset
   end
 
   def save_to_cloud_storage
-    Services.cloud_storage.save(self, cache_control: AssetManager.cache_control.header, content_disposition: AssetManager.content_disposition.header_for(self))
+    Services.cloud_storage.save(self, cloud_storage_options)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
     raise
   end
 
 protected
+
+  def cloud_storage_options
+    {
+      cache_control: AssetManager.cache_control.header,
+      content_disposition: AssetManager.content_disposition.header_for(self)
+    }
+  end
 
   def valid_filenames
     filename_history + [filename]

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,4 +37,5 @@ module AssetManager
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :stream_all_assets_from_s3
   mattr_accessor :cache_control
+  mattr_accessor :content_disposition
 end

--- a/config/initializers/content_disposition.rb
+++ b/config/initializers/content_disposition.rb
@@ -1,0 +1,5 @@
+require 'content_disposition_configuration'
+
+AssetManager.content_disposition = ContentDispositionConfiguration.new(
+  type: 'inline'
+)

--- a/lib/content_disposition_configuration.rb
+++ b/lib/content_disposition_configuration.rb
@@ -9,6 +9,10 @@ class ContentDispositionConfiguration
     { filename: filename_for(asset), disposition: type }
   end
 
+  def header_for(asset)
+    %{#{type}; filename="#{filename_for(asset)}"}
+  end
+
 private
 
   def filename_for(asset)

--- a/lib/content_disposition_configuration.rb
+++ b/lib/content_disposition_configuration.rb
@@ -1,0 +1,17 @@
+class ContentDispositionConfiguration
+  attr_reader :type
+
+  def initialize(type:)
+    @type = type
+  end
+
+  def options_for(asset)
+    { filename: filename_for(asset), disposition: type }
+  end
+
+private
+
+  def filename_for(asset)
+    File.basename(asset.file.path)
+  end
+end

--- a/spec/lib/content_disposition_configuration_spec.rb
+++ b/spec/lib/content_disposition_configuration_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 RSpec.describe ContentDispositionConfiguration do
   subject { described_class.new(type: type) }
 
+  let(:type) { 'inline' }
+  let(:asset) { FactoryGirl.build(:asset) }
+
   describe '#type' do
     let(:type) { 'attachment' }
 
@@ -12,15 +15,18 @@ RSpec.describe ContentDispositionConfiguration do
   end
 
   describe '#options_for' do
-    let(:type) { 'inline' }
-    let(:asset) { FactoryGirl.build(:asset) }
-
     it 'returns options including filename for asset' do
       expect(subject.options_for(asset)).to include(filename: 'asset.png')
     end
 
     it 'returns options including disposition for asset' do
       expect(subject.options_for(asset)).to include(disposition: 'inline')
+    end
+  end
+
+  describe '#header_for' do
+    it 'returns Content-Disposition header value' do
+      expect(subject.header_for(asset)).to eq(%{inline; filename="asset.png"})
     end
   end
 end

--- a/spec/lib/content_disposition_configuration_spec.rb
+++ b/spec/lib/content_disposition_configuration_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ContentDispositionConfiguration do
+  subject { described_class.new(type: type) }
+
+  describe '#type' do
+    let(:type) { 'attachment' }
+
+    it 'returns type supplied to constructor' do
+      expect(subject.type).to eq('attachment')
+    end
+  end
+
+  describe '#options_for' do
+    let(:type) { 'inline' }
+    let(:asset) { FactoryGirl.build(:asset) }
+
+    it 'returns options including filename for asset' do
+      expect(subject.options_for(asset)).to include(filename: 'asset.png')
+    end
+
+    it 'returns options including disposition for asset' do
+      expect(subject.options_for(asset)).to include(disposition: 'inline')
+    end
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "content_disposition_configuration"
 
 RSpec.describe Asset, type: :model do
   include DelayedJobHelpers
@@ -121,11 +122,14 @@ RSpec.describe Asset, type: :model do
     let(:asset) { FactoryGirl.create(:clean_asset) }
     let(:cloud_storage) { double(:cloud_storage) }
     let(:cache_control) { instance_double(CacheControlConfiguration) }
+    let(:content_disposition) { instance_double(ContentDispositionConfiguration) }
 
     before do
       allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
       allow(AssetManager).to receive(:cache_control).and_return(cache_control)
       allow(cache_control).to receive(:header).and_return('cache-control-header')
+      allow(AssetManager).to receive(:content_disposition).and_return(content_disposition)
+      allow(content_disposition).to receive(:header_for).with(asset).and_return('content-disposition-header')
     end
 
     it 'saves the asset to cloud storage' do
@@ -135,7 +139,13 @@ RSpec.describe Asset, type: :model do
     end
 
     it 'sets the Cache-Control header on the asset stored in the cloud' do
-      expect(cloud_storage).to receive(:save).with(anything, cache_control: 'cache-control-header')
+      expect(cloud_storage).to receive(:save).with(anything, include(cache_control: 'cache-control-header'))
+
+      asset.save_to_cloud_storage
+    end
+
+    it 'sets the Content-Disposition header on the asset stored in the cloud' do
+      expect(cloud_storage).to receive(:save).with(anything, include(content_disposition: 'content-disposition-header'))
 
       asset.save_to_cloud_storage
     end


### PR DESCRIPTION
We want to be able to redirect Asset Manager requests to the assets stored in an S3 bucket. However, we want as much of the externally-visible behaviour to remain the same and so we need to set the 'Content-Disposition' header to the same value as in `MediaController#download`, i.e. the value generated by [`ActionController::DataStreaming#send_data`][1] or [`ActionController::DataStreaming#send_file`][2].

Note that his is based on the work in [Add Cache-Control header to S3 object][3], so it's probably worth waiting until that is merged before reviewing this.

Closes #95.

[1]: http://api.rubyonrails.org/v4.2.7.1/classes/ActionController/DataStreaming.html#method-i-send_data
[2]: http://api.rubyonrails.org/v4.2.7.1/classes/ActionController/DataStreaming.html#method-i-send_file
[3]: https://github.com/alphagov/asset-manager/pull/109