### PR TITLE
Reduce duplication in asset-related logic

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,2 @@
 module ApplicationHelper
-  def asset_mime_type(asset)
-    MIME::Types.type_for(asset.file.current_path).first
-  end
 end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -11,15 +11,9 @@ class AssetPresenter
       },
       id: @view_context.asset_url(@asset.id),
       name: @asset.file.file.identifier,
-      content_type: asset_mime_type.to_s,
+      content_type: @asset.content_type,
       file_url: "#{Plek.new.asset_root}/media/#{@asset.id}/#{@asset.file.file.identifier}",
       state: @asset.state,
     }
-  end
-
-private
-
-  def asset_mime_type
-    MIME::Types.type_for(@asset.file.current_path).first
   end
 end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -10,9 +10,9 @@ class AssetPresenter
         status: options[:status] || "ok",
       },
       id: @view_context.asset_url(@asset.id),
-      name: @asset.file.file.identifier,
+      name: @asset.filename,
       content_type: @asset.content_type,
-      file_url: "#{Plek.new.asset_root}/media/#{@asset.id}/#{@asset.file.file.identifier}",
+      file_url: "#{Plek.new.asset_root}/media/#{@asset.id}/#{@asset.filename}",
       state: @asset.state,
     }
   end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:clean_asset) }
 
       def do_get(extra_params = {})
-        get :download, { id: asset, filename: asset.file.file.identifier }.merge(extra_params)
+        get :download, { id: asset, filename: asset.filename }.merge(extra_params)
       end
 
       it "responds with 200 OK" do
@@ -214,7 +214,7 @@ RSpec.describe MediaController, type: :controller do
           let(:http_method) { 'HEAD' }
 
           it "responds with 200 OK" do
-            head :download, id: asset, filename: asset.file.file.identifier
+            head :download, id: asset, filename: asset.filename
             expect(response).to have_http_status(:ok)
           end
         end
@@ -270,7 +270,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:asset) }
 
       it "responds with 404 Not Found" do
-        get :download, id: asset, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.filename
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -279,7 +279,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:infected_asset) }
 
       it "responds with 404 Not Found" do
-        get :download, id: asset, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.filename
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -342,7 +342,7 @@ RSpec.describe MediaController, type: :controller do
       let(:asset) { FactoryGirl.create(:deleted_asset) }
 
       before do
-        get :download, id: asset, filename: asset.file.file.identifier
+        get :download, id: asset, filename: asset.filename
       end
 
       it "responds with not found status" do

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe AssetPresenter do
+  subject(:presenter) { described_class.new(asset, view_context) }
+
+  let(:asset) { FactoryGirl.build(:asset) }
+  let(:view_context) { instance_double(ActionView::Base) }
+
+  context '#as_json' do
+    let(:options) { {} }
+    let(:json) { presenter.as_json(options) }
+    let(:asset_url) { 'asset-url' }
+
+    before do
+      allow(view_context).to receive(:asset_url).with(asset.id).and_return(asset_url)
+    end
+
+    context 'when no status is supplied' do
+      let(:options) { { status: nil } }
+
+      it 'returns hash including default response status' do
+        expect(json).to include(_response_info: { status: 'ok' })
+      end
+    end
+
+    context 'when status is supplied' do
+      let(:options) { { status: 'not_found' } }
+
+      it 'returns hash including response status' do
+        expect(json).to include(_response_info: { status: 'not_found' })
+      end
+    end
+
+    it 'returns hash including asset URL as API identifier' do
+      expect(json).to include(id: 'asset-url')
+    end
+
+    it 'returns hash including asset filename as name' do
+      expect(json).to include(name: 'asset.png')
+    end
+
+    it 'returns hash including asset content type' do
+      expect(json).to include(content_type: 'image/png')
+    end
+
+    it 'returns hash including public asset URL as file_url' do
+      uri = URI.parse(json[:file_url])
+      expect("#{uri.scheme}://#{uri.host}").to eq(Plek.new.asset_root)
+      expect(uri.path).to eq("/media/#{asset.id}/#{asset.filename}")
+    end
+
+    it 'returns hash including asset state' do
+      expect(json).to include(state: 'unscanned')
+    end
+  end
+end


### PR DESCRIPTION
By making use of methods that have been added to `Asset`, e.g. `Asset#content_type` and `Asset#filename`.