### PR TITLE
Remove jenkins scripts from dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,4 @@
 README.md
 CONTRIBUTING.md
 LICENSE
-jenkins.sh
-jenkins_branches.sh
 log/*


### PR DESCRIPTION
These scripts were removed in [this commit][1].

[1]: https://github.com/alphagov/asset-manager/commit/74af146d48fbbd98595df5d3f000899f77d2aee9