### PR TITLE
Obtain asset IDs for govuk_assets:store_values_generated_from_file_metadata Rake task in single fast-running query

### DIFF
--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -2,14 +2,14 @@ namespace :govuk_assets do
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
     STDOUT.sync = true
-    assets = Asset.all
-    total = assets.count
-    assets.each_with_index do |asset, index|
+    asset_ids = Asset.pluck(:id).to_a
+    total = asset_ids.count
+    asset_ids.each_with_index do |asset_id, index|
       percent = "%0.0f" % (index / total.to_f * 100)
       if (index % 1000).zero?
         puts "#{index} of #{total} (#{percent}%) assets queued"
       end
-      AssetFileMetadataWorker.perform_async(asset.id)
+      AssetFileMetadataWorker.perform_async(asset_id.to_s)
     end
     puts "\nFinished!"
   end


### PR DESCRIPTION
I've continued to see problems with the progress indicator going over 100% even since converting the `govuk_assets:store_values_generated_from_file_metadata` Rake task to use Sidekiq to queue the work. By obtaining *all* the asset IDs in a single fast-running query I'm hoping to avoid any problems with Mongoid cursors, which I think is at the root of the problems I've been seeing.

Prior to opening this PR, I've deployed this branch to integration and run the Rake task with the following output:

```
$ govuk_setenv asset-manager bundle exec rake govuk_assets:store_values_generated_from_file_metadata
I, [2017-10-05T14:37:03.276150 #17598]  INFO -- sentry: ** [Raven] Raven 2.6.3 ready to catch errors
0 of 60842 (0%) assets queued
1000 of 60842 (2%) assets queued
2000 of 60842 (3%) assets queued
3000 of 60842 (5%) assets queued
4000 of 60842 (7%) assets queued
5000 of 60842 (8%) assets queued
6000 of 60842 (10%) assets queued
7000 of 60842 (12%) assets queued
8000 of 60842 (13%) assets queued
9000 of 60842 (15%) assets queued
10000 of 60842 (16%) assets queued
11000 of 60842 (18%) assets queued
12000 of 60842 (20%) assets queued
13000 of 60842 (21%) assets queued
14000 of 60842 (23%) assets queued
15000 of 60842 (25%) assets queued
16000 of 60842 (26%) assets queued
17000 of 60842 (28%) assets queued
18000 of 60842 (30%) assets queued
19000 of 60842 (31%) assets queued
20000 of 60842 (33%) assets queued
21000 of 60842 (35%) assets queued
22000 of 60842 (36%) assets queued
23000 of 60842 (38%) assets queued
24000 of 60842 (39%) assets queued
25000 of 60842 (41%) assets queued
26000 of 60842 (43%) assets queued
27000 of 60842 (44%) assets queued
28000 of 60842 (46%) assets queued
29000 of 60842 (48%) assets queued
30000 of 60842 (49%) assets queued
31000 of 60842 (51%) assets queued
32000 of 60842 (53%) assets queued
33000 of 60842 (54%) assets queued
34000 of 60842 (56%) assets queued
35000 of 60842 (58%) assets queued
36000 of 60842 (59%) assets queued
37000 of 60842 (61%) assets queued
38000 of 60842 (62%) assets queued
39000 of 60842 (64%) assets queued
40000 of 60842 (66%) assets queued
41000 of 60842 (67%) assets queued
42000 of 60842 (69%) assets queued
43000 of 60842 (71%) assets queued
44000 of 60842 (72%) assets queued
45000 of 60842 (74%) assets queued
46000 of 60842 (76%) assets queued
47000 of 60842 (77%) assets queued
48000 of 60842 (79%) assets queued
49000 of 60842 (81%) assets queued
50000 of 60842 (82%) assets queued
51000 of 60842 (84%) assets queued
52000 of 60842 (85%) assets queued
53000 of 60842 (87%) assets queued
54000 of 60842 (89%) assets queued
55000 of 60842 (90%) assets queued
56000 of 60842 (92%) assets queued
57000 of 60842 (94%) assets queued
58000 of 60842 (95%) assets queued
59000 of 60842 (97%) assets queued
60000 of 60842 (99%) assets queued

Finished!
```

The task took less than 2 mins to run and Sidekiq took just under 10 mins to process all the jobs from the `low_priority` queue (see below). I'm fairly happy that this has resolved the Mongoid cursor-related problem.

![2017-10-05-asset-manager-sidekiq-low-priority-queue](https://user-images.githubusercontent.com/3169/31233456-9b345716-a9e4-11e7-8461-78190bae51fd.png)
