### PR TITLE
Avoid sending empty Content-Type header when proxying to S3

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -57,11 +57,8 @@ class Asset
   end
 
   def content_type
-    if extension.present?
-      Mime::Type.lookup_by_extension(extension).to_s
-    else
-      AssetManager.default_content_type
-    end
+    mime_type = Mime::Type.lookup_by_extension(extension)
+    mime_type ? mime_type.to_s : AssetManager.default_content_type
   end
 
   def etag

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -335,10 +335,20 @@ RSpec.describe Asset, type: :model do
 
   describe "content_type" do
     context "when asset file has extension" do
-      let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+      context 'and the extension is a recognised mime type' do
+        let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
 
-      it "returns content type based on asset file extension" do
-        expect(asset.content_type).to eq(Mime::Type.lookup('image/png').to_s)
+        it "returns content type based on asset file extension" do
+          expect(asset.content_type).to eq(Mime::Type.lookup('image/png').to_s)
+        end
+      end
+
+      context 'and the extension is not a recognised mime type' do
+        let(:asset) { Asset.new(file: load_fixture_file("asset-with-unregistered-mimetype-extension.doc")) }
+
+        it "returns default content type" do
+          expect(asset.content_type).to eq('application/octet-stream')
+        end
       end
     end
 


### PR DESCRIPTION
Prior to this commit, `Asset#content_type` would return an empty string
if the file extension wasn't found by `Mime::Type.lookup`. This meant
that the `Content-Type` response header was also being set to an empty
string. Something else in the Rails stack (presumably some middleware)
was then replacing this empty string with "\*/\*; charset=utf-8". The
effect of this was that the `Content-Type` response header for files
with unrecognised mime types would be 'application/octet-stream' when
serving the file from the disk and '\*/\*; charset=utf-8' when serving the
file from S3.

This commit ensures we send the default content type
('application/octet-stream') for files with unrecognised mime types when
proxying requests to S3.

Note that `Mime::Type.lookup_by_extension(nil)` returns the same as
`Mime::Type.lookup_by_extension('unrecognised-extension')` which allows
me to get rid of the `if extension.present?` condition.

Fixes issue #175.