### PR TITLE
Optionally redirect public asset requests to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ The following environment variables are only needed if you want to enable this f
 
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
 * `STREAM_ALL_ASSETS_FROM_S3` - causes *all* assets to be served from S3 via the app
+* `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* requests for assets to be redirected to S3
+* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
 
-#### Request parameter
+#### Request parameters
 
-Assets can be streamed from S3 even if `STREAM_ALL_ASSETS_FROM_S3` is not set by adding `stream_from_s3=true` as a request parameter key-value pair to the query string.
+* Assets can be streamed from S3 even if `STREAM_ALL_ASSETS_FROM_S3` is not set by adding `stream_from_s3=true` as a request parameter key-value pair to the query string.
+* Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -16,7 +16,9 @@ class MediaController < ApplicationController
     respond_to do |format|
       format.any do
         set_expiry(AssetManager.cache_control.max_age)
-        if stream_from_s3?
+        if redirect_to_s3?
+          redirect_to Services.cloud_storage.public_url_for(asset)
+        elsif stream_from_s3?
           body = Services.cloud_storage.load(asset)
           send_data(body.read, **AssetManager.content_disposition.options_for(asset))
         else
@@ -27,6 +29,10 @@ class MediaController < ApplicationController
   end
 
 protected
+
+  def redirect_to_s3?
+    AssetManager.redirect_all_asset_requests_to_s3 || params[:redirect_to_s3].present?
+  end
 
   def stream_from_s3?
     AssetManager.stream_all_assets_from_s3 || params[:stream_from_s3].present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,8 @@ module AssetManager
 
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :stream_all_assets_from_s3
+  mattr_accessor :redirect_all_asset_requests_to_s3
+  mattr_accessor :aws_s3_use_virtual_host
   mattr_accessor :cache_control
   mattr_accessor :content_disposition
 end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,7 @@
 AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
 AssetManager.stream_all_assets_from_s3 = ENV['STREAM_ALL_ASSETS_FROM_S3'].present?
+AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?
+AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 
 Aws.config.update(
   logger: Rails.logger

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -27,6 +27,10 @@ class S3Storage
     object_for(asset).get.body
   end
 
+  def public_url_for(asset)
+    object_for(asset).public_url(virtual_host: AssetManager.aws_s3_use_virtual_host)
+  end
+
 private
 
   def object_for(asset)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
+      context "when redirect_to_s3 param is present" do
+        let(:cloud_storage) { double(:cloud_storage) }
+
+        before do
+          allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+          allow(cloud_storage).to receive(:public_url_for).with(asset).and_return('public-url')
+        end
+
+        it "should redirect temporarily (302 Found) to the public URL of the asset" do
+          do_get redirect_to_s3: true
+          expect(response).to redirect_to('public-url')
+          expect(response).to have_http_status(:found)
+        end
+      end
+
       context "when config.stream_all_assets_from_s3 is true" do
         let(:io) { StringIO.new('s3-object-data') }
         let(:cloud_storage) { double(:cloud_storage) }

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -60,4 +60,28 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe '#public_url_for' do
+    before do
+      allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)
+    end
+
+    context 'when configured not to use virtual host' do
+      let(:use_virtual_host) { false }
+
+      it 'returns public URL for asset on S3' do
+        allow(s3_object).to receive(:public_url).with(virtual_host: false).and_return('public-url')
+        expect(subject.public_url_for(asset)).to eq('public-url')
+      end
+    end
+
+    context 'when configured to use virtual host' do
+      let(:use_virtual_host) { true }
+
+      it 'returns public URL for asset on S3 using virtual host' do
+        allow(s3_object).to receive(:public_url).with(virtual_host: true).and_return('public-url')
+        expect(subject.public_url_for(asset)).to eq('public-url')
+      end
+    end
+  end
 end


### PR DESCRIPTION
We're currently experimenting with different ways to serve assets and adding this optional behaviour makes it possible to have the Asset Manager *redirect* public requests for assets to S3 rather than serving them from the (NFS) filesystem or streaming them from S3 through the app.

The new behaviour is not enabled by default and can be enabled for a single request using a query string parameter or for all requests in an environment by setting an environment variable. See the changes in the `README` for details.

Eventually we're probably going to want to use a "virtual host" style URL for the assets on S3, but this will require us to setup a DNS CNAME for an appropriate sub-domain of gov.uk and setup a bucket with the bucket name matching the fully-qualified domain name. To make it possible to try out the new redirect behaviour before this is in place, I've made the `virtual_host` option for `Aws::S3::Object#public_url` configurable via an environment variable.

Note that I chose not to store the public URL in the database, because the call to `Aws::S3::Object#public_url` doesn't appear to connect to the remote API, i.e. it already has all the information it needs to construct the URL.

Fixes #93.