### PR TITLE
Specify appropriate HTTP method when pre-signing S3 URLs

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,7 +19,7 @@ class MediaController < ApplicationController
         if redirect_to_s3?
           redirect_to Services.cloud_storage.public_url_for(asset)
         elsif proxy_to_s3_via_nginx?
-          url = Services.cloud_storage.presigned_url_for(asset)
+          url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
           headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
           headers['ETag'] = %{"#{asset.etag}"}
           headers['Last-Modified'] = asset.last_modified.httpdate

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -31,8 +31,8 @@ class S3Storage
     object_for(asset).public_url(virtual_host: AssetManager.aws_s3_use_virtual_host)
   end
 
-  def presigned_url_for(asset)
-    object_for(asset).presigned_url(:get, expires_in: 1.minute, virtual_host: AssetManager.aws_s3_use_virtual_host)
+  def presigned_url_for(asset, http_method: 'GET')
+    object_for(asset).presigned_url(http_method, expires_in: 1.minute, virtual_host: AssetManager.aws_s3_use_virtual_host)
   end
 
 private

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -93,9 +93,14 @@ RSpec.describe S3Storage do
     context 'when configured not to use virtual host' do
       let(:use_virtual_host) { false }
 
-      it 'returns presigned URL for asset on S3' do
-        allow(s3_object).to receive(:presigned_url).with(:get, expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+      it 'returns presigned URL for GET request to asset on S3 by default' do
+        allow(s3_object).to receive(:presigned_url).with('GET', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
+      end
+
+      it 'returns presigned URL for HEAD request to asset on S3 when http_method specified' do
+        allow(s3_object).to receive(:presigned_url).with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+        expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
       end
     end
 
@@ -103,7 +108,7 @@ RSpec.describe S3Storage do
       let(:use_virtual_host) { true }
 
       it 'returns presigned URL for asset on S3 using virtual host' do
-        allow(s3_object).to receive(:presigned_url).with(:get, expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
+        allow(s3_object).to receive(:presigned_url).with('GET', expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
     end


### PR DESCRIPTION
Previously we were assuming all requests handled by `MediaController#download` were HTTP GET requests, but HEAD requests are also possible. When proxying asset requests to S3 via Nginx we were then generating S3 URL signatures based on this assumption, but these signatures were invalid when used in the subsequent HEAD request by Nginx and led to a 403 Forbidden response being sent to the client.

This commit supplies the HTTP method to the code which generates the pre-signed S3 URLs and hence HEAD requests for assets now work OK when proxying to S3 via Nginx.

Fixes #169.