### PR TITLE
Optionally instruct nginx to proxy assets from S3

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -31,6 +31,10 @@ class S3Storage
     object_for(asset).public_url(virtual_host: AssetManager.aws_s3_use_virtual_host)
   end
 
+  def presigned_url_for(asset)
+    object_for(asset).presigned_url(:get, expires_in: 1.minute, virtual_host: AssetManager.aws_s3_use_virtual_host)
+  end
+
 private
 
   def object_for(asset)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -84,4 +84,28 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe '#presigned_url_for' do
+    before do
+      allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)
+    end
+
+    context 'when configured not to use virtual host' do
+      let(:use_virtual_host) { false }
+
+      it 'returns presigned URL for asset on S3' do
+        allow(s3_object).to receive(:presigned_url).with(:get, expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+        expect(subject.presigned_url_for(asset)).to eq('presigned-url')
+      end
+    end
+
+    context 'when configured to use virtual host' do
+      let(:use_virtual_host) { true }
+
+      it 'returns presigned URL for asset on S3 using virtual host' do
+        allow(s3_object).to receive(:presigned_url).with(:get, expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
+        expect(subject.presigned_url_for(asset)).to eq('presigned-url')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This complements [the change in the asset-manager nginx config][1].

The app sets the `X-Accel-Redirect` header to instruct nginx to proxy
the request for an asset to S3.

We're generating a presigned URL for the assets on S3 so that we can
avoid making them publicly accessible. The presigned URL is valid for 1
minute which should be enough time for nginx to use the URL to make the
request.

[1]: https://github.com/alphagov/govuk-puppet/pull/6280