### PR TITLE
Use Sidekiq worker to store values generated from file metadata on assets

### DIFF
--- a/app/workers/asset_file_metadata_worker.rb
+++ b/app/workers/asset_file_metadata_worker.rb
@@ -1,5 +1,6 @@
 class AssetFileMetadataWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
 
   def perform(asset_id)
     asset = Asset.find(asset_id)

--- a/app/workers/asset_file_metadata_worker.rb
+++ b/app/workers/asset_file_metadata_worker.rb
@@ -1,0 +1,12 @@
+class AssetFileMetadataWorker
+  include Sidekiq::Worker
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    asset.set(
+      etag: asset.etag_from_file,
+      last_modified: asset.last_modified_from_file,
+      md5_hexdigest: asset.md5_hexdigest_from_file
+    )
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,5 @@
 ---
 :concurrency: 2
+:queues:
+  - default
+  - low_priority

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -7,17 +7,10 @@ namespace :assets do
     assets.each_with_index do |asset, index|
       percent = "%0.0f" % (index / total.to_f * 100)
       if (index % 1000).zero?
-        puts "#{index} of #{total} (#{percent}%) assets processed"
+        puts "#{index} of #{total} (#{percent}%) assets queued"
       end
-      asset.set(
-        etag: asset.etag_from_file,
-        last_modified: asset.last_modified_from_file,
-        md5_hexdigest: asset.md5_hexdigest_from_file
-      )
+      AssetFileMetadataWorker.perform_async(asset.id)
     end
     puts "\nFinished!"
-    puts "#{Asset.where(etag: nil).count} assets have no etag set"
-    puts "#{Asset.where(last_modified: nil).count} assets have no last_modified set"
-    puts "#{Asset.where(md5_hexdigest: nil).count} assets have no md5_hexdigest set"
   end
 end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -2,8 +2,9 @@ namespace :assets do
   desc 'Store values generated from file metadata for all assets'
   task store_values_generated_from_file_metadata: :environment do
     STDOUT.sync = true
-    total = Asset.count
-    Asset.all.each_with_index do |asset, index|
+    assets = Asset.all
+    total = assets.count
+    assets.each_with_index do |asset, index|
       percent = "%0.0f" % (index / total.to_f * 100)
       if (index % 1000).zero?
         puts "#{index} of #{total} (#{percent}%) assets processed"

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,5 +1,5 @@
-namespace :assets do
-  desc 'Store values generated from file metadata for all assets'
+namespace :govuk_assets do
+  desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
     STDOUT.sync = true
     assets = Asset.all


### PR DESCRIPTION
This PR contains further improvement to the `assets:store_values_generated_from_file_metadata` Rake task based on my recent experience of running it in staging.

In staging @thomasleese & I saw a problem running the Rake task in which the `each` block was executed more times than the number of assets in the database, i.e. the percent complete went well over 100%. I suspect this was caused by a problem with the MongoDB cursor somehow being reset within the `each` block, perhaps due to a timeout.

This PR changes the Rake task so it just queues up jobs to be executed by a worker class at a lower priority than the jobs used by the application in normal operation. This way the execution of the `each` block will be less than 1 min vs more than 15 mins. I'm hopeful that this will avoid the cursor problem, because the original synchronous version of the Rake task ran OK on staging despite taking nearly 15 mins to run and I didn't see any evidence of the cursor problem.

Additionally this PR changes the namespace of the Rake task from `assets` to `govuk_assets` to distinguish it from the standard Rake tasks related to the Rails asset pipeline.

It also makes a small change to ensure that the same query is used to calculate the total number of assets as is used to iterate over all the assets - thus ensuring the percent complete is as accurate as possible.