### PR TITLE
Enable Rails asset pipeline

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require File.expand_path('../boot', __FILE__)
 require "action_controller/railtie"
 require "action_mailer/railtie"
 # require "action_view/railtie"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -32,6 +32,8 @@ module AssetManager
     config.action_dispatch.rack_cache = nil
 
     config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
+
+    config.assets.prefix = '/asset-manager'
   end
 
   mattr_accessor :aws_s3_bucket_name


### PR DESCRIPTION
We're going to want to use this for the `thumbnail-placeholder.png` image which we're going to move across from Whitehall.

We've set the assets prefix in order to: (a) avoid a conflict with the `/assets` route defined within Asset Manager for its API endpoint; and (b) conform with the approach taken by other apps like Static to allow routing [via the Nginx configuration for the assets-origin host][1].

Note that we don't need any of `sass-rails`, `coffee-rails` and `uglifier` gems, because we only need to serve images.

[1]:
https://github.com/alphagov/govuk-puppet/blob/994d5424c7e4e28e903039f9f603e8d345b4f01d/hieradata/common.yaml#L1545-L1566