### PR TITLE
Add a rake task to allow uploading existing assets to S3

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -69,6 +69,10 @@ class Asset
     file_stat.mtime
   end
 
+  def md5_hexdigest
+    @md5_hexdigest ||= Digest::MD5.hexdigest(file.file.read)
+  end
+
   def scan_for_viruses
     scanner = VirusScanner.new(self.file.current_path)
     if scanner.clean?
@@ -104,6 +108,7 @@ protected
   def reset_state
     self.state = 'unscanned'
     @file_stat = nil
+    @md5_hexdigest = nil
   end
 
   def schedule_virus_scan

--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -1,0 +1,15 @@
+namespace :s3 do
+  desc "Upload clean assets to S3 (percentage: fraction of assets to upload; default: 0)"
+  task :upload_all_clean_assets, [:percentage] => [:environment] do |_t, args|
+    random_number_generator = Random.new
+    Asset.where(state: 'clean').each do |asset|
+      if asset.file.file.exists?
+        if random_number_generator.rand(100) < args[:percentage].to_i
+          asset.delay(priority: 10).save_to_cloud_storage
+        end
+      else
+        puts "Ignoring asset (#{asset.id}) with missing file: #{asset.file.file.path}"
+      end
+    end
+  end
+end

--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -1,15 +1,18 @@
 namespace :s3 do
   desc "Upload clean assets to S3 (percentage: fraction of assets to upload; default: 0)"
   task :upload_all_clean_assets, [:percentage] => [:environment] do |_t, args|
+    count = 0
     random_number_generator = Random.new
     Asset.where(state: 'clean').each do |asset|
       if asset.file.file.exists?
         if random_number_generator.rand(100) < args[:percentage].to_i
           asset.delay(priority: 10).save_to_cloud_storage
+          count += 1
         end
       else
         puts "Ignoring asset (#{asset.id}) with missing file: #{asset.file.file.path}"
       end
     end
+    puts "Total jobs enqueued: #{count}"
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -5,25 +5,71 @@ RSpec.describe S3Storage do
   subject { described_class.build(bucket_name) }
 
   let(:bucket_name) { 'bucket-name' }
+  let(:s3_client) { instance_double(Aws::S3::Client) }
   let(:s3_object) { instance_double(Aws::S3::Object) }
   let(:asset) { FactoryGirl.build(:asset) }
-  let(:s3_object_params) { { bucket_name: bucket_name, key: asset.uuid } }
+  let(:key) { asset.uuid }
+  let(:s3_object_params) { { bucket_name: bucket_name, key: key } }
+  let(:s3_head_object_params) { { bucket: bucket_name, key: key } }
 
   before do
+    allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
     allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
   end
 
   describe '#save' do
+    let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }
+
+    before do
+      allow(s3_client).to receive(:head_object).with(s3_head_object_params).and_raise(not_found_error)
+    end
+
     it 'uploads file to S3 bucket' do
       expect(s3_object).to receive(:upload_file).with(asset.file.path, anything)
 
       subject.save(asset)
     end
 
+    it 'sets md5-hexdigest custom metadata on S3 object' do
+      expected_metadata = include(metadata: include('md5-hexdigest' => asset.md5_hexdigest))
+      expect(s3_object).to receive(:upload_file).with(anything, expected_metadata)
+
+      subject.save(asset)
+    end
+
     it 'passes options to Aws::S3::Object#upload_file' do
-      expect(s3_object).to receive(:upload_file).with(anything, cache_control: 'cache-control-header')
+      expect(s3_object).to receive(:upload_file).with(anything, include(cache_control: 'cache-control-header'))
 
       subject.save(asset, cache_control: 'cache-control-header')
+    end
+
+    context 'when S3 object already exists' do
+      let(:attributes) { { metadata: { 'md5-hexdigest' => md5_hexdigest } } }
+      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
+
+      before do
+        allow(s3_client).to receive(:head_object).with(s3_head_object_params).and_return(s3_result)
+      end
+
+      context 'and MD5 hex digest does match' do
+        let(:md5_hexdigest) { asset.md5_hexdigest }
+
+        it 'does not upload file to S3' do
+          expect(s3_object).not_to receive(:upload_file)
+
+          subject.save(asset)
+        end
+      end
+
+      context 'and MD5 hex digest does not match' do
+        let(:md5_hexdigest) { 'does-not-match' }
+
+        it 'uploads file to S3' do
+          expect(s3_object).to receive(:upload_file)
+
+          subject.save(asset)
+        end
+      end
     end
 
     context 'when bucket name is blank' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -404,4 +404,13 @@ RSpec.describe Asset, type: :model do
       expect(asset.last_modified).to eq(mtime)
     end
   end
+
+  describe "#md5_hexdigest" do
+    let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+    let(:md5_hexdigest) { 'a0d8aa55f6db670e38a14962c0652776' }
+
+    it "returns MD5 hex digest for asset file content" do
+      expect(asset.md5_hexdigest).to eq(md5_hexdigest)
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the existing upload mechanism so that we store an MD5 digest on each asset in S3 which means we can do a HEAD request to check whether an up-to-date copy of the asset already exists on S3 and thus avoid having to upload it again. See the commit note with subject "Do not upload asset to S3 if file content is identical" for further details on why we chose to do it this way.

This PR also adds a rake task (`s3:upload_all_clean_assets`) to upload existing clean assets to S3 via a low priority `Delayed::Job` per asset. The rake task accepts a `percentage` argument which sets the probability that an asset is uploaded - the idea is that we can use this to test the task with a random subset of assets. The improved upload mechanism mentioned above means it's OK to run the rake task multiple times - each asset will only ever be uploaded once.
