### PR TITLE
Update BUNDLED WITH in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,4 +329,4 @@ DEPENDENCIES
   unicorn (= 5.0.1)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1


### PR DESCRIPTION
This app [currently uses Ruby v2.3.1][1] which means it [will run with v1.15.1 of bundler in production][2]. This commit brings the version listed in `Gemfile.lock` into line.

[1]:
https://github.com/alphagov/asset-manager/blob/00ecdd6f62bdd479db8339c1c25d17fc51822537/.ruby-version#L1
[2]:
https://github.com/alphagov/govuk-puppet/blob/c54ffa3132b5ead484d9ac78a36813760a89d6e5/modules/govuk_rbenv/manifests/all.pp#L55-L57