### PR TITLE
Improvements to assets:store_values_generated_from_file_metadata Rake task

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,12 +1,21 @@
 namespace :assets do
   desc 'Store values generated from file metadata for all assets'
   task store_values_generated_from_file_metadata: :environment do
-    Asset.all.each do |asset|
+    total = Asset.count
+    Asset.all.each_with_index do |asset, index|
+      percent = "%0.0f" % (index / total.to_f * 100)
+      if (index % 1000).zero?
+        puts "#{index} of #{total} (#{percent}%) assets processed"
+      end
       asset.set(
         etag: asset.etag_from_file,
         last_modified: asset.last_modified_from_file,
         md5_hexdigest: asset.md5_hexdigest_from_file
       )
     end
+    puts "\nFinished!"
+    puts "#{Asset.where(etag: nil).count} assets have no etag set"
+    puts "#{Asset.where(last_modified: nil).count} assets have no last_modified set"
+    puts "#{Asset.where(md5_hexdigest: nil).count} assets have no md5_hexdigest set"
   end
 end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -2,7 +2,7 @@ namespace :assets do
   desc 'Store values generated from file metadata for all assets'
   task store_values_generated_from_file_metadata: :environment do
     Asset.all.each do |asset|
-      asset.update_attributes!(
+      asset.set(
         etag: asset.etag_from_file,
         last_modified: asset.last_modified_from_file,
         md5_hexdigest: asset.md5_hexdigest_from_file


### PR DESCRIPTION
This makes some improvements to the `assets:store_values_generated_from_file_metadata` Rake task (added in #240) based on my experience of running it in integration:

* Use `Asset#set` vs `Asset#update_attributes!` to avoid unnecessarily running validation & callbacks
* Add debug output to give an indication of progress and check that all assets have file metadata attributes set

The Rake task takes about 15 mins to run in integration - I'm hopefully it will run a bit faster in production.
