### PR TITLE
Require legacy_url_path when creating Whitehall asset

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,6 +53,7 @@ RSpec/NestedGroups:
     - 'spec/controllers/media_controller_spec.rb'
     - 'spec/lib/s3_storage_spec.rb'
     - 'spec/models/asset_spec.rb'
+    - 'spec/models/whitehall_asset_spec.rb'
 
 # Offense count: 10
 # Configuration parameters: Strict, EnforcedStyle, SupportedStyles.

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -1,6 +1,6 @@
 class WhitehallAssetsController < ApplicationController
   def create
-    @asset = Asset.new(asset_params)
+    @asset = WhitehallAsset.new(asset_params)
 
     if @asset.save
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -5,7 +5,7 @@ class WhitehallMediaController < ApplicationController
 
   def download
     path = "/government/uploads/#{params[:path]}.#{params[:format]}"
-    asset = Asset.find_by(legacy_url_path: path)
+    asset = WhitehallAsset.find_by(legacy_url_path: path)
 
     if asset.unscanned?
       set_expiry(1.minute)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -13,22 +13,10 @@ class Asset
   field :uuid, type: String, default: -> { SecureRandom.uuid }
   attr_readonly :uuid
 
-  field :legacy_url_path, type: String
-  attr_readonly :legacy_url_path
-
   field :access_limited, type: Boolean, default: false
   field :organisation_slug, type: String
 
   validates :file, presence: true
-  validates :legacy_url_path,
-    uniqueness: {
-      allow_blank: true
-    },
-    format: {
-      with: %r{\A/government/uploads},
-      allow_blank: true,
-      message: 'must start with /government/uploads'
-    }
   validates :organisation_slug, presence: true, if: :access_limited?
 
   validates :uuid, presence: true,
@@ -57,11 +45,11 @@ class Asset
   end
 
   def public_url_path
-    legacy_url_path || "/media/#{id}/#{filename}"
+    "/media/#{id}/#{filename}"
   end
 
   def mainstream?
-    legacy_url_path.blank?
+    true
   end
 
   def file=(file)

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -3,12 +3,10 @@ class WhitehallAsset < Asset
   attr_readonly :legacy_url_path
 
   validates :legacy_url_path,
-    uniqueness: {
-      allow_blank: true
-    },
+    presence: true,
+    uniqueness: true,
     format: {
       with: %r{\A/government/uploads},
-      allow_blank: true,
       message: 'must start with /government/uploads'
     }
 

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -1,0 +1,22 @@
+class WhitehallAsset < Asset
+  field :legacy_url_path, type: String
+  attr_readonly :legacy_url_path
+
+  validates :legacy_url_path,
+    uniqueness: {
+      allow_blank: true
+    },
+    format: {
+      with: %r{\A/government/uploads},
+      allow_blank: true,
+      message: 'must start with /government/uploads'
+    }
+
+  def public_url_path
+    legacy_url_path
+  end
+
+  def mainstream?
+    false
+  end
+end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe MediaController, type: :controller do
 
     context "with an otherwise servable whitehall asset" do
       let(:path) { '/government/uploads/asset.png' }
-      let(:asset) { FactoryGirl.create(:clean_asset, legacy_url_path: path) }
+      let(:asset) { FactoryGirl.create(:clean_whitehall_asset, legacy_url_path: path) }
 
       it "responds with 404 Not Found" do
         get :download, id: asset, filename: asset.filename

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe WhitehallMediaController, type: :controller do
     let(:legacy_url_path) { "/government/uploads/#{path}.#{format}" }
 
     before do
-      allow(Asset).to receive(:find_by).with(legacy_url_path: legacy_url_path).and_return(asset)
+      allow(WhitehallAsset).to receive(:find_by).with(legacy_url_path: legacy_url_path).and_return(asset)
     end
 
     context 'when asset is clean' do
-      let(:asset) { FactoryGirl.build(:asset, legacy_url_path: legacy_url_path, state: 'clean') }
+      let(:asset) { FactoryGirl.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
       let(:content_disposition) { instance_double(ContentDispositionConfiguration) }
 
       before do
@@ -37,7 +37,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is unscanned image' do
-      let(:asset) { FactoryGirl.build(:asset, state: 'unscanned') }
+      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'unscanned') }
 
       before do
         allow(asset).to receive(:image?).and_return(true)
@@ -51,7 +51,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is unscanned non-image' do
-      let(:asset) { FactoryGirl.build(:asset, state: 'unscanned') }
+      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'unscanned') }
 
       before do
         allow(asset).to receive(:image?).and_return(false)
@@ -65,7 +65,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is infected' do
-      let(:asset) { FactoryGirl.build(:asset, state: 'infected') }
+      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'infected') }
 
       it 'responds with 404 Not Found' do
         get :download, path: path, format: format

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -18,6 +18,12 @@ FactoryGirl.define do
     deleted_at { Time.now }
   end
 
+  factory :whitehall_asset, parent: :asset, class: WhitehallAsset
+
+  factory :clean_whitehall_asset, parent: :whitehall_asset do
+    after :create, &:scanned_clean!
+  end
+
   factory :user do
     sequence(:name) { |n| "Winston #{n}" }
     permissions { ["signin"] }

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -18,7 +18,9 @@ FactoryGirl.define do
     deleted_at { Time.now }
   end
 
-  factory :whitehall_asset, parent: :asset, class: WhitehallAsset
+  factory :whitehall_asset, parent: :asset, class: WhitehallAsset do
+    sequence(:legacy_url_path) { |n| "/government/uploads/asset-#{n}.png" }
+  end
 
   factory :clean_whitehall_asset, parent: :whitehall_asset do
     after :create, &:scanned_clean!

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -67,106 +67,12 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe 'validation' do
-    subject(:asset) { FactoryGirl.build(:asset) }
-
-    context 'when legacy_url_path is not set' do
-      it 'is valid' do
-        expect(asset).to be_valid
-      end
-
-      context 'and legacy_url_path is not unique' do
-        let(:existing_asset) { FactoryGirl.create(:asset, legacy_url_path: nil) }
-
-        before do
-          asset.legacy_url_path = existing_asset.legacy_url_path
-        end
-
-        it 'is valid' do
-          expect(asset).to be_valid
-        end
-      end
-    end
-
-    context 'when legacy_url_path is set' do
-      context 'and legacy_url_path starts with /government/uploads' do
-        before do
-          asset.legacy_url_path = '/government/uploads/asset.png'
-        end
-
-        it 'is valid' do
-          expect(asset).to be_valid
-        end
-      end
-
-      context 'and legacy_url_path does not start with /government/uploads' do
-        before do
-          asset.legacy_url_path = '/not-government/uploads/asset.png'
-        end
-
-        it 'is not valid' do
-          expect(asset).not_to be_valid
-          expect(asset.errors[:legacy_url_path]).to include('must start with /government/uploads')
-        end
-      end
-
-      context 'and legacy_url_path is not unique' do
-        let(:valid_path) { '/government/uploads/asset.png' }
-        let(:existing_asset) { FactoryGirl.create(:asset, legacy_url_path: valid_path) }
-
-        before do
-          asset.legacy_url_path = existing_asset.legacy_url_path
-        end
-
-        it 'is not valid' do
-          expect(asset).not_to be_valid
-          expect(asset.errors[:legacy_url_path]).to include('is already taken')
-        end
-      end
-    end
-  end
-
-  describe '#legacy_url_path' do
-    subject(:asset) { FactoryGirl.build(:asset) }
-
-    before do
-      asset.legacy_url_path = '/government/uploads/asset.png'
-      asset.save!
-    end
-
-    context 'when creating asset' do
-      it 'can be set' do
-        expect(asset.reload.legacy_url_path).to eq('/government/uploads/asset.png')
-      end
-    end
-
-    context 'when updating asset' do
-      it 'cannot be set' do
-        asset.legacy_url_path = '/government/uploads/another-asset.png'
-        asset.save!
-        expect(asset.reload.legacy_url_path).to eq('/government/uploads/asset.png')
-      end
-    end
-  end
-
   describe '#public_url_path' do
     subject(:asset) { Asset.new }
 
-    context 'when legacy_url_path is not set' do
-      it 'returns public URL path for mainstream asset' do
-        expected_path = "/media/#{asset.id}/#{asset.filename}"
-        expect(asset.public_url_path).to eq(expected_path)
-      end
-    end
-
-    context 'when legacy_url_path is set' do
-      before do
-        asset.legacy_url_path = '/legacy-url-path'
-      end
-
-      it 'returns legacy URL path for whitehall asset' do
-        expect(asset.public_url_path).to eq('/legacy-url-path')
-      end
+    it 'returns public URL path for mainstream asset' do
+      expected_path = "/media/#{asset.id}/#{asset.filename}"
+      expect(asset.public_url_path).to eq(expected_path)
     end
   end
 
@@ -572,22 +478,10 @@ RSpec.describe Asset, type: :model do
   end
 
   describe '#mainstream?' do
-    let(:asset) { Asset.new(legacy_url_path: legacy_url_path) }
+    let(:asset) { Asset.new }
 
-    context 'when legacy_url_path is not set' do
-      let(:legacy_url_path) { nil }
-
-      it 'returns truth-y' do
-        expect(asset).to be_mainstream
-      end
-    end
-
-    context 'when legacy_url_path is set' do
-      let(:legacy_url_path) { '/government/uploads/asset.png' }
-
-      it 'returns false-y' do
-        expect(asset).not_to be_mainstream
-      end
+    it 'returns truth-y' do
+      expect(asset).to be_mainstream
     end
   end
 end

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -2,23 +2,12 @@ require 'rails_helper'
 
 RSpec.describe WhitehallAsset, type: :model do
   describe 'validation' do
-    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+    subject(:asset) { FactoryGirl.build(:whitehall_asset, legacy_url_path: nil) }
 
     context 'when legacy_url_path is not set' do
-      it 'is valid' do
-        expect(asset).to be_valid
-      end
-
-      context 'and legacy_url_path is not unique' do
-        let(:existing_asset) { FactoryGirl.create(:whitehall_asset, legacy_url_path: nil) }
-
-        before do
-          asset.legacy_url_path = existing_asset.legacy_url_path
-        end
-
-        it 'is valid' do
-          expect(asset).to be_valid
-        end
+      it 'is not valid' do
+        expect(asset).not_to be_valid
+        expect(asset.errors[:legacy_url_path]).to include("can't be blank")
       end
     end
 
@@ -45,8 +34,7 @@ RSpec.describe WhitehallAsset, type: :model do
       end
 
       context 'and legacy_url_path is not unique' do
-        let(:valid_path) { '/government/uploads/asset.png' }
-        let(:existing_asset) { FactoryGirl.create(:whitehall_asset, legacy_url_path: valid_path) }
+        let(:existing_asset) { FactoryGirl.create(:whitehall_asset) }
 
         before do
           asset.legacy_url_path = existing_asset.legacy_url_path

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe WhitehallAsset, type: :model do
+  describe 'validation' do
+    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+
+    context 'when legacy_url_path is not set' do
+      it 'is valid' do
+        expect(asset).to be_valid
+      end
+
+      context 'and legacy_url_path is not unique' do
+        let(:existing_asset) { FactoryGirl.create(:whitehall_asset, legacy_url_path: nil) }
+
+        before do
+          asset.legacy_url_path = existing_asset.legacy_url_path
+        end
+
+        it 'is valid' do
+          expect(asset).to be_valid
+        end
+      end
+    end
+
+    context 'when legacy_url_path is set' do
+      context 'and legacy_url_path starts with /government/uploads' do
+        before do
+          asset.legacy_url_path = '/government/uploads/asset.png'
+        end
+
+        it 'is valid' do
+          expect(asset).to be_valid
+        end
+      end
+
+      context 'and legacy_url_path does not start with /government/uploads' do
+        before do
+          asset.legacy_url_path = '/not-government/uploads/asset.png'
+        end
+
+        it 'is not valid' do
+          expect(asset).not_to be_valid
+          expect(asset.errors[:legacy_url_path]).to include('must start with /government/uploads')
+        end
+      end
+
+      context 'and legacy_url_path is not unique' do
+        let(:valid_path) { '/government/uploads/asset.png' }
+        let(:existing_asset) { FactoryGirl.create(:whitehall_asset, legacy_url_path: valid_path) }
+
+        before do
+          asset.legacy_url_path = existing_asset.legacy_url_path
+        end
+
+        it 'is not valid' do
+          expect(asset).not_to be_valid
+          expect(asset.errors[:legacy_url_path]).to include('is already taken')
+        end
+      end
+    end
+  end
+
+  describe '#legacy_url_path' do
+    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+
+    before do
+      asset.legacy_url_path = '/government/uploads/asset.png'
+      asset.save!
+    end
+
+    context 'when creating asset' do
+      it 'can be set' do
+        expect(asset.reload.legacy_url_path).to eq('/government/uploads/asset.png')
+      end
+    end
+
+    context 'when updating asset' do
+      it 'cannot be set' do
+        asset.legacy_url_path = '/government/uploads/another-asset.png'
+        asset.save!
+        expect(asset.reload.legacy_url_path).to eq('/government/uploads/asset.png')
+      end
+    end
+  end
+
+  describe '#public_url_path' do
+    subject(:asset) { WhitehallAsset.new(legacy_url_path: '/legacy-url-path') }
+
+    it 'returns legacy URL path for whitehall asset' do
+      expect(asset.public_url_path).to eq('/legacy-url-path')
+    end
+  end
+
+  describe '#mainstream?' do
+    let(:asset) { WhitehallAsset.new }
+
+    it 'returns false-y' do
+      expect(asset).not_to be_mainstream
+    end
+  end
+end

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
 
     before do
       FactoryGirl.create(
-        :asset,
+        :whitehall_asset,
         file: load_fixture_file('asset.png'),
         legacy_url_path: path
       )
@@ -36,7 +36,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
 
     before do
       FactoryGirl.create(
-        :asset,
+        :whitehall_asset,
         file: load_fixture_file('lorem.txt'),
         legacy_url_path: path
       )
@@ -55,7 +55,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
 
   describe 'request for a clean asset' do
     let(:path) { '/government/uploads/asset.png' }
-    let!(:asset) { FactoryGirl.create(:clean_asset, legacy_url_path: path) }
+    let!(:asset) { FactoryGirl.create(:clean_whitehall_asset, legacy_url_path: path) }
 
     before do
       get path, nil,


### PR DESCRIPTION
This introduces a `WhitehallAsset` subclass of `Asset` and pulls down the `legacy_url_path` attribute from `Asset` to `WhitehallAsset` along with related behaviour. The validation for `WhitehallAsset` is then modified to require the presence of the `legacy_url_path` attribute. The effect of this will be to respond with an error if no `legacy_url_path` is supplied to `WhitehallAssetsController#create`.