### PR TITLE
Avoid Mongoid warning about overwriting Asset field

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -6,7 +6,6 @@ class Asset
   include Mongoid::Paranoia
   include Mongoid::Timestamps
 
-  field :file, type: String
   field :state, type: String, default: 'unscanned'
   field :filename_history, type: Array, default: -> { [] }
   protected :filename_history=


### PR DESCRIPTION
We were seeing the following warning in the Rails log:

    Overwriting existing field file in class Asset

This was happening because the [uploader declaration was also declaring the `file` field][1]:

    mount_uploader :file, AssetUploader

The latter set the field type to be `Object` whereas the former set the field type to `String`. However the latter took precedence anyway and so removing the former has no net effect.

Fixes #69.

[1]: https://github.com/carrierwaveuploader/carrierwave-mongoid/blob/v0.8.1/lib/carrierwave/mongoid.rb#L15