### PR TITLE
Send more response headers when proxying to S3 via Nginx

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -23,6 +23,8 @@ class MediaController < ApplicationController
           headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
           headers['ETag'] = %{"#{asset.etag}"}
           headers['Last-Modified'] = asset.last_modified.httpdate
+          headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
+          headers['Content-Type'] = asset.content_type
           render nothing: true
         elsif proxy_to_s3_via_rails?
           body = Services.cloud_storage.load(asset)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -90,21 +90,13 @@ class Asset
   end
 
   def save_to_cloud_storage
-    Services.cloud_storage.save(self, cloud_storage_options)
+    Services.cloud_storage.save(self)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
     raise
   end
 
 protected
-
-  def cloud_storage_options
-    {
-      cache_control: AssetManager.cache_control.header,
-      content_disposition: AssetManager.content_disposition.header_for(self),
-      content_type: content_type
-    }
-  end
 
   def valid_filenames
     filename_history + [filename]

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "content_disposition_configuration"
 
 RSpec.describe Asset, type: :model do
   include DelayedJobHelpers
@@ -135,37 +134,13 @@ RSpec.describe Asset, type: :model do
 
     context 'when S3 bucket is configured' do
       let(:cloud_storage) { double(:cloud_storage) }
-      let(:cache_control) { instance_double(CacheControlConfiguration) }
-      let(:content_disposition) { instance_double(ContentDispositionConfiguration) }
 
       before do
         allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
-        allow(AssetManager).to receive(:cache_control).and_return(cache_control)
-        allow(cache_control).to receive(:header).and_return('cache-control-header')
-        allow(AssetManager).to receive(:content_disposition).and_return(content_disposition)
-        allow(content_disposition).to receive(:header_for).with(asset).and_return('content-disposition-header')
       end
 
       it 'saves the asset to cloud storage' do
-        expect(cloud_storage).to receive(:save).with(asset, anything)
-
-        asset.save_to_cloud_storage
-      end
-
-      it 'sets the Cache-Control header on the asset stored in the cloud' do
-        expect(cloud_storage).to receive(:save).with(anything, include(cache_control: 'cache-control-header'))
-
-        asset.save_to_cloud_storage
-      end
-
-      it 'sets the Content-Disposition header on the asset stored in the cloud' do
-        expect(cloud_storage).to receive(:save).with(anything, include(content_disposition: 'content-disposition-header'))
-
-        asset.save_to_cloud_storage
-      end
-
-      it 'sets the Content-Type header on the asset stored in the cloud' do
-        expect(cloud_storage).to receive(:save).with(anything, include(content_type: 'image/png'))
+        expect(cloud_storage).to receive(:save).with(asset)
 
         asset.save_to_cloud_storage
       end


### PR DESCRIPTION
And stop setting them on the S3 object.

Prior to this commit, the Rails app was both setting a `Cache-Control` response header on the S3 object *and* sending a `Cache-Control` response header in the response to Nginx instructing it to proxy the request to S3. Thus the user was receiving two duplicate `Cache-Control` headers. Although the values would have been the same, we want to avoid confusion and/or unexpected behaviour.

After this commit we no longer set the `Cache-Control`, `Content-Disposition`, or `Content-Type` headers on the S3 object. Instead the Rails app sends these headers to Nginx. We plan to update the Nginx configuration in a separate pull request against govuk-puppet in order to ensure the headers from Rails are added to the proxied response.

In #158 we considered preventing the Rails app from sending the `Cache-Control` header, but as @chrisroos pointed out, it was confusing that some headers were being set by Rails and some by S3. Given that we want to override the `ETag` and `Last-Modified` response headers to match those sent by Nginx when using the default Sendfile functionality (see Rails app to be the canonical source of *all* response headers when proxying to S3 via Nginx.

Note that the `Cache-Control` header is already being set via the call to `ApplicationController#set_expiry` and so we don't need to set it more verbosely like we have for the other headers.

Addresses the Asset Manager aspect of #149. As noted above, we will need to make some corresponding changes to govuk-puppet.

Supersedes #158.