### PR TITLE
Allow a percentage of traffic to be proxied to S3 via Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ The following environment variables are only needed if you want to enable this f
 
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
+* `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *all* asset requests to be proxied to S3 via Nginx
 * `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
 * `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
 
 #### Request parameters
 
 * Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
-* Asset requests can be proxied to S3 via Nginx by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
+* Asset requests can be proxied to S3 via Nginx even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
 * Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The following environment variables are only needed if you want to enable this f
 #### Request parameters
 
 * Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
-* Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 * Asset requests can be proxied to S3 via Nginx by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
+* Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ The following environment variables are only needed if you want to enable this f
 #### Application-specific environment variables
 
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
-* `STREAM_ALL_ASSETS_FROM_S3` - causes *all* assets to be served from S3 via the app
-* `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* requests for assets to be redirected to S3
+* `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
+* `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
 * `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
 
 #### Request parameters
 
-* Assets can be streamed from S3 even if `STREAM_ALL_ASSETS_FROM_S3` is not set by adding `stream_from_s3=true` as a request parameter key-value pair to the query string.
+* Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
 * Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ The following environment variables are only needed if you want to enable this f
 At most *one* of these should be used in any given environment. If none of them are set then the default behaviour is for the Rails app to instruct Nginx to serve the assets from the NFS mount.
 
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
-* `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *all* asset requests to be proxied to S3 via Nginx
+* `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100
 * `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
 
 #### Request parameters
 
 * Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
-* Asset requests can be proxied to S3 via Nginx even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
+* Asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
 * Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -54,8 +54,14 @@ The following environment variables are only needed if you want to enable this f
 
 #### Application-specific environment variables
 
+##### AWS
+
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
 * `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
+
+##### Feature flags
+
+At most *one* of these should be used in any given environment. If none of them are set then the default behaviour is for the Rails app to instruct Nginx to serve the assets from the NFS mount.
 
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *all* asset requests to be proxied to S3 via Nginx

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following environment variables are only needed if you want to enable this f
 
 * Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
 * Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
+* Asset requests can be proxied to S3 via Nginx by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ The following environment variables are only needed if you want to enable this f
 #### Application-specific environment variables
 
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
+* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
+
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
 * `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *all* asset requests to be proxied to S3 via Nginx
 * `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
-* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
 
 #### Request parameters
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -39,7 +39,10 @@ protected
   end
 
   def proxy_to_s3_via_nginx?
-    AssetManager.proxy_all_asset_requests_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
+    random_number_generator = Random.new
+    percentage = AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx
+    proxy_to_s3_via_nginx = random_number_generator.rand(100) < percentage
+    proxy_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
   end
 
   def proxy_to_s3_via_rails?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -18,7 +18,7 @@ class MediaController < ApplicationController
         set_expiry(AssetManager.cache_control.max_age)
         if redirect_to_s3?
           redirect_to Services.cloud_storage.public_url_for(asset)
-        elsif stream_from_s3?
+        elsif proxy_to_s3_via_rails?
           body = Services.cloud_storage.load(asset)
           send_data(body.read, **AssetManager.content_disposition.options_for(asset))
         elsif proxy_via_nginx?
@@ -42,8 +42,8 @@ protected
     AssetManager.redirect_all_asset_requests_to_s3 || params[:redirect_to_s3].present?
   end
 
-  def stream_from_s3?
-    AssetManager.stream_all_assets_from_s3 || params[:stream_from_s3].present?
+  def proxy_to_s3_via_rails?
+    AssetManager.proxy_all_asset_requests_to_s3_via_rails || params[:proxy_to_s3_via_rails].present?
   end
 
   def filename_current?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -39,7 +39,7 @@ protected
   end
 
   def proxy_to_s3_via_nginx?
-    params[:proxy_to_s3_via_nginx].present?
+    AssetManager.proxy_all_asset_requests_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
   end
 
   def proxy_to_s3_via_rails?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -21,7 +21,7 @@ class MediaController < ApplicationController
         elsif proxy_to_s3_via_rails?
           body = Services.cloud_storage.load(asset)
           send_data(body.read, **AssetManager.content_disposition.options_for(asset))
-        elsif proxy_via_nginx?
+        elsif proxy_to_s3_via_nginx?
           url = Services.cloud_storage.presigned_url_for(asset)
           headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
           render nothing: true
@@ -34,8 +34,8 @@ class MediaController < ApplicationController
 
 protected
 
-  def proxy_via_nginx?
-    params[:proxy_via_nginx].present?
+  def proxy_to_s3_via_nginx?
+    params[:proxy_to_s3_via_nginx].present?
   end
 
   def redirect_to_s3?

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module AssetManager
   mattr_accessor :aws_s3_use_virtual_host
 
   mattr_accessor :proxy_all_asset_requests_to_s3_via_rails
-  mattr_accessor :proxy_all_asset_requests_to_s3_via_nginx
+  mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
   mattr_accessor :redirect_all_asset_requests_to_s3
 
   mattr_accessor :cache_control

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,10 +35,12 @@ module AssetManager
   end
 
   mattr_accessor :aws_s3_bucket_name
+  mattr_accessor :aws_s3_use_virtual_host
+
   mattr_accessor :proxy_all_asset_requests_to_s3_via_rails
   mattr_accessor :proxy_all_asset_requests_to_s3_via_nginx
   mattr_accessor :redirect_all_asset_requests_to_s3
-  mattr_accessor :aws_s3_use_virtual_host
+
   mattr_accessor :cache_control
   mattr_accessor :content_disposition
   mattr_accessor :default_content_type

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module AssetManager
   end
 
   mattr_accessor :aws_s3_bucket_name
-  mattr_accessor :stream_all_assets_from_s3
+  mattr_accessor :proxy_all_asset_requests_to_s3_via_rails
   mattr_accessor :redirect_all_asset_requests_to_s3
   mattr_accessor :aws_s3_use_virtual_host
   mattr_accessor :cache_control

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module AssetManager
 
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :proxy_all_asset_requests_to_s3_via_rails
+  mattr_accessor :proxy_all_asset_requests_to_s3_via_nginx
   mattr_accessor :redirect_all_asset_requests_to_s3
   mattr_accessor :aws_s3_use_virtual_host
   mattr_accessor :cache_control

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,7 +1,4 @@
 AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
-AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
-AssetManager.proxy_all_asset_requests_to_s3_via_nginx = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].present?
-AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?
 AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 
 Aws.config.update(

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,6 @@
 AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
 AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
+AssetManager.proxy_all_asset_requests_to_s3_via_nginx = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].present?
 AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?
 AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,5 @@
 AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
-AssetManager.stream_all_assets_from_s3 = ENV['STREAM_ALL_ASSETS_FROM_S3'].present?
+AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
 AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?
 AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,0 +1,3 @@
+AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
+AssetManager.proxy_all_asset_requests_to_s3_via_nginx = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].present?
+AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,3 +1,3 @@
 AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
-AssetManager.proxy_all_asset_requests_to_s3_via_nginx = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].present?
+AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
 AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
-      context "when proxy_via_nginx param is present" do
+      context "when proxy_to_s3_via_nginx param is present" do
         let(:cloud_storage) { double(:cloud_storage) }
         let(:presigned_url) { 'https://s3-host.test/presigned-url' }
 
@@ -98,12 +98,12 @@ RSpec.describe MediaController, type: :controller do
         end
 
         it "responds with 200 OK" do
-          do_get proxy_via_nginx: true
+          do_get proxy_to_s3_via_nginx: true
           expect(response).to have_http_status(:ok)
         end
 
         it "instructs nginx to proxy the request to S3" do
-          do_get proxy_via_nginx: true
+          do_get proxy_to_s3_via_nginx: true
           expect(response.headers["X-Accel-Redirect"]).to match("/cloud-storage-proxy/#{presigned_url}")
         end
       end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:clean_asset) }
 
       def do_get(extra_params = {})
-        get :download, { id: asset.id.to_s, filename: asset.file.file.identifier }.merge(extra_params)
+        get :download, { id: asset, filename: asset.file.file.identifier }.merge(extra_params)
       end
 
       it "responds with 200 OK" do
@@ -146,12 +146,12 @@ RSpec.describe MediaController, type: :controller do
         let(:old_file_name) { "an_old_filename.pdf" }
 
         before do
-          allow(Asset).to receive(:find).with(asset.id.to_s).and_return(asset)
+          allow(Asset).to receive(:find).with(asset.id).and_return(asset)
           allow(asset).to receive(:filename_valid?).and_return(true)
         end
 
         it "redirects to the new file name" do
-          get :download, id: asset.id, filename: old_file_name
+          get :download, id: asset, filename: old_file_name
 
           expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
         end
@@ -161,7 +161,7 @@ RSpec.describe MediaController, type: :controller do
         let(:invalid_file_name) { "invalid_file_name.pdf" }
 
         it "responds with 404 Not Found" do
-          get :download, id: asset.id, filename: invalid_file_name
+          get :download, id: asset, filename: invalid_file_name
 
           expect(response).to have_http_status(:not_found)
         end
@@ -172,7 +172,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:asset) }
 
       it "responds with 404 Not Found" do
-        get :download, id: asset.id.to_s, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.file.file.identifier
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -181,7 +181,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:infected_asset) }
 
       it "responds with 404 Not Found" do
-        get :download, id: asset.id.to_s, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.file.file.identifier
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -198,12 +198,12 @@ RSpec.describe MediaController, type: :controller do
       let(:unrestricted_asset) { FactoryGirl.create(:clean_asset) }
 
       it "responds with 404 Not Found for access-limited documents" do
-        get :download, id: restricted_asset.id.to_s, filename: 'asset.png'
+        get :download, id: restricted_asset, filename: 'asset.png'
         expect(response).to have_http_status(:not_found)
       end
 
       it "responds with 200 OK for unrestricted documents" do
-        get :download, id: unrestricted_asset.id.to_s, filename: 'asset.png'
+        get :download, id: unrestricted_asset, filename: 'asset.png'
         expect(response).to have_http_status(:ok)
       end
     end
@@ -218,14 +218,14 @@ RSpec.describe MediaController, type: :controller do
       it "bounces anonymous users to sign-on" do
         expect(controller).to receive(:require_signin_permission!)
 
-        get :download, id: asset.id.to_s, filename: 'asset.png'
+        get :download, id: asset, filename: 'asset.png'
       end
 
       it "responds with 404 Not Found for access-limited documents if the user has the wrong organisation" do
         user = FactoryGirl.create(:user, organisation_slug: 'incorrect-organisation-slug')
         login_as(user)
 
-        get :download, id: asset.id.to_s, filename: 'asset.png'
+        get :download, id: asset, filename: 'asset.png'
 
         expect(response).to have_http_status(:not_found)
       end
@@ -234,7 +234,7 @@ RSpec.describe MediaController, type: :controller do
         user = FactoryGirl.create(:user, organisation_slug: 'correct-organisation-slug')
         login_as(user)
 
-        get :download, id: asset.id.to_s, filename: 'asset.png'
+        get :download, id: asset, filename: 'asset.png'
 
         expect(response).to have_http_status(:ok)
       end
@@ -244,7 +244,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:deleted_asset) }
 
       before do
-        get :download, id: asset.id.to_s, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.file.file.identifier
       end
 
       it "responds with not found status" do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -195,22 +195,23 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
-      context "when proxy_to_s3_via_nginx param is present" do
+      context "when proxy_to_s3_via_nginx? is truthy" do
         let(:cloud_storage) { double(:cloud_storage) }
         let(:presigned_url) { 'https://s3-host.test/presigned-url' }
 
         before do
+          allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(true)
           allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
           allow(cloud_storage).to receive(:presigned_url_for).with(asset).and_return(presigned_url)
         end
 
         it "responds with 200 OK" do
-          do_get proxy_to_s3_via_nginx: true
+          do_get
           expect(response).to have_http_status(:ok)
         end
 
         it "instructs nginx to proxy the request to S3" do
-          do_get proxy_to_s3_via_nginx: true
+          do_get
           expect(response.headers["X-Accel-Redirect"]).to match("/cloud-storage-proxy/#{presigned_url}")
         end
       end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe MediaController, type: :controller do
         expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
       end
 
-      context "when stream_from_s3 param is present" do
+      context "when proxy_to_s3_via_rails param is present" do
         let(:io) { StringIO.new('s3-object-data') }
         let(:cloud_storage) { double(:cloud_storage) }
 
@@ -46,7 +46,7 @@ RSpec.describe MediaController, type: :controller do
         end
 
         it "responds with 200 OK" do
-          do_get stream_from_s3: true
+          do_get proxy_to_s3_via_rails: true
           expect(response).to have_http_status(:ok)
         end
 
@@ -54,16 +54,16 @@ RSpec.describe MediaController, type: :controller do
           expect(controller).to receive(:send_data).with('s3-object-data', filename: 'asset.png', disposition: "inline")
           allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_data
 
-          do_get stream_from_s3: true
+          do_get proxy_to_s3_via_rails: true
         end
 
         it "sets the Content-Type header based on the file extension" do
-          do_get stream_from_s3: true
+          do_get proxy_to_s3_via_rails: true
           expect(response.headers["Content-Type"]).to eq("image/png")
         end
 
         it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-          do_get stream_from_s3: true
+          do_get proxy_to_s3_via_rails: true
 
           expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
         end
@@ -108,14 +108,14 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
-      context "when config.stream_all_assets_from_s3 is true" do
+      context "when config.proxy_all_asset_requests_to_s3_via_rails is true" do
         let(:io) { StringIO.new('s3-object-data') }
         let(:cloud_storage) { double(:cloud_storage) }
 
         before do
           allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
           allow(cloud_storage).to receive(:load).with(asset).and_return(io)
-          allow(AssetManager).to receive(:stream_all_assets_from_s3).and_return(true)
+          allow(AssetManager).to receive(:proxy_all_asset_requests_to_s3_via_rails).and_return(true)
         end
 
         it "responds with 200 OK" do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -44,23 +44,41 @@ RSpec.describe MediaController, type: :controller do
 
   describe "#proxy_to_s3_via_nginx?" do
     before do
+      allow(AssetManager).to receive(:proxy_all_asset_requests_to_s3_via_nginx)
+        .and_return(proxy_all_asset_requests_to_s3_via_nginx)
       allow(controller).to receive(:params)
         .and_return(proxy_to_s3_via_nginx: proxy_to_s3_via_nginx)
     end
 
-    context "when proxy_to_s3_via_nginx is not set" do
-      let(:proxy_to_s3_via_nginx) { false }
+    context "when proxy_all_asset_requests_to_s3_via_nginx is not set" do
+      let(:proxy_all_asset_requests_to_s3_via_nginx) { false }
 
-      it "returns falsey" do
-        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
+      context "when proxy_to_s3_via_nginx is not set" do
+        let(:proxy_to_s3_via_nginx) { false }
+
+        it "returns falsey" do
+          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
+        end
       end
-    end
 
-    context "when proxy_to_s3_via_nginx is set" do
-      let(:proxy_to_s3_via_nginx) { true }
+      context "when proxy_to_s3_via_nginx is set" do
+        let(:proxy_to_s3_via_nginx) { true }
 
-      it "returns truthy" do
-        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
+        it "returns truthy" do
+          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
+        end
+      end
+
+      context "when proxy_all_asset_requests_to_s3_via_nginx is set" do
+        let(:proxy_all_asset_requests_to_s3_via_nginx) { true }
+
+        context "even when proxy_to_s3_via_nginx is not set" do
+          let(:proxy_to_s3_via_nginx) { false }
+
+          it "returns truthy" do
+            expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
+          end
+        end
       end
     end
   end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -1,6 +1,111 @@
 require "rails_helper"
 
 RSpec.describe MediaController, type: :controller do
+  describe "#proxy_to_s3_via_nginx?" do
+    before do
+      allow(controller).to receive(:params)
+        .and_return(proxy_to_s3_via_nginx: proxy_to_s3_via_nginx)
+    end
+
+    context "when proxy_to_s3_via_nginx is not set" do
+      let(:proxy_to_s3_via_nginx) { false }
+
+      it "returns falsey" do
+        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
+      end
+    end
+
+    context "when proxy_to_s3_via_nginx is set" do
+      let(:proxy_to_s3_via_nginx) { true }
+
+      it "returns truthy" do
+        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
+      end
+    end
+  end
+
+  describe "#redirect_to_s3?" do
+    before do
+      allow(AssetManager).to receive(:redirect_all_asset_requests_to_s3)
+        .and_return(redirect_all_asset_requests_to_s3)
+      allow(controller).to receive(:params)
+        .and_return(redirect_to_s3: redirect_to_s3)
+    end
+
+    context "when redirect_all_asset_requests_to_s3 is not set" do
+      let(:redirect_all_asset_requests_to_s3) { false }
+
+      context "when redirect_to_s3 is not set" do
+        let(:redirect_to_s3) { false }
+
+        it "returns falsey" do
+          expect(controller.send(:redirect_to_s3?)).to be_falsey
+        end
+      end
+
+      context "when redirect_to_s3 is set" do
+        let(:redirect_to_s3) { true }
+
+        it "returns truthy" do
+          expect(controller.send(:redirect_to_s3?)).to be_truthy
+        end
+      end
+    end
+
+    context "when redirect_all_asset_requests_to_s3 is set" do
+      let(:redirect_all_asset_requests_to_s3) { true }
+
+      context "even when redirect_to_s3 is not set" do
+        let(:redirect_to_s3) { false }
+
+        it "returns truthy" do
+          expect(controller.send(:redirect_to_s3?)).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe "#proxy_to_s3_via_rails?" do
+    before do
+      allow(AssetManager).to receive(:proxy_all_asset_requests_to_s3_via_rails)
+        .and_return(proxy_all_asset_requests_to_s3_via_rails)
+      allow(controller).to receive(:params)
+        .and_return(proxy_to_s3_via_rails: proxy_to_s3_via_rails)
+    end
+
+    context "when proxy_all_asset_requests_to_s3_via_rails is not set" do
+      let(:proxy_all_asset_requests_to_s3_via_rails) { false }
+
+      context "when proxy_to_s3_via_rails is not set" do
+        let(:proxy_to_s3_via_rails) { false }
+
+        it "returns falsey" do
+          expect(controller.send(:proxy_to_s3_via_rails?)).to be_falsey
+        end
+      end
+
+      context "when proxy_to_s3_via_rails is set" do
+        let(:proxy_to_s3_via_rails) { true }
+
+        it "returns truthy" do
+          expect(controller.send(:proxy_to_s3_via_rails?)).to be_truthy
+        end
+      end
+    end
+
+    context "when proxy_all_asset_requests_to_s3_via_rails is set" do
+      let(:proxy_all_asset_requests_to_s3_via_rails) { true }
+
+      context "even when proxy_to_s3_via_rails is not set" do
+        let(:proxy_to_s3_via_rails) { false }
+
+        it "returns truthy" do
+          expect(controller.send(:proxy_to_s3_via_rails?)).to be_truthy
+        end
+      end
+    end
+  end
+
   describe "GET 'download'" do
     before do
       allow(controller).to receive_messages(requested_via_private_vhost?: false)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MediaController, type: :controller do
 
         it "streams the asset to the client using send_data" do
           expect(controller).to receive(:send_data).with('s3-object-data', filename: 'asset.png', disposition: "inline")
-          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_file
+          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_data
 
           do_get stream_from_s3: true
         end
@@ -125,7 +125,7 @@ RSpec.describe MediaController, type: :controller do
 
         it "streams the asset to the client using send_data" do
           expect(controller).to receive(:send_data).with('s3-object-data', filename: 'asset.png', disposition: "inline")
-          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_file
+          allow(controller).to receive(:render) # prevent template_not_found errors because we intercepted send_data
 
           do_get
         end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -175,21 +175,22 @@ RSpec.describe MediaController, type: :controller do
         end
       end
 
-      context "when redirect_to_s3 param is present" do
+      context "when redirect_to_s3? is truthy" do
         let(:cloud_storage) { double(:cloud_storage) }
 
         before do
+          allow(controller).to receive(:redirect_to_s3?).and_return(true)
           allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
           allow(cloud_storage).to receive(:public_url_for).with(asset).and_return('public-url')
         end
 
         it "responds with 302 Found (temporary redirect)" do
-          do_get redirect_to_s3: true
+          do_get
           expect(response).to have_http_status(:found)
         end
 
         it "redirects to the public URL of the asset" do
-          do_get redirect_to_s3: true
+          do_get
           expect(response).to redirect_to('public-url')
         end
       end

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Media requests", type: :request do
     end
   end
 
-  describe "request an asset to be streamed from S3", disable_cloud_storage_stub: true do
+  describe "request an asset to be proxied to S3 via the Rails app", disable_cloud_storage_stub: true do
     context "when bucket not configured" do
       let(:asset) { FactoryGirl.create(:clean_asset) }
 
@@ -17,12 +17,12 @@ RSpec.describe "Media requests", type: :request do
       end
 
       it "should respond with internal server error status" do
-        get "/media/#{asset.id}/asset.png?stream_from_s3=true"
+        get "/media/#{asset.id}/asset.png?proxy_to_s3_via_rails=true"
         expect(response).to have_http_status(:internal_server_error)
       end
 
       it "should include error message in JSON response" do
-        get "/media/#{asset.id}/asset.png?stream_from_s3=true"
+        get "/media/#{asset.id}/asset.png?proxy_to_s3_via_rails=true"
         json = JSON.parse(response.body)
         status = json['_response_info']['status']
         expect(status).to eq('Internal server error: AWS S3 bucket not correctly configured')


### PR DESCRIPTION
The motivation behind this commit is to allow us to incrementally roll-out the use of the proxying to S3 via Nginx mechanism. Although we've done a bunch of performance testing and analysis of the production logs, it's difficult to be certain that the production stack will be able to handle all its usual traffic when this mechanism is enabled. By only enabling it gradually we hope to observe any problems before they become catastrophic.

The `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` environment variable has been renamed to `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` and this should be set to an integer value between 0 and 100. We will need to set appropriate values for each environment via `govuk-puppet`.

This addresses the Asset Manager aspect of #151, but we will need to set values for this new environment variable via `govuk-puppet`.

I ended up doing quite a bit of tidying of the code prior to making the actual change; the latter is the final commit. Other changes include:

* Making other environment variable names consistent (I don't think we've used them anywhere yet, so this should be safe)
* Making code & specs more consistent.
* Improving test coverage and reducing combinatorial explosion in specs.
* Improve documentation about feature flags.

I think there's a case to be made to extract the response strategy selection logic and the response strategies themselves into their own classes - this would make the `MediaController#download` action easier to understand and easier to test. I did make a start on doing this, but decided it was a step too far for this PR. It may also be moot if we remove some of the response strategies in the near future.
