### PR TITLE
Add default REDIS_HOST env var to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV GOVUK_APP_NAME asset-manager
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk
 ENV MONGODB_URI mongodb://mongo/asset-manager
 ENV PORT 3037
+ENV REDIS_HOST redis
 ENV TEST_MONGODB_URI mongodb://mongo/asset-manager-test
 
 ENV APP_HOME /app


### PR DESCRIPTION
This project is now dependent on Redis since Sidekiq was introduced,
this adds in a default value for the hostname.