### PR TITLE
Set X-Frame-Options response header explicitly in Rails app

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -16,6 +16,7 @@ class MediaController < ApplicationController
     respond_to do |format|
       format.any do
         set_expiry(AssetManager.cache_control.max_age)
+        headers['X-Frame-Options'] = AssetManager.frame_options
         if redirect_to_s3?
           redirect_to Services.cloud_storage.public_url_for(asset)
         elsif proxy_to_s3_via_nginx?

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -21,6 +21,7 @@ class WhitehallMediaController < ApplicationController
     end
 
     set_expiry(AssetManager.whitehall_cache_control.max_age)
+    headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
     send_file(asset.file.path, disposition: AssetManager.content_disposition.type)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,4 +46,6 @@ module AssetManager
   mattr_accessor :whitehall_cache_control
   mattr_accessor :content_disposition
   mattr_accessor :default_content_type
+  mattr_accessor :frame_options
+  mattr_accessor :whitehall_frame_options
 end

--- a/config/initializers/frame_options.rb
+++ b/config/initializers/frame_options.rb
@@ -1,0 +1,2 @@
+AssetManager.frame_options = 'DENY'
+AssetManager.whitehall_frame_options = 'SAMEORIGIN'

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -26,5 +26,9 @@ RSpec.describe "Media requests", type: :request do
       expect(response.headers["Content-Type"]).to eq("image/png")
       expect(response.headers["Content-Disposition"]).to eq('inline; filename="asset.png"')
     end
+
+    it "sets the X-Frame-Options header to SAMEORIGIN" do
+      expect(response.headers["X-Frame-Options"]).to eq('DENY')
+    end
   end
 end

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -84,5 +84,9 @@ RSpec.describe 'Whitehall media requests', type: :request do
     it 'sets the Cache-Control response header to 4 hours' do
       expect(response.headers['Cache-Control']).to eq('max-age=14400, public')
     end
+
+    it 'sets the X-Frame-Options response header to SAMEORIGIN' do
+      expect(response.headers['X-Frame-Options']).to eq('SAMEORIGIN')
+    end
   end
 end


### PR DESCRIPTION
Currently the `X-Frame-Options` header is set to `DENY` for Mainstream assets [via the Nginx config for the `asset-manager` host][1]. For Whitehall assets this header is set to the value in the response from the Whitehall Rails app [by the Nginx config for the `whitehall-admin` host][2]. [By default Rails sets this value to `SAMEORIGIN`][3] and the default is not overridden in the Whitehall app config.

We're planning to serve Whitehall assets from Asset Manager. This PR changes the Rails app to set the response header explicitly to "DENY" for Mainstream assets and to "SAMEORIGIN" for Whitehall assets. Once this change is deployed we will be able to change the Nginx config for the `asset-manager` host to [respect the value in the response from the Asset Manager Rails app][4] in order to preserve the externally visible behaviour when we switch Whitehall assets to be served by Asset Manager. Note that until this config Nginx change is made, the value from the Rails app will be ignored.

In time, unless there's a good reason to use different values in different scenarios, we should standardise on one of the values in all scenarios.

#235 will be fixed by a combination of this PR and alphagov/govuk-puppet#6602.

[1]:
https://github.com/alphagov/govuk-puppet/blob/4cca939ec49a9b4c106b14b7cf896db31a003636/modules/govuk/manifests/apps/asset_manager.pp#L143-L151
[2]:
https://github.com/alphagov/govuk-puppet/blob/4cca939ec49a9b4c106b14b7cf896db31a003636/modules/govuk/manifests/apps/whitehall.pp#L235-L236
[3]:
http://guides.rubyonrails.org/v4.2.7.1/security.html#default-headers
[4]: https://github.com/alphagov/govuk-puppet/pull/6602
