### PR TITLE
Fix asset attributes generated from file metadata

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -17,8 +17,13 @@ class Asset
   field :organisation_slug, type: String
 
   field :etag, type: String
+  protected :etag=
+
   field :last_modified, type: Time
+  protected :last_modified=
+
   field :md5_hexdigest, type: String
+  protected :md5_hexdigest=
 
   validates :file, presence: true
   validates :organisation_slug, presence: true, if: :access_limited?

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -119,9 +119,9 @@ class Asset
 protected
 
   def store_metadata
-    self[:etag] = etag_from_file
-    self[:last_modified] = last_modified_from_file
-    self[:md5_hexdigest] = md5_hexdigest_from_file
+    self.etag = etag_from_file
+    self.last_modified = last_modified_from_file
+    self.md5_hexdigest = md5_hexdigest_from_file
   end
 
   def valid_filenames

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -32,7 +32,7 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  after_create :store_metadata
+  before_create :store_metadata
   after_save :schedule_virus_scan
 
   state_machine :state, initial: :unscanned do

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -32,7 +32,7 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  before_create :store_metadata
+  before_save :store_metadata
   after_save :schedule_virus_scan
 
   state_machine :state, initial: :unscanned do

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -119,9 +119,9 @@ class Asset
 protected
 
   def store_metadata
-    self[:etag] ||= etag_from_file
-    self[:last_modified] ||= last_modified_from_file
-    self[:md5_hexdigest] ||= md5_hexdigest_from_file
+    self[:etag] = etag_from_file
+    self[:last_modified] = last_modified_from_file
+    self[:md5_hexdigest] = md5_hexdigest_from_file
   end
 
   def valid_filenames

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -2,8 +2,8 @@ class WhitehallAsset < Asset
   field :legacy_url_path, type: String
   attr_readonly :legacy_url_path
 
-  alias_method :legacy_etag=, :etag=
-  alias_method :legacy_last_modified=, :last_modified=
+  field :legacy_etag, type: String
+  field :legacy_last_modified, type: Time
 
   validates :legacy_url_path,
     presence: true,
@@ -12,6 +12,14 @@ class WhitehallAsset < Asset
       with: %r{\A/government/uploads},
       message: 'must start with /government/uploads'
     }
+
+  def etag
+    legacy_etag || super
+  end
+
+  def last_modified
+    legacy_last_modified || super
+  end
 
   def public_url_path
     legacy_url_path

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).legacy_url_path).to eq(attributes[:legacy_url_path])
       end
 
-      it "stores legacy_etag as etag on asset" do
+      it "stores legacy_etag on asset" do
         post :create, asset: attributes
 
-        expect(assigns(:asset).etag).to eq(attributes[:legacy_etag])
+        expect(assigns(:asset).legacy_etag).to eq(attributes[:legacy_etag])
       end
 
-      it "stores legacy_last_modified as last_modified on asset" do
+      it "stores legacy_last_modified on asset" do
         post :create, asset: attributes
 
-        expect(assigns(:asset).last_modified).to eq(attributes[:legacy_last_modified])
+        expect(assigns(:asset).legacy_last_modified).to eq(attributes[:legacy_last_modified])
       end
 
       it "returns a created status" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -330,15 +330,15 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:etag_from_file).and_return('etag-from-file')
     end
 
-    context "when etag attribute is explicitly set" do
-      let(:etag) { 'etag-attribute-value' }
+    context "when etag attribute is set" do
+      let(:etag) { 'etag-value' }
 
-      it "returns attribute value" do
-        expect(asset.etag).to eq('etag-attribute-value')
+      it "returns etag attribute value" do
+        expect(asset.etag).to eq('etag-value')
       end
     end
 
-    context "when etag attribute is not explicitly set" do
+    context "when etag attribute is not set" do
       let(:etag) { nil }
 
       it "returns value generated from file metadata" do
@@ -346,19 +346,7 @@ RSpec.describe Asset, type: :model do
       end
     end
 
-    context "when asset is created with an explicit etag" do
-      let(:etag) { 'etag-attribute-value' }
-
-      before do
-        asset.save!
-      end
-
-      it "stores the etag attribute value in the database" do
-        expect(asset.reload.etag).to eq('etag-attribute-value')
-      end
-    end
-
-    context "when asset is created without an explicit etag" do
+    context "when asset is created" do
       let(:etag) { nil }
 
       before do
@@ -396,15 +384,15 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:last_modified_from_file).and_return(time_from_file)
     end
 
-    context "when last_modified attribute is explicitly set" do
+    context "when last_modified attribute is set" do
       let(:last_modified) { time }
 
-      it "returns attribute value" do
+      it "returns last_modified attribute value" do
         expect(asset.last_modified).to eq(time)
       end
     end
 
-    context "when last_modified attribute is not explicitly set" do
+    context "when last_modified attribute is not set" do
       let(:last_modified) { nil }
 
       it "returns value generated from file metadata" do
@@ -412,19 +400,7 @@ RSpec.describe Asset, type: :model do
       end
     end
 
-    context "when asset is created with an explicit last_modified" do
-      let(:last_modified) { time }
-
-      before do
-        asset.save!
-      end
-
-      it "stores the last_modified attribute value in the database" do
-        expect(asset.reload.last_modified).to eq(time)
-      end
-    end
-
-    context "when asset is created without an explicit last_modified" do
+    context "when asset is created" do
       let(:last_modified) { nil }
 
       before do
@@ -453,15 +429,15 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:md5_hexdigest_from_file).and_return('md5-from-file')
     end
 
-    context "when md5_hexdigest attribute is explicitly set" do
-      let(:md5_hexdigest) { 'md5-attribute-value' }
+    context "when md5_hexdigest attribute is set" do
+      let(:md5_hexdigest) { 'md5-value' }
 
-      it "returns attribute value" do
-        expect(asset.md5_hexdigest).to eq('md5-attribute-value')
+      it "returns md5_hexdigest attribute value" do
+        expect(asset.md5_hexdigest).to eq('md5-value')
       end
     end
 
-    context "when md5_hexdigest attribute is not explicitly set" do
+    context "when md5_hexdigest attribute is not set" do
       let(:md5_hexdigest) { nil }
 
       it "returns value generated from file metadata" do
@@ -469,19 +445,7 @@ RSpec.describe Asset, type: :model do
       end
     end
 
-    context "when asset is created with an explicit md5_hexdigest" do
-      let(:md5_hexdigest) { 'md5-attribute-value' }
-
-      before do
-        asset.save!
-      end
-
-      it "stores the md5_hexdigest attribute value in the database" do
-        expect(asset.reload.md5_hexdigest).to eq('md5-attribute-value')
-      end
-    end
-
-    context "when asset is created without an explicit md5_hexdigest" do
+    context "when asset is created" do
       let(:md5_hexdigest) { nil }
 
       before do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -372,6 +372,14 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#etag=" do
+    let(:asset) { Asset.new }
+
+    it "cannot be called from outside the Asset class" do
+      expect { asset.etag = 'etag-value' }.to raise_error(NoMethodError)
+    end
+  end
+
   describe "#last_modified_from_file" do
     let!(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
 
@@ -440,6 +448,14 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#last_modified=" do
+    let(:asset) { Asset.new }
+
+    it "cannot be called from outside the Asset class" do
+      expect { asset.last_modified = Time.now }.to raise_error(NoMethodError)
+    end
+  end
+
   describe "#md5_hexdigest_from_file" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
     let(:md5_hexdigest) { 'a0d8aa55f6db670e38a14962c0652776' }
@@ -495,6 +511,14 @@ RSpec.describe Asset, type: :model do
           expect(asset.reload.md5_hexdigest).to eq('md5-from-new-file')
         end
       end
+    end
+  end
+
+  describe "#md5_hexdigest=" do
+    let(:asset) { Asset.new }
+
+    it "cannot be called from outside the Asset class" do
+      expect { asset.md5_hexdigest = 'md5-value' }.to raise_error(NoMethodError)
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -356,6 +356,19 @@ RSpec.describe Asset, type: :model do
       it "stores the value generated from the file in the database" do
         expect(asset.reload.etag).to eq('etag-from-file')
       end
+
+      context "when asset is updated with new file" do
+        let(:new_file) { load_fixture_file("asset2.jpg") }
+
+        before do
+          allow(asset).to receive(:etag_from_file).and_return('etag-from-new-file')
+          asset.update_attributes!(file: new_file)
+        end
+
+        it "stores the value generated from the new file in the database" do
+          expect(asset.reload.etag).to eq('etag-from-new-file')
+        end
+      end
     end
   end
 
@@ -410,6 +423,20 @@ RSpec.describe Asset, type: :model do
       it "stores the value generated from the file in the database" do
         expect(asset.reload.last_modified).to eq(time_from_file)
       end
+
+      context "when asset is updated with new file" do
+        let(:new_file) { load_fixture_file("asset2.jpg") }
+        let(:time_from_new_file) { Time.parse('2003-03-03 03:03') }
+
+        before do
+          allow(asset).to receive(:last_modified_from_file).and_return(time_from_new_file)
+          asset.update_attributes!(file: new_file)
+        end
+
+        it "stores the value generated from the new file in the database" do
+          expect(asset.reload.last_modified).to eq(time_from_new_file)
+        end
+      end
     end
   end
 
@@ -454,6 +481,19 @@ RSpec.describe Asset, type: :model do
 
       it "stores the value generated from the file in the database" do
         expect(asset.reload.md5_hexdigest).to eq('md5-from-file')
+      end
+
+      context "when asset is updated with new file" do
+        let(:new_file) { load_fixture_file("asset2.jpg") }
+
+        before do
+          allow(asset).to receive(:md5_hexdigest_from_file).and_return('md5-from-new-file')
+          asset.update_attributes!(file: new_file)
+        end
+
+        it "stores the value generated from the new file in the database" do
+          expect(asset.reload.md5_hexdigest).to eq('md5-from-new-file')
+        end
       end
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -330,29 +330,43 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:etag_from_file).and_return('etag-from-file')
     end
 
-    context "when etag is stored in database" do
-      let(:etag) { 'etag-from-db' }
+    context "when etag attribute is explicitly set" do
+      let(:etag) { 'etag-attribute-value' }
 
-      it "returns value from database" do
-        expect(asset.etag).to eq('etag-from-db')
+      it "returns attribute value" do
+        expect(asset.etag).to eq('etag-attribute-value')
       end
     end
 
-    context "when etag is not stored in database" do
+    context "when etag attribute is not explicitly set" do
       let(:etag) { nil }
 
       it "returns value generated from file metadata" do
         expect(asset.etag).to eq('etag-from-file')
       end
+    end
 
-      context "and asset is saved" do
-        before do
-          asset.save!
-        end
+    context "when asset is created with an explicit etag" do
+      let(:etag) { 'etag-attribute-value' }
 
-        it "stores the value generated from the file in the database" do
-          expect(asset[:etag]).to eq('etag-from-file')
-        end
+      before do
+        asset.save!
+      end
+
+      it "stores the etag attribute value in the database" do
+        expect(asset.reload.etag).to eq('etag-attribute-value')
+      end
+    end
+
+    context "when asset is created without an explicit etag" do
+      let(:etag) { nil }
+
+      before do
+        asset.save!
+      end
+
+      it "stores the value generated from the file in the database" do
+        expect(asset.reload.etag).to eq('etag-from-file')
       end
     end
   end
@@ -375,36 +389,50 @@ RSpec.describe Asset, type: :model do
   describe "#last_modified" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png"), last_modified: last_modified) }
 
+    let(:time) { Time.parse('2002-02-02 02:02') }
     let(:time_from_file) { Time.parse('2001-01-01 01:01') }
-    let(:time_from_db) { Time.parse('2002-02-02 02:02') }
 
     before do
       allow(asset).to receive(:last_modified_from_file).and_return(time_from_file)
     end
 
-    context "when last_modified is stored in database" do
-      let(:last_modified) { time_from_db }
+    context "when last_modified attribute is explicitly set" do
+      let(:last_modified) { time }
 
-      it "returns value from database" do
-        expect(asset.last_modified).to eq(time_from_db)
+      it "returns attribute value" do
+        expect(asset.last_modified).to eq(time)
       end
     end
 
-    context "when last_modified is not stored in database" do
+    context "when last_modified attribute is not explicitly set" do
       let(:last_modified) { nil }
 
       it "returns value generated from file metadata" do
         expect(asset.last_modified).to eq(time_from_file)
       end
+    end
 
-      context "and asset is saved" do
-        before do
-          asset.save!
-        end
+    context "when asset is created with an explicit last_modified" do
+      let(:last_modified) { time }
 
-        it "stores the value generated from the file in the database" do
-          expect(asset[:last_modified]).to eq(time_from_file)
-        end
+      before do
+        asset.save!
+      end
+
+      it "stores the last_modified attribute value in the database" do
+        expect(asset.reload.last_modified).to eq(time)
+      end
+    end
+
+    context "when asset is created without an explicit last_modified" do
+      let(:last_modified) { nil }
+
+      before do
+        asset.save!
+      end
+
+      it "stores the value generated from the file in the database" do
+        expect(asset.reload.last_modified).to eq(time_from_file)
       end
     end
   end
@@ -425,29 +453,43 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:md5_hexdigest_from_file).and_return('md5-from-file')
     end
 
-    context "when md5_hexdigest is stored in database" do
-      let(:md5_hexdigest) { 'md5-from-db' }
+    context "when md5_hexdigest attribute is explicitly set" do
+      let(:md5_hexdigest) { 'md5-attribute-value' }
 
-      it "returns value from database" do
-        expect(asset.md5_hexdigest).to eq('md5-from-db')
+      it "returns attribute value" do
+        expect(asset.md5_hexdigest).to eq('md5-attribute-value')
       end
     end
 
-    context "when md5_hexdigest is not stored in database" do
+    context "when md5_hexdigest attribute is not explicitly set" do
       let(:md5_hexdigest) { nil }
 
       it "returns value generated from file metadata" do
         expect(asset.md5_hexdigest).to eq('md5-from-file')
       end
+    end
 
-      context "and asset is saved" do
-        before do
-          asset.save!
-        end
+    context "when asset is created with an explicit md5_hexdigest" do
+      let(:md5_hexdigest) { 'md5-attribute-value' }
 
-        it "stores the value generated from the file in the database" do
-          expect(asset[:md5_hexdigest]).to eq('md5-from-file')
-        end
+      before do
+        asset.save!
+      end
+
+      it "stores the md5_hexdigest attribute value in the database" do
+        expect(asset.reload.md5_hexdigest).to eq('md5-attribute-value')
+      end
+    end
+
+    context "when asset is created without an explicit md5_hexdigest" do
+      let(:md5_hexdigest) { nil }
+
+      before do
+        asset.save!
+      end
+
+      it "stores the value generated from the file in the database" do
+        expect(asset.reload.md5_hexdigest).to eq('md5-from-file')
       end
     end
   end

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -79,23 +79,45 @@ RSpec.describe WhitehallAsset, type: :model do
     end
   end
 
-  describe '#legacy_etag=' do
-    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+  describe '#etag' do
+    let(:etag) { 'etag-value' }
+    let(:asset) { WhitehallAsset.new(etag: etag, legacy_etag: legacy_etag) }
 
-    it 'is aliased to Asset#etag=' do
-      asset.legacy_etag = 'legacy-etag'
-      expect(asset.etag).to eq('legacy-etag')
+    context "when legacy_etag attribute is set" do
+      let(:legacy_etag) { 'legacy-etag-value' }
+
+      it "returns legacy_etag attribute value" do
+        expect(asset.etag).to eq(legacy_etag)
+      end
+    end
+
+    context "when legacy_etag attribute is not set" do
+      let(:legacy_etag) { nil }
+
+      it "returns Asset#etag attribute value" do
+        expect(asset.etag).to eq(etag)
+      end
     end
   end
 
-  describe '#legacy_last_modified=' do
-    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+  describe '#last_modified' do
+    let(:asset) { WhitehallAsset.new(last_modified: last_modified, legacy_last_modified: legacy_last_modified) }
+    let(:last_modified) { Time.parse('2001-01-01 01:01') }
 
-    let(:example_time) { Time.parse('2001-01-01 01:01') }
+    context "when legacy_last_modified attribute is set" do
+      let(:legacy_last_modified) { Time.parse('2002-02-02 02:02') }
 
-    it 'is aliased to Asset#last_modified=' do
-      asset.legacy_last_modified = example_time
-      expect(asset.last_modified).to eq(example_time)
+      it "returns legacy_last_modified attribute value" do
+        expect(asset.last_modified).to eq(legacy_last_modified)
+      end
+    end
+
+    context "when legacy_last_modified attribute is not set" do
+      let(:legacy_last_modified) { nil }
+
+      it "returns Asset#last_modified attribute value" do
+        expect(asset.last_modified).to eq(last_modified)
+      end
     end
   end
 

--- a/spec/workers/asset_file_metadata_worker_spec.rb
+++ b/spec/workers/asset_file_metadata_worker_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe AssetFileMetadataWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryGirl.create(:asset) }
+
+  it 'sets Asset#etag to Asset#etag_from_file in database' do
+    asset.set(etag: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.etag).to eq(asset.etag_from_file)
+  end
+
+  it 'sets Asset#last_modified to Asset#last_modified_from_file in database' do
+    asset.set(last_modified: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.last_modified.to_i).to eq(asset.last_modified_from_file.to_i)
+  end
+
+  it 'sets Asset#md5_hexdigest to Asset#md5_hexdigest_from_file in database' do
+    asset.set(md5_hexdigest: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.md5_hexdigest).to eq(asset.md5_hexdigest_from_file)
+  end
+end


### PR DESCRIPTION
This was prompted by the concern I mentioned in [this comment][1]:

> If the attributes on an `Asset` which are derived from the file metadata are set in the database and then the `Asset` is updated with a new file, the attributes will not be updated as you might expect.

In doing this work, I also realised that although the attribute values derived from file metadata were being set, they were not being persisted! This was because I had used an `after_create` callback vs `before_create` and it is fixed in the first commit (with title "Save asset attribute values generated from file metadata").

In some ways, the fact that no values were being persisted makes things simpler for us in deciding whether to merge this PR, because we know that no assets will have `etag`, `last_modified` or `md5_hexdigest` values set in integration, staging or production.

In the second commit (with title "Store WhitehallAsset#legacy_etag & #legacy_last_modified in database"), I've promoted `WhitehallAsset#legacy_etag` and `WhitehallAsset#legacy_last_modified` to be proper fields on `WhitehallAsset`. This simplifies the logic in `Asset` and separates the concerns of (a) caching the file metadata-derived values in the database; and (b) overriding the attribute values when migrating existing Whitehall assets to Asset Manager.

The third commit (with title "Regenerate attributes from file metadata on asset update") I fixed the problem which triggered this work (see above).

And in the final commit (with title "Add spec for AssetFileMetadataWorker used by Rake task"), I've added some test coverage for the worker used by the Rake task to populate the attributes for existing Asset Manager assets.

[1]: https://github.com/alphagov/asset-manager/issues/182#issuecomment-334786966