### PR TITLE
Add missing 2nd argument to S3Storage::Null#save

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -4,7 +4,7 @@ class S3Storage
   NotConfiguredError = Class.new(CloudStorage::NotConfiguredError)
 
   class Null
-    def save(_asset); end
+    def save(_asset, _options = {}); end
 
     def load(_asset)
       raise NotConfiguredError.new('AWS S3 bucket not correctly configured')


### PR DESCRIPTION
This resolves an argument error when `S3Storage::Null#save` gets called with 2 arguments per usage in https://github.com/alphagov/asset-manager/blob/master/app/models/asset.rb#L74

We see a few of these errors come through with the [Publishing E2E Tests](https://github.com/alphagov/publishing-e2e-tests) each time it runs.

Eg
```
timestamp: 2017-08-10 15:06:48 +0000
<?xml version="1.0" encoding="UTF-8"?>
<notice version="2.4">
  <api-key>1</api-key>
  <notifier>
    <name>Airbrake Notifier</name>
    <version>4.0.0</version>
    <url>https://github.com/airbrake/airbrake</url>
  </notifier>
  <error>
    <class>ArgumentError</class>
    <message>ArgumentError: wrong number of arguments (2 for 1)</message>
    <backtrace>
      <line number="7" file="[PROJECT_ROOT]/lib/s3_storage.rb" method="save"/>
      <line number="74" file="[PROJECT_ROOT]/app/models/asset.rb" method="save_to_cloud_storage"/>
      <line number="30" file="[GEM_ROOT]/gems/delayed_job-4.1.1/lib/delayed/performable_method.rb" method="perform"/>
      <line number="100" file="[GEM_ROOT]/gems/delayed_job-4.1.1/lib/delayed/backend/base.rb" method="block in invoke_job"/>
      <line number="61" file="[GEM_ROOT]/gems/delayed_job-4.1.1/lib/delayed/lifecycle.rb" method="call"/>
```

Incidentally is there anything we need to configure in the e2e tests to tell it that it won't be using s3 as a storage layer? (ENV vars or similar)