### PR TITLE
Send ETag & Last-Modified response headers when proxying to S3 via Nginx

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -21,6 +21,8 @@ class MediaController < ApplicationController
         elsif proxy_to_s3_via_nginx?
           url = Services.cloud_storage.presigned_url_for(asset)
           headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
+          headers['ETag'] = %{"#{asset.etag}"}
+          headers['Last-Modified'] = asset.last_modified.httpdate
           render nothing: true
         elsif proxy_to_s3_via_rails?
           body = Services.cloud_storage.load(asset)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -62,6 +62,14 @@ class Asset
     end
   end
 
+  def etag
+    '%x-%x' % [last_modified, file_stat.size]
+  end
+
+  def last_modified
+    file_stat.mtime
+  end
+
   def scan_for_viruses
     scanner = VirusScanner.new(self.file.current_path)
     if scanner.clean?
@@ -104,9 +112,14 @@ protected
 
   def reset_state
     self.state = 'unscanned'
+    @file_stat = nil
   end
 
   def schedule_virus_scan
     self.delay.scan_for_viruses if self.unscanned?
+  end
+
+  def file_stat
+    @file_stat ||= File.stat(file.path)
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -369,4 +369,48 @@ RSpec.describe Asset, type: :model do
       end
     end
   end
+
+  describe "#etag" do
+    let!(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+
+    let(:size) { 1024 }
+    let(:mtime) { Time.zone.parse('2017-01-01') }
+    let(:stat) { instance_double(File::Stat, size: size, mtime: mtime) }
+
+    before do
+      allow(File).to receive(:stat).and_return(stat)
+    end
+
+    it "returns string made up of 2 parts separated by a hyphen" do
+      parts = asset.etag.split('-')
+      expect(parts.length).to eq(2)
+    end
+
+    it "has 1st part as file mtime (unix time in seconds written in lowercase hex)" do
+      last_modified_hex = asset.etag.split('-').first
+      last_modified = last_modified_hex.to_i(16)
+      expect(last_modified).to eq(mtime.to_i)
+    end
+
+    it "has 2nd part as file size (number of bytes written in lowercase hex)" do
+      size_hex = asset.etag.split('-').last
+      size = size_hex.to_i(16)
+      expect(size).to eq(size)
+    end
+  end
+
+  describe "#last_modified" do
+    let!(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+
+    let(:mtime) { Time.zone.parse('2017-01-01') }
+    let(:stat) { instance_double(File::Stat, mtime: mtime) }
+
+    before do
+      allow(File).to receive(:stat).and_return(stat)
+    end
+
+    it "returns time file was last modified" do
+      expect(asset.last_modified).to eq(mtime)
+    end
+  end
 end


### PR DESCRIPTION
We're planning to gradually rollout the implementation whereby the Rails app instructs Nginx to proxy asset requests to S3. The current default implementation is for the Rails app to instruct Nginx to serve the asset files from NFS. In this implementation Nginx is automatically adding an ETag and a Last-Modified header.

When we switch to proxying the asset requests to S3, we want to ensure these response headers are the same for a given asset file in order to avoid unnecessary cache invalidation and therefore extra load which will make it hard to discriminate between changes in performance due to the change in implementation versus changes in performance due to a reduction in caching.

This commit changes the Rails app so that it calculates the ETag and Last-Modified values based on the underlying file, in the same way that Nginx would, and sends them in the response if we are proxying to S3. We plan to make changes to the Nginx configuration to store these headers and add them to the proxied response from S3. Without those changes, these response headers are ignored by Nginx and so I think it's safe to make this change in isolation.

The ETag value is calculated based on the string format in the [`ngx_http_set_etag` function][1], `"%xT-%xO"` in combination with the file's last modified time and its size. It turns out that the `"T"` and the `"O"` in that string format are Nginx-specific and are defined in the [`ngx_vslprintf` function][2]. As far as I can see they are just type modifiers [for `time_t`][3] and [for `off_t`][4] respectively and I don't think they are relevant to the Ruby string format, `"%x-%x"`.

According to RFC2616, the [ETag value should be quoted][5] and the [Last-Modified value should be formatted as an "HTTP date"][6].

This change means that when we're proxying to S3, the Rails app will have to access the underlying file on the NFS mount which might slow things down. I've tried to minimize this by memo-izing the call to `File.stat` which is used to obtain the data needed to calculate the two header values. This means that the app should only make a single call to `File.stat` per request.

Note that this solution relies on the fact that the Rails app has access to the NFS mount. Since the purpose of the change in overall implementation is to stop using NFS, we may want to store these header values in the database, but that can be a separate change.

See [this Gist][7] for a demonstration of how this can work in conjunction with changes in the Nginx configuration.

Addresses the Asset Manager aspect of #144 and #148.

[1]: http://lxr.nginx.org/source/src/http/ngx_http_core_module.c?v=nginx-1.4.6#1801
[2]: http://lxr.nginx.org/source/src/core/ngx_string.c?v=nginx-1.4.6#0147
[3]: http://lxr.nginx.org/source/src/core/ngx_string.c?v=1.4.6#0279
[4]: http://lxr.nginx.org/source/src/core/ngx_string.c?v=1.4.6#0269
[5]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
[6]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29
[7]: https://gist.github.com/floehopper/4b52c39cff18e108962c793c579dee1a
