### PR TITLE
Conservative upgrade of origin gem (fix inconsistent Gemfile.lock)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    origin (2.1.1)
+    origin (2.3.1)
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)


### PR DESCRIPTION
I ran the following command:

    bundle update origin --conservative

My motivation for doing this was that I was seeing the following error when trying to upgrade unrelated gems:

    Bundler could not find compatible versions for gem "origin":
    In snapshot (Gemfile.lock):
    origin (= 2.1.1)

    In Gemfile:
    mongoid (~> 5.0) was resolved to 5.2.1, which depends on
      origin (~> 2.3)

This seems to suggest that the `origin` gem was locked at a version which was incompatible with the locked version of the `mongoid` gem. I'm guessing that the `Gemfile.lock` was edited by hand and left in an inconsistent state, so although `bundle install` worked OK, `bundle update` did not. This commit should fix that problem.