### PR TITLE
Avoid duplicate Cache-Control headers when proxying to S3 via Nginx

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,9 @@ module AssetManager
     config.action_dispatch.rack_cache = nil
 
     config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
+
+    require "cache_control_middleware"
+    config.middleware.insert_before Rack::ETag, CacheControlMiddleware
   end
 
   mattr_accessor :aws_s3_bucket_name

--- a/lib/cache_control_middleware.rb
+++ b/lib/cache_control_middleware.rb
@@ -1,0 +1,13 @@
+class CacheControlMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    if headers['X-Accel-ETag'].present?
+      headers.delete('Cache-Control')
+    end
+    [status, headers, body]
+  end
+end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -254,14 +254,19 @@ RSpec.describe MediaController, type: :controller do
           expect(response).to have_http_status(:ok)
         end
 
-        it "sends ETag response header with quoted value" do
+        it "sends X-Accel-ETag response header with quoted value" do
           do_get
-          expect(response.headers["ETag"]).to eq(%{"599ffda8-e169"})
+          expect(response.headers["X-Accel-ETag"]).to eq(%{"599ffda8-e169"})
         end
 
-        it "sends Last-Modified response header in HTTP time format" do
+        it "sends X-Accel-Last-Modified response header in HTTP time format" do
           do_get
-          expect(response.headers["Last-Modified"]).to eq("Sun, 01 Jan 2017 00:00:00 GMT")
+          expect(response.headers["X-Accel-Last-Modified"]).to eq("Sun, 01 Jan 2017 00:00:00 GMT")
+        end
+
+        it "does not send Cache-Control response header" do
+          do_get
+          expect(response.headers["Cache-Control"]).not_to be_present
         end
 
         it "instructs nginx to proxy the request to S3" do

--- a/spec/lib/cache_control_middleware_spec.rb
+++ b/spec/lib/cache_control_middleware_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe CacheControlMiddleware do
+  let(:headers) { {} }
+  let(:app) { ->(_env) { [200, headers, ['OK']] } }
+
+  subject { described_class.new(app) }
+
+  context 'when Rack::ETag adds Cache-Control response header' do
+    before do
+      headers['Cache-Control'] = 'no-cache'
+    end
+
+    context 'when proxying asset requests to S3 via Nginx' do
+      before do
+        headers['X-Accel-ETag'] = %{"599ef674-1d"}
+      end
+
+      it 'removes Cache-Control response header' do
+        _status, headers, _body = subject.call([])
+
+        expect(headers['Cache-Control']).not_to be_present
+      end
+    end
+
+    context 'when not proxying asset requests to S3 via Nginx' do
+      it 'does not remove Cache-Control response header' do
+        _status, headers, _body = subject.call([])
+
+        expect(headers['Cache-Control']).to eq('no-cache')
+      end
+    end
+  end
+end

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -30,6 +30,28 @@ RSpec.describe "Media requests", type: :request do
     end
   end
 
+  describe "request an asset to be proxied to S3 via Nginx" do
+    let(:asset) { FactoryGirl.create(:clean_asset) }
+
+    it "does not send ETag response header" do
+      get "/media/#{asset.id}/asset.png?proxy_to_s3_via_nginx=true"
+
+      expect(headers['ETag']).not_to be_present
+    end
+
+    it "does not send Last-Modified response header" do
+      get "/media/#{asset.id}/asset.png?proxy_to_s3_via_nginx=true"
+
+      expect(headers['Last-Modified']).not_to be_present
+    end
+
+    it "does not send Cache-Control response header" do
+      get "/media/#{asset.id}/asset.png?proxy_to_s3_via_nginx=true"
+
+      expect(headers['Cache-Control']).not_to be_present
+    end
+  end
+
   describe "request an asset that does exist" do
     let(:asset) { FactoryGirl.create(:clean_asset) }
 


### PR DESCRIPTION
We are setting a `Cache-Control` response header on the S3 object and that's the one we want the client to receive. However prior to this commit, the Rails app was also sending a (duplicate) `Cache-Control` response header which Nginx was including in the response. Thus the user was receiving two duplicate `Cache-Control` headers. Although the values would almost certainly have been the same, we want to avoid confusion and/or unexpected behaviour.

This commit aims to achieve that by stopping the Rails app from sending a `Cache-Control` response header. Unfortunately that turns out to be harder than one might expect and necessitates the following changes:

* Avoid explicitly calling `ActionController::ConditionalGet::ClassMethods#expires_in` via `ApplicationController#set_expiry`. I think there's an argument for not calling this in some of the other cases, but I'm ignoring that for now.

* Avoid setting `ETag` or `Last-Modified` response headers. Setting either of these means that [`ActionDispatch::Http::Cache#handle_conditional_get!`][1] sets a default `Cache-Control` header value of ["max-age=0, private, must-revalidate"][2]. We avoid setting `ETag` or `Last-Modified` headers by renaming them to `X-Accel-ETag` and `X-Accel-Last-Modified`. This makes sense to me because the response from the Rails app is just an instruction to Nginx to proxy the request to S3; Nginx can then make use of these headers as it sees fit. Note that this will require a corresponding change to the Nginx configuration.

* Remove default `Cache-Control` response header set by `Rack::ETag`. [Rails explicitly sets a default `Cache-Control` header value of "no-cache" on this middleware][3] which [is added if no `ETag` header is set][4]. By inserting a new custom middleware, we can remove this `Cache-Control` header if the response is instructing Nginx to proxy the request to S3. We can detect this scenario via the presence of the `X-Accel-ETag` header in the response.

I considered the following alternative solutions:

1. Change the Nginx configuration to ignore the `Cache-Control` header from Rails.
2. Change the Nginx configuration to ignore the `Cache-Control` header from S3.
3. Remove the `Cache-Control` header from the S3 object.

While all of these would've avoided the client receiving duplicate `Cache-Control` headers, I couldn't find a way to implement option 1 and options 2 & 3 feel like a step backwards on the journey to redirecting asset requests to S3. Even if there was a way to implement option 1, it feels better to me that the Rails app doesn't send the `Cache-Control` header in the first place rather than having Nginx ignore it.

Addresses the Asset Manager aspect of #149. As noted above, we will need to make some corresponding changes to `govuk-puppet`.

[1]:
https://github.com/rails/rails/blob/v4.2.7.1/actionpack/lib/action_dispatch/http/cache.rb#L129-L133
[2]:
https://github.com/rails/rails/blob/v4.2.7.1/actionpack/lib/action_dispatch/http/cache.rb#L135
[3]:
https://github.com/rails/rails/blob/v4.2.7.1/railties/lib/rails/application/default_middleware_stack.rb#L58
[4]: https://github.com/rack/rack/blob/1.6.4/lib/rack/etag.rb#L39