### PR TITLE
Simplify Asset attributes obtained from file metadata

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -91,24 +91,12 @@ class Asset
     %w(jpg jpeg png gif).include?(extension)
   end
 
-  def etag
-    self[:etag] || etag_from_file
-  end
-
   def etag_from_file
     '%x-%x' % [last_modified_from_file, file_stat.size]
   end
 
-  def last_modified
-    self[:last_modified] || last_modified_from_file
-  end
-
   def last_modified_from_file
     file_stat.mtime
-  end
-
-  def md5_hexdigest
-    self[:md5_hexdigest] || md5_hexdigest_from_file
   end
 
   def md5_hexdigest_from_file

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -96,7 +96,7 @@ class Asset
   end
 
   def etag_from_file
-    '%x-%x' % [last_modified, file_stat.size]
+    '%x-%x' % [last_modified_from_file, file_stat.size]
   end
 
   def last_modified

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe S3Storage do
   let(:bucket_name) { 'bucket-name' }
   let(:s3_client) { instance_double(Aws::S3::Client) }
   let(:s3_object) { instance_double(Aws::S3::Object) }
-  let(:asset) { FactoryGirl.build(:asset) }
+  let(:asset) { FactoryGirl.create(:asset) }
   let(:key) { asset.uuid }
   let(:s3_object_params) { { bucket_name: bucket_name, key: key } }
   let(:s3_head_object_params) { { bucket: bucket_name, key: key } }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -330,22 +330,6 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:etag_from_file).and_return('etag-from-file')
     end
 
-    context "when etag attribute is set" do
-      let(:etag) { 'etag-value' }
-
-      it "returns etag attribute value" do
-        expect(asset.etag).to eq('etag-value')
-      end
-    end
-
-    context "when etag attribute is not set" do
-      let(:etag) { nil }
-
-      it "returns value generated from file metadata" do
-        expect(asset.etag).to eq('etag-from-file')
-      end
-    end
-
     context "when asset is created" do
       let(:etag) { nil }
 
@@ -405,22 +389,6 @@ RSpec.describe Asset, type: :model do
       allow(asset).to receive(:last_modified_from_file).and_return(time_from_file)
     end
 
-    context "when last_modified attribute is set" do
-      let(:last_modified) { time }
-
-      it "returns last_modified attribute value" do
-        expect(asset.last_modified).to eq(time)
-      end
-    end
-
-    context "when last_modified attribute is not set" do
-      let(:last_modified) { nil }
-
-      it "returns value generated from file metadata" do
-        expect(asset.last_modified).to eq(time_from_file)
-      end
-    end
-
     context "when asset is created" do
       let(:last_modified) { nil }
 
@@ -470,22 +438,6 @@ RSpec.describe Asset, type: :model do
 
     before do
       allow(asset).to receive(:md5_hexdigest_from_file).and_return('md5-from-file')
-    end
-
-    context "when md5_hexdigest attribute is set" do
-      let(:md5_hexdigest) { 'md5-value' }
-
-      it "returns md5_hexdigest attribute value" do
-        expect(asset.md5_hexdigest).to eq('md5-value')
-      end
-    end
-
-    context "when md5_hexdigest attribute is not set" do
-      let(:md5_hexdigest) { nil }
-
-      it "returns value generated from file metadata" do
-        expect(asset.md5_hexdigest).to eq('md5-from-file')
-      end
     end
 
     context "when asset is created" do


### PR DESCRIPTION
Now that the `govuk_assets:store_values_generated_from_file_metadata` Rake task has been run in all environments, we can rely on the presence of the value in the database which is set in a `before_save` callback by `Asset#store_metadata`.

I did consider adding validation for the presence of these attributes, but it turned out to be very awkward and in any case, I soon realised that it's a bit odd to validate attributes which are set automatically by a `before_save` callback, especially given that the attribute writer methods are protected. So I decided that adding such validation was unnecessary.
