### PR TITLE
Add Whitehall asset endpoint

### DIFF
--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -10,6 +10,14 @@ class WhitehallAssetsController < ApplicationController
     end
   end
 
+  def show
+    path = "/#{params[:path]}.#{params[:format]}"
+    @asset = WhitehallAsset.find_by(legacy_url_path: path)
+
+    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
+    render json: AssetPresenter.new(@asset, view_context)
+  end
+
 private
 
   def asset_params

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -7,7 +7,9 @@ class WhitehallAsset < Asset
 
   validates :legacy_url_path,
     presence: true,
-    uniqueness: true,
+    uniqueness: {
+      conditions: -> { where(deleted_at: nil) }
+    },
     format: {
       with: %r{\A/government/uploads},
       message: 'must start with /government/uploads'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
 
   resources :whitehall_assets, only: %i(create)
+  get '/whitehall_assets/*path' => 'whitehall_assets#show'
 
   get "/media/:id/:filename" => "media#download", :constraints => { filename: /.*/ }
   get "/government/uploads/*path" => "whitehall_media#download"

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe WhitehallAsset, type: :model do
           expect(asset).not_to be_valid
           expect(asset.errors[:legacy_url_path]).to include('is already taken')
         end
+
+        context 'but the existing asset has been marked as deleted' do
+          before do
+            asset.legacy_url_path = existing_asset.legacy_url_path
+            existing_asset.delete
+          end
+
+          it 'is valid because legacy_url_path is unique within the assets not marked as deleted' do
+            expect(asset).to be_valid
+          end
+        end
       end
     end
   end

--- a/spec/requests/whitehall_asset_requests_spec.rb
+++ b/spec/requests/whitehall_asset_requests_spec.rb
@@ -74,4 +74,14 @@ RSpec.describe 'Asset requests', type: :request do
       end
     end
   end
+
+  describe 'requesting an asset' do
+    it 'returns a 200 response when the asset is found' do
+      FactoryGirl.create(:whitehall_asset, legacy_url_path: '/government/uploads/asset.png')
+
+      get '/whitehall_assets/government/uploads/asset.png'
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
This endpoint allows us to find a Whitehall asset using its `legacy_url_path`. We're going to use this in Whitehall to update/delete assets stored in Asset Manager.