### PR TITLE
Independent control of proxying Whitehall vs Mainstream assets to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,15 @@ As long as the S3 bucket is configured, all assets are uploaded to the S3 bucket
 
 ##### Feature flags
 
-At most *one* of these should be used in any given environment. If none of them are set then the default behaviour is for the Rails app to instruct Nginx to serve the assets from the NFS mount.
+* `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* Mainstream asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100. The remaining Mainstream asset requests will be served from NFS via Nginx. The default is to serve all Mainstream asset requests from NFS via Nginx.
 
-* `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100
+* `PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* Whitehall asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100. The remaining Whitehall asset requests will be served from NFS via Nginx. The default is to serve all Whitehall asset requests from NFS via Nginx.
 
 #### Request parameters
 
-* Asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
+* Mainstream asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
+
+* Whitehall asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
 
 ### Testing
 

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -3,9 +3,13 @@ class BaseMediaController < ApplicationController
 
 protected
 
+  def proxy_percentage_of_asset_requests_to_s3_via_nginx
+    raise NotImplementedError
+  end
+
   def proxy_to_s3_via_nginx?
     random_number_generator = Random.new
-    percentage = AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx
+    percentage = proxy_percentage_of_asset_requests_to_s3_via_nginx
     proxy_to_s3_via_nginx = random_number_generator.rand(100) < percentage
     proxy_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -27,6 +27,10 @@ class MediaController < BaseMediaController
 
 protected
 
+  def proxy_percentage_of_asset_requests_to_s3_via_nginx
+    AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx
+  end
+
   def filename_current?
     asset.filename == params[:filename]
   end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -26,4 +26,10 @@ class WhitehallMediaController < BaseMediaController
       serve_from_nfs_via_nginx(asset)
     end
   end
+
+protected
+
+  def proxy_percentage_of_asset_requests_to_s3_via_nginx
+    AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module AssetManager
   mattr_accessor :aws_s3_use_virtual_host
 
   mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
+  mattr_accessor :proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx
 
   mattr_accessor :cache_control
   mattr_accessor :whitehall_cache_control

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,1 +1,4 @@
-AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
+AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx =
+  ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
+AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx =
+  ENV['PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -29,13 +29,21 @@ RSpec.describe BaseMediaController, type: :controller do
     get :anything
   end
 
+  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
+    it 'raises NotImplementedError' do
+      expect {
+        controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
+      }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe "#proxy_to_s3_via_nginx?" do
     let(:proxy_to_s3_via_nginx) { false }
     let(:random_number_generator) { instance_double(Random) }
     let(:random_number) { 50 }
 
     before do
-      allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
+      allow(controller).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
         .and_return(proxy_percentage_of_asset_requests_to_s3_via_nginx)
       allow(controller).to receive(:params)
         .and_return(proxy_to_s3_via_nginx: proxy_to_s3_via_nginx)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -169,4 +169,19 @@ RSpec.describe MediaController, type: :controller do
       end
     end
   end
+
+  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
+    let(:mainstream_percentage) { 55 }
+
+    before do
+      allow(AssetManager)
+        .to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
+        .and_return(mainstream_percentage)
+    end
+
+    it 'returns the percentage of Mainstream requests to proxy to S3' do
+      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
+        .to eq(mainstream_percentage)
+    end
+  end
 end

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -80,4 +80,19 @@ RSpec.describe WhitehallMediaController, type: :controller do
       end
     end
   end
+
+  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
+    let(:whitehall_percentage) { 45 }
+
+    before do
+      allow(AssetManager)
+        .to receive(:proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx)
+        .and_return(whitehall_percentage)
+    end
+
+    it 'returns the percentage of Whitehall requests to proxy to S3' do
+      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
+        .to eq(whitehall_percentage)
+    end
+  end
 end


### PR DESCRIPTION
We're already proxying 100% of Mainstream asset requests to S3 in production (although 0% in other environments).

These changes give us the flexibility to gradually ramp up proxying Whitehall asset requests to S3 independent of the percentage set for Mainstream asset requests.

I did contemplate encapsulating the differences in Mainstream vs Whitehall asset configuration somewhere, but given that we're hoping this is only going to be a temporary change, it didn't seem worthwhile.

Closes #259.