### PR TITLE
[DO NOT MERGE] Serve assets from S3 if they exist

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -31,7 +31,7 @@ class MediaController < ApplicationController
 protected
 
   def redirect_to_s3?
-    AssetManager.redirect_all_asset_requests_to_s3 || params[:redirect_to_s3].present?
+    asset.uploaded_to_s3?
   end
 
   def stream_from_s3?

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -14,6 +14,8 @@ class Asset
   field :access_limited, type: Boolean, default: false
   field :organisation_slug, type: String
 
+  field :uploaded_to_s3, type: Boolean, default: false
+
   validates :file, presence: true
   validates :organisation_slug, presence: true, if: :access_limited?
 
@@ -72,6 +74,7 @@ class Asset
 
   def save_to_cloud_storage
     Services.cloud_storage.save(self, cloud_storage_options)
+    update_attribute(:uploaded_to_s3, true)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
     raise


### PR DESCRIPTION
__NOTE. We're not intending for this branch to be merged to master. We're going to use it to test the behaviour of redirecting to S3 in integration.__

---

This is a temporary change that will allow us to test redirecting to and
serving assets from S3 on integration.

This commit causes some tests to fail but we're not worrying about that
as we're not expecting this commit to end up in master.

We've tested the change locally and are happy that it results in a
redirect to assets uploaded to S3. Assets not on S3 continue to be
served directly from the filesystem.