### PR TITLE
Fix some Rubocop offences & warnings in AWS config

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,8 +1,8 @@
 AssetManager.aws_s3_bucket_name = if Rails.env.production?
-  ENV.fetch('AWS_S3_BUCKET_NAME')
-else
-  ENV['AWS_S3_BUCKET_NAME']
-end
+                                    ENV.fetch('AWS_S3_BUCKET_NAME')
+                                  else
+                                    ENV['AWS_S3_BUCKET_NAME']
+                                  end
 
 AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
 


### PR DESCRIPTION
I was seeing the following locally:

* Layout/IndentationWidth
* Layout/ElseAlignment
* Lint/EndAlignment

For some reason these were not picked up by the Jenkins CI build of the master branch. I plan to investigate why this didn't happen separately.