### PR TITLE
Fail fast if S3 bucket name is not configured in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ This functionality is *very* experimental and should not be switched on in produ
 
 As long as the S3 bucket is configured, all assets are uploaded to the S3 bucket via a separate `Delayed::Job` triggered if virus scanning succeeds. Assets are still saved to the NFS mount as per the original behaviour.
 
-The following environment variables are only needed if you want to enable this functionality, i.e. they are all optional.
-
-#### Standard AWS environment variables
+#### Standard AWS environment variables (required in production)
 
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`
@@ -56,8 +54,8 @@ The following environment variables are only needed if you want to enable this f
 
 ##### AWS
 
-* `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored
-* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (requires CNAME setup for bucket)
+* `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored (required in production)
+* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (assumes CNAME has been setup for bucket)
 
 ##### Feature flags
 

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,4 +1,9 @@
-AssetManager.aws_s3_bucket_name = ENV['AWS_S3_BUCKET_NAME']
+AssetManager.aws_s3_bucket_name = if Rails.env.production?
+  ENV.fetch('AWS_S3_BUCKET_NAME')
+else
+  ENV['AWS_S3_BUCKET_NAME']
+end
+
 AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 
 Aws.config.update(


### PR DESCRIPTION
Supersedes #159.

The app will now fail fast with a KeyError if the `AWS_S3_BUCKET_NAME` environment variable is not set in the production environment.

If the environment variable is not set in the development environment then a "null object" version of the `S3Storage` class is used so that uploads are a no-op. However, note that asset requests using the `proxy_to_s3_via_nginx` option will fail with a 500 Server Error via the `S3Storage::NotConfiguredError` exception.

In the test environment, by default the `Services.cloud_storage` method returns an RSpec stub. This can be overridden by setting `disable_cloud_storage_stub: true` in the RSpec metadata for an example, context, or spec.

I've updated the README to reflect these changes and indicate which environment variables are required in production.

Fixes #154.