### PR TITLE
Migrate S3 upload worker to sidekiq

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,6 +54,7 @@ RSpec/NestedGroups:
     - 'spec/lib/s3_storage_spec.rb'
     - 'spec/models/asset_spec.rb'
     - 'spec/models/whitehall_asset_spec.rb'
+    - 'spec/workers/save_to_cloud_storage_worker_spec.rb'
 
 # Offense count: 10
 # Configuration parameters: Strict, EnforcedStyle, SupportedStyles.
@@ -71,3 +72,4 @@ RSpec/VerifiedDoubles:
     - 'spec/models/asset_spec.rb'
     - 'spec/support/authentication.rb'
     - 'spec/support/cloud_storage.rb'
+    - 'spec/workers/save_to_cloud_storage_worker_spec.rb'

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -36,7 +36,7 @@ class Asset
     end
 
     after_transition to: :clean do |asset, _|
-      asset.delay.save_to_cloud_storage
+      SaveToCloudStorageWorker.perform_async(asset)
     end
 
     event :scanned_infected do
@@ -113,10 +113,7 @@ class Asset
   end
 
   def save_to_cloud_storage
-    Services.cloud_storage.save(self)
-  rescue => e
-    Airbrake.notify_or_ignore(e, params: { id: self.id, filename: self.filename })
-    raise
+    SaveToCloudStorageWorker.new.perform(self)
   end
 
 protected

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -36,7 +36,7 @@ class Asset
     end
 
     after_transition to: :clean do |asset, _|
-      SaveToCloudStorageWorker.perform_async(asset)
+      SaveToCloudStorageWorker.perform_async(asset.id)
     end
 
     event :scanned_infected do
@@ -113,7 +113,7 @@ class Asset
   end
 
   def save_to_cloud_storage
-    SaveToCloudStorageWorker.new.perform(self)
+    SaveToCloudStorageWorker.new.perform(self.id)
   end
 
 protected

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -1,0 +1,10 @@
+class SaveToCloudStorageWorker
+  include Sidekiq::Worker
+
+  def perform(asset)
+    Services.cloud_storage.save(asset)
+  rescue => e
+    Airbrake.notify_or_ignore(e, params: { id: asset.id, filename: asset.filename })
+    raise
+  end
+end

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -1,7 +1,8 @@
 class SaveToCloudStorageWorker
   include Sidekiq::Worker
 
-  def perform(asset)
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
     Services.cloud_storage.save(asset)
   rescue => e
     Airbrake.notify_or_ignore(e, params: { id: asset.id, filename: asset.filename })

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it 'schedules saving the asset to cloud storage' do
-      expect(SaveToCloudStorageWorker).to receive(:perform_async).with(asset)
+      expect(SaveToCloudStorageWorker).to receive(:perform_async).with(asset.id)
 
       asset.scan_for_viruses
     end
@@ -181,7 +181,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it 'synchronously calls SaveToCloudStorageWorker' do
-      expect(worker).to receive(:perform).with(asset)
+      expect(worker).to receive(:perform).with(asset.id)
       asset.save_to_cloud_storage
     end
   end

--- a/spec/workers/save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/save_to_cloud_storage_worker_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+RSpec.describe SaveToCloudStorageWorker, type: :worker do
+  let(:worker) { described_class.new }
+
+  describe "#perform" do
+    let(:asset) { FactoryGirl.create(:clean_asset) }
+
+    context 'when S3 bucket is configured' do
+      let(:cloud_storage) { double(:cloud_storage) }
+
+      before do
+        allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+      end
+
+      it 'saves the asset to cloud storage' do
+        expect(cloud_storage).to receive(:save).with(asset)
+
+        worker.perform(asset)
+      end
+
+      context 'when an exception is raised' do
+        let(:exception_class) { Class.new(StandardError) }
+        let(:exception) { exception_class.new }
+
+        before do
+          allow(cloud_storage).to receive(:save).and_raise(exception)
+        end
+
+        it 'reports the exception to Errbit via Airbrake' do
+          expect(Airbrake).to receive(:notify_or_ignore)
+          .with(exception, params: { id: asset.id, filename: asset.filename })
+
+          worker.perform(asset) rescue exception_class
+        end
+
+        it 're-raises the exception so Delayed::Job will re-try it' do
+          allow(Airbrake).to receive(:notify_or_ignore)
+
+          expect {
+            worker.perform(asset)
+          }.to raise_error(exception)
+        end
+      end
+    end
+
+    context 'when S3 bucket is not configured' do
+      before do
+        allow(AssetManager).to receive(:aws_s3_bucket_name).and_return(nil)
+      end
+
+      it 'does not attempt to build AWS S3 resource', disable_cloud_storage_stub: true do
+        expect(Aws::Resources::Resource).not_to receive(:new)
+
+        worker.perform(asset)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the uploading of assets to S3 from a delayed_job worker to a sidekiq worker. 

There is a reference to `asset-manager/lib/tasks/s3.rake` to `save_to_cloud_storage`. Looking at this rake task, I think it should be removed as it has already been run (and if we need it again it'll be in a different form) so I haven't converted it. I've [opened a new PR](https://github.com/alphagov/asset-manager/pull/222) to do that. 

Contributes to: #179 