### PR TITLE
Remove ability to redirect asset requests to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,10 @@ As long as the S3 bucket is configured, all assets are uploaded to the S3 bucket
 At most *one* of these should be used in any given environment. If none of them are set then the default behaviour is for the Rails app to instruct Nginx to serve the assets from the NFS mount.
 
 * `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100
-* `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` - causes *all* asset requests to be redirected to S3
 
 #### Request parameters
 
 * Asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
-* Asset requests can be redirected to S3 even if `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` is not set by adding `redirect_to_s3=true` as a request parameter key-value pair to the query string.
 
 ### Testing
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -17,9 +17,7 @@ class MediaController < ApplicationController
       format.any do
         set_expiry(AssetManager.cache_control.max_age)
         headers['X-Frame-Options'] = AssetManager.frame_options
-        if redirect_to_s3?
-          redirect_to Services.cloud_storage.public_url_for(asset)
-        elsif proxy_to_s3_via_nginx?
+        if proxy_to_s3_via_nginx?
           url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
           headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
           headers['ETag'] = %{"#{asset.etag}"}
@@ -35,10 +33,6 @@ class MediaController < ApplicationController
   end
 
 protected
-
-  def redirect_to_s3?
-    AssetManager.redirect_all_asset_requests_to_s3 || params[:redirect_to_s3].present?
-  end
 
   def proxy_to_s3_via_nginx?
     random_number_generator = Random.new

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,6 @@ module AssetManager
   mattr_accessor :aws_s3_use_virtual_host
 
   mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
-  mattr_accessor :redirect_all_asset_requests_to_s3
 
   mattr_accessor :cache_control
   mattr_accessor :whitehall_cache_control

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,2 +1,1 @@
 AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
-AssetManager.redirect_all_asset_requests_to_s3 = ENV['REDIRECT_ALL_ASSET_REQUESTS_TO_S3'].present?

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -12,10 +12,6 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
-    def public_url_for(_asset)
-      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
-    end
-
     def presigned_url_for(_asset, _http_method: 'GET')
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
@@ -38,10 +34,6 @@ class S3Storage
 
   def load(asset)
     object_for(asset).get.body
-  end
-
-  def public_url_for(asset)
-    object_for(asset).public_url(virtual_host: AssetManager.aws_s3_use_virtual_host)
   end
 
   def presigned_url_for(asset, http_method: 'GET')

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -1,47 +1,6 @@
 require "rails_helper"
 
 RSpec.describe MediaController, type: :controller do
-  describe "#redirect_to_s3?" do
-    before do
-      allow(AssetManager).to receive(:redirect_all_asset_requests_to_s3)
-        .and_return(redirect_all_asset_requests_to_s3)
-      allow(controller).to receive(:params)
-        .and_return(redirect_to_s3: redirect_to_s3)
-    end
-
-    context "when redirect_all_asset_requests_to_s3 is not set" do
-      let(:redirect_all_asset_requests_to_s3) { false }
-
-      context "when redirect_to_s3 is not set" do
-        let(:redirect_to_s3) { false }
-
-        it "returns falsey" do
-          expect(controller.send(:redirect_to_s3?)).to be_falsey
-        end
-      end
-
-      context "when redirect_to_s3 is set" do
-        let(:redirect_to_s3) { true }
-
-        it "returns truthy" do
-          expect(controller.send(:redirect_to_s3?)).to be_truthy
-        end
-      end
-    end
-
-    context "when redirect_all_asset_requests_to_s3 is set" do
-      let(:redirect_all_asset_requests_to_s3) { true }
-
-      context "even when redirect_to_s3 is not set" do
-        let(:redirect_to_s3) { false }
-
-        it "returns truthy" do
-          expect(controller.send(:redirect_to_s3?)).to be_truthy
-        end
-      end
-    end
-  end
-
   describe "#proxy_to_s3_via_nginx?" do
     let(:proxy_to_s3_via_nginx) { false }
     let(:random_number_generator) { instance_double(Random) }
@@ -217,26 +176,6 @@ RSpec.describe MediaController, type: :controller do
             head :download, id: asset, filename: asset.filename
             expect(response).to have_http_status(:ok)
           end
-        end
-      end
-
-      context "when redirect_to_s3? is truthy" do
-        let(:cloud_storage) { double(:cloud_storage) }
-
-        before do
-          allow(controller).to receive(:redirect_to_s3?).and_return(true)
-          allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
-          allow(cloud_storage).to receive(:public_url_for).with(asset).and_return('public-url')
-        end
-
-        it "responds with 302 Found (temporary redirect)" do
-          do_get
-          expect(response).to have_http_status(:found)
-        end
-
-        it "redirects to the public URL of the asset" do
-          do_get
-          expect(response).to redirect_to('public-url')
         end
       end
 

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -107,42 +107,6 @@ RSpec.describe S3Storage do
     end
   end
 
-  describe '#public_url_for' do
-    let(:use_virtual_host) { nil }
-
-    before do
-      allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)
-    end
-
-    context 'when configured not to use virtual host' do
-      let(:use_virtual_host) { false }
-
-      it 'returns public URL for asset on S3' do
-        allow(s3_object).to receive(:public_url).with(virtual_host: false).and_return('public-url')
-        expect(subject.public_url_for(asset)).to eq('public-url')
-      end
-    end
-
-    context 'when configured to use virtual host' do
-      let(:use_virtual_host) { true }
-
-      it 'returns public URL for asset on S3 using virtual host' do
-        allow(s3_object).to receive(:public_url).with(virtual_host: true).and_return('public-url')
-        expect(subject.public_url_for(asset)).to eq('public-url')
-      end
-    end
-
-    context 'when bucket name is blank' do
-      let(:bucket_name) { '' }
-
-      it 'raises NotConfiguredError exception' do
-        expect {
-          subject.public_url_for(asset)
-        }.to raise_error(S3Storage::NotConfiguredError)
-      end
-    end
-  end
-
   describe '#presigned_url_for' do
     before do
       allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)


### PR DESCRIPTION
We added this functionality in #112 when we were investigating the performance of various approaches. Since we're not planning to use this behaviour in the near future and I'm not confident that the behaviour is as well tested as the other two alternatives (e.g. response headers), I think it's better to remove the functionality for now - we can always find this code in the git history if we need it again.

Note that I've retained `AssetManager.aws_s3_use_virtual_host`, because although it was introduced in #112, it's now being used for `S3Storage#presigned_url_for`.

Note also that I've checked that the `REDIRECT_ALL_ASSET_REQUESTS_TO_S3` environment variable isn't beeing set anywhere in `govuk-puppet`.