### PR TITLE
Asset Manager generates IDs of objects stored on S3

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -10,6 +10,8 @@ class Asset
   field :filename_history, type: Array, default: -> { [] }
   protected :filename_history=
 
+  field :uuid, type: String, default: -> { SecureRandom.uuid }
+
   field :access_limited, type: Boolean, default: false
   field :organisation_slug, type: String
 

--- a/lib/data_migration.rb
+++ b/lib/data_migration.rb
@@ -1,8 +1,7 @@
 class DataMigration
   def self.add_uuid_to_assets
     Asset.where(uuid: nil).each do |asset|
-      asset.uuid = SecureRandom.uuid
-      asset.save
+      asset.update_attribute(:uuid, SecureRandom.uuid)
     end
   end
 end

--- a/lib/data_migration.rb
+++ b/lib/data_migration.rb
@@ -1,0 +1,8 @@
+class DataMigration
+  def self.add_uuid_to_assets
+    Asset.where(uuid: nil).each do |asset|
+      asset.uuid = SecureRandom.uuid
+      asset.save
+    end
+  end
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -38,6 +38,6 @@ class S3Storage
 private
 
   def object_for(asset)
-    Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.id.to_s)
+    Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.uuid)
   end
 end

--- a/lib/tasks/add_uuid_to_assets.rake
+++ b/lib/tasks/add_uuid_to_assets.rake
@@ -2,7 +2,7 @@ require 'data_migration'
 
 namespace :migrate do
   desc "Populate the UUID field for all Assets if it is blank"
-  task :add_uuid_to_assets => :environment do
+  task add_uuid_to_assets: :environment do
     DataMigration.add_uuid_to_assets
   end
 end

--- a/lib/tasks/add_uuid_to_assets.rake
+++ b/lib/tasks/add_uuid_to_assets.rake
@@ -1,0 +1,8 @@
+require 'data_migration'
+
+namespace :migrate do
+  desc "Populate the UUID field for all Assets if it is blank"
+  task :add_uuid_to_assets => :environment do
+    DataMigration.add_uuid_to_assets
+  end
+end

--- a/spec/lib/data_migration_spec.rb
+++ b/spec/lib/data_migration_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'data_migration'
+
+RSpec.describe DataMigration do
+  let!(:unmigrated_asset) { FactoryGirl.create(:asset, uuid: 'some-uuid') }
+  let!(:migrated_asset) { FactoryGirl.create(:asset) }
+
+  describe 'add_uuid_to_assets' do
+    it 'generates a new uuid for assets with a blank uuid' do
+      DataMigration.add_uuid_to_assets
+
+      migrated_asset.reload
+      expect(migrated_asset.uuid).to_not be_blank
+    end
+
+    it 'does not generate a new uuid for an asset when one already exists' do
+      DataMigration.add_uuid_to_assets
+
+      unmigrated_asset.reload
+      expect(unmigrated_asset.uuid).to eq('some-uuid')
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe S3Storage do
   let(:bucket_name) { 'bucket-name' }
   let(:s3_object) { instance_double(Aws::S3::Object) }
   let(:asset) { FactoryGirl.build(:asset) }
-  let(:s3_object_params) { { bucket_name: bucket_name, key: asset.id.to_s } }
+  let(:s3_object_params) { { bucket_name: bucket_name, key: asset.uuid } }
 
   before do
     allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Asset, type: :model do
 
       expect(a).to be_persisted
     end
+
+    it 'should generate a 36-character UUID' do
+      a = Asset.new
+      expect(a.uuid.length).to eq(36)
+    end
   end
 
   describe "#filename" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe Asset, type: :model do
       expect(a).to be_persisted
     end
 
-    it 'should generate a 36-character UUID' do
+    it 'should generate a UUID' do
+      allow(SecureRandom).to receive(:uuid).and_return('uuid')
       a = Asset.new
-      expect(a.uuid.length).to eq(36)
+      expect(a.uuid).to eq('uuid')
     end
   end
 


### PR DESCRIPTION
Before this PR we were using Asset#id to generate the `key` used to store the asset in the S3 bucket. We feel that this couples the storage of the assets a little too closely to Mongo and its mechanism for generating ids and may make it difficult to change database technology in the future. In addition it overloads further the `_id` field in the asset document which is already used to generate URLs in the API response and filenames for NFS storage.

Instead we'll use a UUID as the object key, generated using Ruby's RFC 4122[1] compliant `SecureRandom#uuid`. This means that the key generation is in the application code and decoupled from the database.

At this stage we are not considering changing how assets are stored on the NFS filesystem, or the object ID created for them in the JSON response.

I'd like a bit of feedback on: 

- the test for the `Asset` `uuid` field, at the moment I'm just expecting it to be a 36-character string, but I could probably use a regex or something and introduce a uniqueness constraint. 
- the best way to migrate existing data. I think I should iterate through the existing records in batches and generate UUIDs but this may require downtime. 



Fixes: #94 