### PR TITLE
Allow etag and last_modified to be specified when creating Whitehall assets via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See the `AssetPresenter` class for the return format for the above API calls. Al
 
 `GET /media/:id/:filename` serves the file to the user if it is marked as clean.
 
-`POST /whitehall_assets` expects a single file uploaded via the `asset[file]` parameter and a path set in `asset[legacy_url_path]`. The latter tells Asset Manager the URL path at which the asset should be served. Note that this is intended as a transitional measure while we move Whitehall assets into Asset Manager. The idea is that eventually all asset URLs will be rationalised and consolidated and at that point Asset Manager will tell Whitehall the URL at which the asset will be served as it currently does for Mainstream assets. **Note** this endpoint should only be used from the Whitehall Admin app; not from any other publishing apps.
+`POST /whitehall_assets` expects a single file uploaded via the `asset[file]` parameter and a path set in `asset[legacy_url_path]`. The latter tells Asset Manager the URL path at which the asset should be served. Note that this is intended as a transitional measure while we move Whitehall assets into Asset Manager. The idea is that eventually all asset URLs will be rationalised and consolidated and at that point Asset Manager will tell Whitehall the URL at which the asset will be served as it currently does for Mainstream assets. This endpoint also accepts two optional parameters, `asset[legacy_etag]` & `asset[legacy_last_modified]`. These are only intended for use when we move *existing* Whitehall assets into Asset Manager so that we can avoid wholesale cache invalidation. **Note** this endpoint should only be used from the Whitehall Admin app; not from any other publishing apps.
 
 ### API examples
 

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -12,6 +12,8 @@ class WhitehallAssetsController < ApplicationController
 private
 
   def asset_params
-    params.require(:asset).permit(:file, :legacy_url_path, :legacy_etag)
+    params
+      .require(:asset)
+      .permit(:file, :legacy_url_path, :legacy_etag, :legacy_last_modified)
   end
 end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -3,7 +3,8 @@ class WhitehallAssetsController < ApplicationController
     @asset = WhitehallAsset.new(asset_params)
 
     if @asset.save
-      render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
+      presenter = AssetPresenter.new(@asset, view_context)
+      render json: presenter.as_json(status: :created), status: :created
     else
       error 422, @asset.errors.full_messages
     end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -12,6 +12,6 @@ class WhitehallAssetsController < ApplicationController
 private
 
   def asset_params
-    params.require(:asset).permit(:file, :legacy_url_path)
+    params.require(:asset).permit(:file, :legacy_url_path, :legacy_etag)
   end
 end

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -2,6 +2,8 @@ class WhitehallAsset < Asset
   field :legacy_url_path, type: String
   attr_readonly :legacy_url_path
 
+  alias_method :legacy_etag=, :etag=
+
   validates :legacy_url_path,
     presence: true,
     uniqueness: true,

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -3,6 +3,7 @@ class WhitehallAsset < Asset
   attr_readonly :legacy_url_path
 
   alias_method :legacy_etag=, :etag=
+  alias_method :legacy_last_modified=, :last_modified=
 
   validates :legacy_url_path,
     presence: true,

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -15,7 +15,18 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         post :create, asset: attributes
 
         expect(assigns(:asset)).to be_persisted
+      end
+
+      it "stores file on asset" do
+        post :create, asset: attributes
+
         expect(assigns(:asset).file.current_path).to match(/asset\.png$/)
+      end
+
+      it "stores legacy_url_path on asset" do
+        post :create, asset: attributes
+
+        expect(assigns(:asset).legacy_url_path).to eq(attributes[:legacy_url_path])
       end
 
       it "returns a created status" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
 
   describe "POST create" do
     context "a valid asset" do
-      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset, :with_legacy_etag) }
+      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset, :with_legacy_metadata) }
 
       it "is persisted" do
         post :create, asset: attributes
@@ -33,6 +33,12 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         post :create, asset: attributes
 
         expect(assigns(:asset).etag).to eq(attributes[:legacy_etag])
+      end
+
+      it "stores legacy_last_modified as last_modified on asset" do
+        post :create, asset: attributes
+
+        expect(assigns(:asset).last_modified).to eq(attributes[:legacy_last_modified])
       end
 
       it "returns a created status" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -9,13 +9,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
 
   describe "POST create" do
     context "a valid asset" do
-      let(:legacy_url_path) { "/government/uploads/asset.png" }
-      let(:attributes) {
-        {
-          file: load_fixture_file("asset.png"),
-          legacy_url_path: legacy_url_path
-        }
-      }
+      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset) }
 
       it "is persisted" do
         post :create, asset: attributes
@@ -56,7 +50,8 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         post :create, asset: attributes
 
         body = JSON.parse(response.body)
-        expect(body['file_url']).to eq("#{Plek.new.asset_root}#{legacy_url_path}")
+        expected_path = "#{Plek.new.asset_root}#{attributes[:legacy_url_path]}"
+        expect(body['file_url']).to eq(expected_path)
       end
     end
 

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
 
   describe "POST create" do
     context "a valid asset" do
-      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset) }
+      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset, :with_legacy_etag) }
 
       it "is persisted" do
         post :create, asset: attributes
@@ -27,6 +27,12 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         post :create, asset: attributes
 
         expect(assigns(:asset).legacy_url_path).to eq(attributes[:legacy_url_path])
+      end
+
+      it "stores legacy_etag as etag on asset" do
+        post :create, asset: attributes
+
+        expect(assigns(:asset).etag).to eq(attributes[:legacy_etag])
       end
 
       it "returns a created status" do

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -21,8 +21,9 @@ FactoryGirl.define do
   factory :whitehall_asset, parent: :asset, class: WhitehallAsset do
     sequence(:legacy_url_path) { |n| "/government/uploads/asset-#{n}.png" }
 
-    trait :with_legacy_etag do
+    trait :with_legacy_metadata do
       sequence(:legacy_etag) { |n| "legacy-etag-#{n}" }
+      sequence(:legacy_last_modified) { |n| Time.parse('2000-01-01') + n.days }
     end
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -20,6 +20,10 @@ FactoryGirl.define do
 
   factory :whitehall_asset, parent: :asset, class: WhitehallAsset do
     sequence(:legacy_url_path) { |n| "/government/uploads/asset-#{n}.png" }
+
+    trait :with_legacy_etag do
+      sequence(:legacy_etag) { |n| "legacy-etag-#{n}" }
+    end
   end
 
   factory :clean_whitehall_asset, parent: :whitehall_asset do

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe WhitehallAsset, type: :model do
     end
   end
 
+  describe '#legacy_last_modified=' do
+    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+
+    let(:example_time) { Time.parse('2001-01-01 01:01') }
+
+    it 'is aliased to Asset#last_modified=' do
+      asset.legacy_last_modified = example_time
+      expect(asset.last_modified).to eq(example_time)
+    end
+  end
+
   describe '#mainstream?' do
     let(:asset) { WhitehallAsset.new }
 

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe WhitehallAsset, type: :model do
     end
   end
 
+  describe '#legacy_etag=' do
+    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+
+    it 'is aliased to Asset#etag=' do
+      asset.legacy_etag = 'legacy-etag'
+      expect(asset.etag).to eq('legacy-etag')
+    end
+  end
+
   describe '#mainstream?' do
     let(:asset) { WhitehallAsset.new }
 


### PR DESCRIPTION
Add optional `legacy_etag` & `legacy_last_modified` parameters for the API endpoint which allows creation of Whitehall assets. We're going to need these when we move existing Whitehall assets to Asset Manager in order to avoid wholesale cache invalidation. See #234 for more details.

I've chosen to use `legacy_xxx` vs just `xxx` as the parameter names, because once we've moved the existing Whitehall assets to Asset Manager they will become redundant. Hopefully the names will also discourage anyone from using the parameters in any of the other publishing apps.

I've aliased `WhitehallAsset#legacy_xxx=` to `Asset#xxx=` partly in recognition that we'll only ever need to set `Asset#xxx` via the API when we move existing Whitehall assets to Asset Manager and partly to keep the code as simple as possible. I think it's correct that the canonical reader method is still just `Asset#xxx` vs `Asset#legacy_xxx`, because that code is used more generally within Asset Manager.

I think there is a case for preventing calls to `Asset#etag=` or `Asset#last_modified=` except from within `Asset#store_metadata` which is called after creation of an Asset, but I'm not sure it's that important so I haven't done anything about it for now.
