### PR TITLE
Update Ruby & Bundler versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ruby:2.2.3
+FROM ruby:2.3.1
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav && apt-get clean
 RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
+RUN gem install bundler -v1.14.5
 
 ENV GOVUK_APP_NAME asset-manager
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk


### PR DESCRIPTION
This brings them into line with the ones specified in the `.ruby-version` file and the `Gemfile.lock`.

I built an image from the `Dockerfile` and ran it in a container to check the changes had taken effect:

```
root@ac73aeccb4e9:/app# ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
root@ac73aeccb4e9:/app# bundler -v
Bundler version 1.14.5
```

Closes #143.