### PR TITLE
Upgrade airbrake gem v4.0.0 -> v4.3.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'airbrake', '~> 4.0.0'
+gem 'airbrake', '~> 4.0'
 gem 'aws-sdk'
 gem 'carrierwave', '~> 0.10.0'
 gem 'carrierwave-mongoid', '~> 0.8.1', require: 'carrierwave/mongoid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    airbrake (4.0.0)
+    airbrake (4.3.8)
       builder
       multi_json
     arel (6.0.3)
@@ -257,7 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 4.0.0)
+  airbrake (~> 4.0)
   aws-sdk
   carrierwave (~> 0.10.0)
   carrierwave-mongoid (~> 0.8.1)


### PR DESCRIPTION
I changed the constraint in the `Gemfile` from `~> 4.0.0` to `~> 4.0` and ran the following command:

    bundle update --conservative airbrake

My main motivation for doing this is so that `airbrake` [reports `ActionController::BadRequest` exceptions correctly][1].

However, I've chosen to upgrade to the latest 4.x version, because that should include other bug fixes without breaking compatibility with `errbit`. I'm pretty sure this is safe to do, because I can see that a bunch of other GOV.UK apps are using this version of `airbrake` in production, e.g.

* `calculators`
* `hmrc-manuals-api`
* `manuals-publisher`
* `publisher`
* `rummager`

Closes #122.

[1]: https://github.com/airbrake/airbrake/pull/271