### PR TITLE
Ignore ActionController::BadRequest exceptions in Airbrake

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -6,5 +6,6 @@ if ENV["ERRBIT_API_KEY"].present?
     config.host = errbit_uri.host
     config.secure = errbit_uri.scheme == "https"
     config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+    config.ignore << 'ActionController::BadRequest'
   end
 end


### PR DESCRIPTION
We've seen a bunch of requests in production which have a path with invalid string encoding. This results in an `ActionController::BadRequest` exception being raised. Rails handles this exception and responds with a 400 Bad Request which seems correct. However, the exception is unnecessarily reported to Errbit.

I did consider only reporting these exceptions when they had a specific exception message, but it turns out that in this case there is no exception message, so it's difficult to be more specific.

However, I'm pretty convinced that ignoring all such exceptions is safe to do given that a bunch of other exceptions that [Rails handles by default][1] are [ignored by default by Airbrake][2]. Indeed there is a case to be made that we should bring the Airbrake list into line with the Rails list.

Closes #121.

[1]: http://guides.rubyonrails.org/v4.2.7.1/configuring.html#configuring-action-dispatch
[2]: https://github.com/airbrake/airbrake/blob/f3fd0550f30108c381c6d71614dfb84f596edc20/lib/airbrake/configuration.rb#L145-L153
