### PR TITLE
Fix brittle AssetFileMetadataWorker spec

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -144,6 +144,6 @@ protected
   end
 
   def file_stat
-    @file_stat ||= File.stat(file.path)
+    File.stat(file.path)
   end
 end

--- a/spec/support/matchers/be_within_a_millisecond_of.rb
+++ b/spec/support/matchers/be_within_a_millisecond_of.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :be_within_a_millisecond_of do |expected|
+  match do |actual|
+    be_within(0.001).of(expected).matches?(actual)
+  end
+
+  failure_message do |actual|
+    "expected #{actual.to_f} to be within a millisecond of #{expected.to_f}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected #{actual.to_f} not to be within a millisecond of #{expected.to_f}"
+  end
+end

--- a/spec/workers/asset_file_metadata_worker_spec.rb
+++ b/spec/workers/asset_file_metadata_worker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AssetFileMetadataWorker, type: :worker do
 
     worker.perform(asset.id.to_s)
 
-    expect(asset.reload.last_modified.to_i).to eq(asset.last_modified_from_file.to_i)
+    expect(asset.reload.last_modified).to be_within(0.001).of(asset.last_modified_from_file)
   end
 
   it 'sets Asset#md5_hexdigest to Asset#md5_hexdigest_from_file in database' do

--- a/spec/workers/asset_file_metadata_worker_spec.rb
+++ b/spec/workers/asset_file_metadata_worker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AssetFileMetadataWorker, type: :worker do
 
     worker.perform(asset.id.to_s)
 
-    expect(asset.reload.last_modified).to be_within(0.001).of(asset.last_modified_from_file)
+    expect(asset.reload.last_modified).to be_within_a_millisecond_of(asset.last_modified_from_file)
   end
 
   it 'sets Asset#md5_hexdigest to Asset#md5_hexdigest_from_file in database' do


### PR DESCRIPTION
On Jenkins CI builds (but not local MacOS or development VM builds), the example for `Asser#last_modified` was slightly brittle for a couple of reasons:

* The memo-izing of `Asset#file_stat` seemed to cause odd results.
* The rounding to an integer occasionally went the wrong way.

I'm not 100% I understand what was going on, but I'm pretty confident that this fixes the problem!