### PR TITLE
Remove ability to proxy to S3 via Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,11 @@ As long as the S3 bucket is configured, all assets are uploaded to the S3 bucket
 
 At most *one* of these should be used in any given environment. If none of them are set then the default behaviour is for the Rails app to instruct Nginx to serve the assets from the NFS mount.
 
-* `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` - causes *all* asset requests to be proxied to S3 via the Rails app
 * `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100
 * `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
 
 #### Request parameters
 
-* Asset requests can be proxied to S3 via the Rails app even if `PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS` is not set by adding `proxy_to_s3_via_rails=true` as a request parameter key-value pair to the query string.
 * Asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
 * Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -26,9 +26,6 @@ class MediaController < ApplicationController
           headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
           headers['Content-Type'] = asset.content_type
           render nothing: true
-        elsif proxy_to_s3_via_rails?
-          body = Services.cloud_storage.load(asset)
-          send_data(body.read, **AssetManager.content_disposition.options_for(asset))
         else
           send_file(asset.file.path, disposition: AssetManager.content_disposition.type)
         end
@@ -47,10 +44,6 @@ protected
     percentage = AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx
     proxy_to_s3_via_nginx = random_number_generator.rand(100) < percentage
     proxy_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
-  end
-
-  def proxy_to_s3_via_rails?
-    AssetManager.proxy_all_asset_requests_to_s3_via_rails || params[:proxy_to_s3_via_rails].present?
   end
 
   def filename_current?

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,6 @@ module AssetManager
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :aws_s3_use_virtual_host
 
-  mattr_accessor :proxy_all_asset_requests_to_s3_via_rails
   mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
   mattr_accessor :redirect_all_asset_requests_to_s3
 

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,3 +1,2 @@
-AssetManager.proxy_all_asset_requests_to_s3_via_rails = ENV['PROXY_ALL_ASSET_REQUESTS_TO_S3_VIA_RAILS'].present?
 AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
 AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -8,28 +8,6 @@ RSpec.describe "Media requests", type: :request do
     end
   end
 
-  describe "request an asset to be proxied to S3 via the Rails app", disable_cloud_storage_stub: true do
-    context "when bucket not configured" do
-      let(:asset) { FactoryGirl.create(:clean_asset) }
-
-      before do
-        allow(AssetManager).to receive(:aws_s3_bucket_name).and_return(nil)
-      end
-
-      it "should respond with internal server error status" do
-        get "/media/#{asset.id}/asset.png?proxy_to_s3_via_rails=true"
-        expect(response).to have_http_status(:internal_server_error)
-      end
-
-      it "should include error message in JSON response" do
-        get "/media/#{asset.id}/asset.png?proxy_to_s3_via_rails=true"
-        json = JSON.parse(response.body)
-        status = json['_response_info']['status']
-        expect(status).to eq('Internal server error: AWS S3 bucket not correctly configured')
-      end
-    end
-  end
-
   describe "request an asset that does exist" do
     let(:asset) { FactoryGirl.create(:clean_asset) }
 


### PR DESCRIPTION
This has been superseded by the better-performing functionality which proxies to S3 via Nginx.