### PR TITLE
Always virus scan uploaded files

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -19,7 +19,6 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  before_save :reset_state_if_file_changed
   after_save :schedule_virus_scan
 
   state_machine :state, initial: :unscanned do
@@ -41,6 +40,7 @@ class Asset
     super(file).tap {
       filename_history.push(old_filename) if old_filename
     }
+    reset_state
   end
 
   def filename_valid?(filename_to_test)
@@ -90,8 +90,8 @@ protected
     filename_history + [filename]
   end
 
-  def reset_state_if_file_changed
-    self.state = 'unscanned' if self.file_changed?
+  def reset_state
+    self.state = 'unscanned'
   end
 
   def schedule_virus_scan

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,6 +1,10 @@
 module FileHelpers
-  def load_fixture_file(path)
-    Rack::Test::UploadedFile.new fixture_file_path(path)
+  def load_fixture_file(path, named: nil)
+    Rack::Test::UploadedFile.new(fixture_file_path(path)).tap do |file|
+      if named.present?
+        file.instance_variable_set(:@original_filename, named)
+      end
+    end
   end
 
   def fixture_file_path(filename)


### PR DESCRIPTION
Previously a virus scan was only triggered if the file had "changed" according to [`ActiveModel::Dirty`][1]. However, this seemed to have been based on whether the filename of the file had changed rather than whether the content had changed which seems to be the more relevant issue. This meant that (as described in #72) it was possible to update an existing asset with a file having the same name, but different content and for the asset to remain in the "clean" state. This seemed like a security hole.

Initially I investigated triggering a virus scan when the file *content* changed. However, this proved awkward due to the way both `state_machines` and `carrierwave` gems work. So after discussion with @chrisroos & @chrislo, I decided to trigger a virus scan whenever the `Asset#file` attribute is changed. While this means virus scans will sometimes be triggered unnecessarily, I don't think it should happen too often and it seems better to do this than allow unscanned files to be served to the citizens.

I'm not sure this is the most elegant solution, but since the `Asset#file=` method already existed, it seemed simplest to make use of it. A better solution might involve persisting an MD5 digest of the file content which has been virus scanned and then only re-scan the content if it has changed. However, the extra complexity doesn't seem warranted.

Fixes #72.

[1]: http://api.rubyonrails.org/v4.2.7.1/classes/ActiveModel/Dirty.html