### PR TITLE
Store asset attributes generated from file metadata in database

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -17,6 +17,7 @@ class Asset
   field :organisation_slug, type: String
 
   field :etag, type: String
+  field :last_modified, type: Time
 
   validates :file, presence: true
   validates :organisation_slug, presence: true, if: :access_limited?
@@ -93,6 +94,10 @@ class Asset
   end
 
   def last_modified
+    self[:last_modified] || last_modified_from_file
+  end
+
+  def last_modified_from_file
     file_stat.mtime
   end
 
@@ -110,6 +115,7 @@ protected
 
   def store_metadata
     self[:etag] ||= etag_from_file
+    self[:last_modified] ||= last_modified_from_file
   end
 
   def valid_filenames

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -18,6 +18,7 @@ class Asset
 
   field :etag, type: String
   field :last_modified, type: Time
+  field :md5_hexdigest, type: String
 
   validates :file, presence: true
   validates :organisation_slug, presence: true, if: :access_limited?
@@ -102,6 +103,10 @@ class Asset
   end
 
   def md5_hexdigest
+    self[:md5_hexdigest] || md5_hexdigest_from_file
+  end
+
+  def md5_hexdigest_from_file
     @md5_hexdigest ||= Digest::MD5.hexdigest(file.file.read)
   end
 
@@ -116,6 +121,7 @@ protected
   def store_metadata
     self[:etag] ||= etag_from_file
     self[:last_modified] ||= last_modified_from_file
+    self[:md5_hexdigest] ||= md5_hexdigest_from_file
   end
 
   def valid_filenames

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -4,7 +4,8 @@ namespace :assets do
     Asset.all.each do |asset|
       asset.update_attributes!(
         etag: asset.etag_from_file,
-        last_modified: asset.last_modified_from_file
+        last_modified: asset.last_modified_from_file,
+        md5_hexdigest: asset.md5_hexdigest_from_file
       )
     end
   end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,8 @@
+namespace :assets do
+  desc 'Store etag value generated from file metadata for all assets'
+  task store_etag_value_generated_from_file_metadata: :environment do
+    Asset.all.each do |asset|
+      asset.update!(etag: asset.etag_from_file)
+    end
+  end
+end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,8 +1,11 @@
 namespace :assets do
-  desc 'Store etag value generated from file metadata for all assets'
-  task store_etag_value_generated_from_file_metadata: :environment do
+  desc 'Store values generated from file metadata for all assets'
+  task store_values_generated_from_file_metadata: :environment do
     Asset.all.each do |asset|
-      asset.update!(etag: asset.etag_from_file)
+      asset.update_attributes!(
+        etag: asset.etag_from_file,
+        last_modified: asset.last_modified_from_file
+      )
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -409,12 +409,46 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "#md5_hexdigest" do
+  describe "#md5_hexdigest_from_file" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
     let(:md5_hexdigest) { 'a0d8aa55f6db670e38a14962c0652776' }
 
     it "returns MD5 hex digest for asset file content" do
-      expect(asset.md5_hexdigest).to eq(md5_hexdigest)
+      expect(asset.md5_hexdigest_from_file).to eq(md5_hexdigest)
+    end
+  end
+
+  describe "#md5_hexdigest" do
+    let(:asset) { Asset.new(file: load_fixture_file("asset.png"), md5_hexdigest: md5_hexdigest) }
+
+    before do
+      allow(asset).to receive(:md5_hexdigest_from_file).and_return('md5-from-file')
+    end
+
+    context "when md5_hexdigest is stored in database" do
+      let(:md5_hexdigest) { 'md5-from-db' }
+
+      it "returns value from database" do
+        expect(asset.md5_hexdigest).to eq('md5-from-db')
+      end
+    end
+
+    context "when md5_hexdigest is not stored in database" do
+      let(:md5_hexdigest) { nil }
+
+      it "returns value generated from file metadata" do
+        expect(asset.md5_hexdigest).to eq('md5-from-file')
+      end
+
+      context "and asset is saved" do
+        before do
+          asset.save!
+        end
+
+        it "stores the value generated from the file in the database" do
+          expect(asset[:md5_hexdigest]).to eq('md5-from-file')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Previously the `Asset` attribute methods `#etag`, `#last_modified` and `#md5_hexdigest` generated a value from the underlying file metadata. However, we want to remove dependencies on the "local" (NFS) filesystem so that it can be removed in preference to the S3 file store. To this end, I've made the following changes:

* For new assets, the attribute values generated from the underlying file metadata are stored in the database.
* For existing assets, I've created the `assets:store_values_generated_from_file_metadata` rake task so we can use it to store the values generated from the underlying file metadata.
* For all assets, the attribute methods now return the value in database in preference to generating a value from the underlying metadata. However, for the time being they will fallback to generating the attribute value from the underlying file metadata if no value is stored in the database. Once we've run the rake task (see above) in production, we'll be able to remove these fallbacks.

My motivation for working on this was to make it easier to allow Whitehall to specify the `etag` and `last_modified` values when it creates an asset in Asset Manager. See #234 for more details.

Closes #182.