### PR TITLE
Ensure S3Storage::Null object implements all public methods of S3Storage

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -3,19 +3,21 @@ require 'cloud_storage'
 class S3Storage
   NotConfiguredError = Class.new(CloudStorage::NotConfiguredError)
 
+  NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
+
   class Null
     def save(_asset, _options = {}); end
 
     def load(_asset)
-      raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
     def public_url_for(_asset)
-      raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
     def presigned_url_for(_asset, _http_method: 'GET')
-      raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
   end
 

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -9,6 +9,14 @@ class S3Storage
     def load(_asset)
       raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
     end
+
+    def public_url_for(_asset)
+      raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
+    end
+
+    def presigned_url_for(_asset, _http_method: 'GET')
+      raise NotConfiguredError.new('AWS S3 bucket not correctly configured')
+    end
   end
 
   def self.build(bucket_name)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe S3Storage do
   end
 
   describe '#public_url_for' do
+    let(:use_virtual_host) { nil }
+
     before do
       allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)
     end
@@ -129,6 +131,16 @@ RSpec.describe S3Storage do
         expect(subject.public_url_for(asset)).to eq('public-url')
       end
     end
+
+    context 'when bucket name is blank' do
+      let(:bucket_name) { '' }
+
+      it 'raises NotConfiguredError exception' do
+        expect {
+          subject.public_url_for(asset)
+        }.to raise_error(S3Storage::NotConfiguredError, 'AWS S3 bucket not correctly configured')
+      end
+    end
   end
 
   describe '#presigned_url_for' do
@@ -148,6 +160,16 @@ RSpec.describe S3Storage do
         allow(s3_object).to receive(:presigned_url).with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
         expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
       end
+
+      context 'when bucket name is blank' do
+        let(:bucket_name) { '' }
+
+        it 'raises NotConfiguredError exception' do
+          expect {
+            subject.presigned_url_for(asset)
+          }.to raise_error(S3Storage::NotConfiguredError, 'AWS S3 bucket not correctly configured')
+        end
+      end
     end
 
     context 'when configured to use virtual host' do
@@ -157,6 +179,13 @@ RSpec.describe S3Storage do
         allow(s3_object).to receive(:presigned_url).with('GET', expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
+    end
+  end
+
+  describe 'S3Storage::Null' do
+    it 'implements all public methods defined on S3Storage' do
+      methods = described_class.public_instance_methods(false)
+      expect(S3Storage::Null.public_instance_methods(false)).to include(*methods)
     end
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe S3Storage do
       it 'raises NotConfiguredError exception' do
         expect {
           subject.load(asset)
-        }.to raise_error(S3Storage::NotConfiguredError, 'AWS S3 bucket not correctly configured')
+        }.to raise_error(S3Storage::NotConfiguredError)
       end
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe S3Storage do
       it 'raises NotConfiguredError exception' do
         expect {
           subject.public_url_for(asset)
-        }.to raise_error(S3Storage::NotConfiguredError, 'AWS S3 bucket not correctly configured')
+        }.to raise_error(S3Storage::NotConfiguredError)
       end
     end
   end
@@ -167,7 +167,7 @@ RSpec.describe S3Storage do
         it 'raises NotConfiguredError exception' do
           expect {
             subject.presigned_url_for(asset)
-          }.to raise_error(S3Storage::NotConfiguredError, 'AWS S3 bucket not correctly configured')
+          }.to raise_error(S3Storage::NotConfiguredError)
         end
       end
     end


### PR DESCRIPTION
The `S3Storage::Null` class had got out of sync with `S3Storage`. I've fixed this and added an example to ensure it doesn't happen again. I've also extracted the exception message into a constant to avoid duplication.