### PR TITLE
Fake S3 in development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /uploads
 
 /spec/examples.txt
+
+/fake-s3

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,3 +82,5 @@ RSpec/VerifiedDoubles:
     - 'spec/support/authentication.rb'
     - 'spec/support/cloud_storage.rb'
     - 'spec/workers/save_to_cloud_storage_worker_spec.rb'
+    - 'spec/lib/s3_storage_spec.rb'
+    - 'spec/routing/fake_s3_route_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,10 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+Style/ConditionalAssignment:
+  Exclude:
+    - 'config/initializers/carrier_wave.rb'
+
 # Offense count: 11
 RSpec/AnyInstance:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,6 +69,7 @@ RSpec/NestedGroups:
 RSpec/PredicateMatcher:
   Exclude:
     - 'spec/models/asset_spec.rb'
+    - 'spec/lib/s3_storage/fake_spec.rb'
 
 # Offense count: 12
 # Configuration parameters: IgnoreSymbolicNames.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-require 'cloud_storage'
+require 's3_storage'
 
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   before_filter :require_signin_permission!
 
   rescue_from Mongoid::Errors::DocumentNotFound, with: :error_404
-  rescue_from CloudStorage::NotConfiguredError, with: :error_500
+  rescue_from S3Storage::NotConfiguredError, with: :error_500
 
 private
 

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -7,16 +7,11 @@ class AssetUploader < CarrierWave::Uploader::Base
     id = model.id.to_s
     # We use chars 2-5 of the timestamp portion of the BSON id (see http://docs.mongodb.org/manual/core/object-id/)
     # to achieve a good distribution of directories
-    "#{store_base_dir}/assets/#{id[2..3]}/#{id[4..5]}/#{id}"
+    "#{AssetManager.carrier_wave_store_base_dir}/assets/#{id[2..3]}/#{id[4..5]}/#{id}"
   end
 
   def cache_dir
-    "#{store_base_dir}/tmp"
-  end
-
-  # Split out the base storage dir so that it can be overridden in tests.
-  def store_base_dir
-    "#{ENV['GOVUK_APP_ROOT'] || Rails.root}/uploads"
+    "#{AssetManager.carrier_wave_store_base_dir}/tmp"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,8 @@ module AssetManager
     config.assets.prefix = '/asset-manager'
   end
 
+  mattr_accessor :app_host
+
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :aws_s3_use_virtual_host
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,4 +52,7 @@ module AssetManager
   mattr_accessor :default_content_type
   mattr_accessor :frame_options
   mattr_accessor :whitehall_frame_options
+
+  mattr_accessor :fake_s3_root
+  mattr_accessor :fake_s3_path_prefix
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,8 @@ module AssetManager
   mattr_accessor :aws_s3_bucket_name
   mattr_accessor :aws_s3_use_virtual_host
 
+  mattr_accessor :carrier_wave_store_base_dir
+
   mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
   mattr_accessor :proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx
 

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,0 +1,7 @@
+if Rails.env.test?
+  directory = "#{Rails.root}/tmp/test_uploads"
+else
+  directory = "#{ENV['GOVUK_APP_ROOT'] || Rails.root}/uploads"
+end
+
+AssetManager.carrier_wave_store_base_dir = directory

--- a/config/initializers/fake_s3.rb
+++ b/config/initializers/fake_s3.rb
@@ -1,0 +1,2 @@
+AssetManager.fake_s3_root = Rails.root.join('fake-s3')
+AssetManager.fake_s3_path_prefix = '/fake-s3'

--- a/config/initializers/govuk.rb
+++ b/config/initializers/govuk.rb
@@ -1,0 +1,7 @@
+begin
+  app_name = ENV.fetch('GOVUK_APP_NAME')
+  app_domain = ENV.fetch('GOVUK_APP_DOMAIN')
+  AssetManager.app_host = "http://#{app_name}.#{app_domain}"
+rescue KeyError
+  AssetManager.app_host = 'http://localhost:3000'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,9 @@ Rails.application.routes.draw do
   get "/media/:id/:filename" => "media#download", :constraints => { filename: /.*/ }
   get "/government/uploads/*path" => "whitehall_media#download"
 
+  if Rails.env.development?
+    mount Rack::File.new(AssetManager.fake_s3_root), at: AssetManager.fake_s3_path_prefix, as: 'fake_s3'
+  end
+
   get "/healthcheck" => Proc.new { [200, { "Content-type" => "text/plain" }, ["OK"]] }
 end

--- a/lib/cloud_storage.rb
+++ b/lib/cloud_storage.rb
@@ -1,3 +1,0 @@
-class CloudStorage
-  NotConfiguredError = Class.new(StandardError)
-end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,3 +1,4 @@
+require 's3_storage/fake'
 require 's3_storage/null'
 
 class S3Storage

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -18,10 +18,6 @@ class S3Storage
     end
   end
 
-  def load(asset)
-    object_for(asset).get.body
-  end
-
   def presigned_url_for(asset, http_method: 'GET')
     object_for(asset).presigned_url(http_method, expires_in: 1.minute, virtual_host: AssetManager.aws_s3_use_virtual_host)
   end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -4,7 +4,11 @@ class S3Storage
   NotConfiguredError = Class.new(StandardError)
 
   def self.build(bucket_name)
-    bucket_name.present? ? new(bucket_name) : Null.new
+    if bucket_name.present?
+      new(bucket_name)
+    else
+      Null.new
+    end
   end
 
   def initialize(bucket_name)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,19 +1,7 @@
+require 's3_storage/null'
+
 class S3Storage
   NotConfiguredError = Class.new(StandardError)
-
-  NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
-
-  class Null
-    def save(_asset, _options = {}); end
-
-    def load(_asset)
-      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
-    end
-
-    def presigned_url_for(_asset, _http_method: 'GET')
-      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
-    end
-  end
 
   def self.build(bucket_name)
     bucket_name.present? ? new(bucket_name) : Null.new

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,7 +1,5 @@
-require 'cloud_storage'
-
 class S3Storage
-  NotConfiguredError = Class.new(CloudStorage::NotConfiguredError)
+  NotConfiguredError = Class.new(StandardError)
 
   NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
 

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -7,6 +7,8 @@ class S3Storage
   def self.build(bucket_name)
     if bucket_name.present?
       new(bucket_name)
+    elsif Rails.env.development?
+      Fake.new(AssetManager.fake_s3_root)
     else
       Null.new
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -1,0 +1,31 @@
+class S3Storage
+  class Fake
+    def initialize(root_directory)
+      @source_root = Pathname.new(AssetManager.carrier_wave_store_base_dir)
+      @target_root = Pathname.new(root_directory)
+    end
+
+    def save(asset, **_args)
+      source_path = source_path_for(asset)
+      relative_path = relative_path_for(asset)
+      target_path = @target_root.join(relative_path)
+      FileUtils.mkdir_p(File.dirname(target_path))
+      File.write(target_path, File.read(source_path))
+    end
+
+    def presigned_url_for(asset, **_args)
+      relative_path = relative_path_for(asset)
+      url_path_prefix = Pathname.new(AssetManager.fake_s3_path_prefix)
+      url_path = url_path_prefix.join(relative_path)
+      "#{AssetManager.app_host}#{url_path}"
+    end
+
+    def source_path_for(asset)
+      Pathname.new(asset.file.path)
+    end
+
+    def relative_path_for(asset)
+      source_path_for(asset).relative_path_from(@source_root)
+    end
+  end
+end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -4,10 +4,6 @@ class S3Storage
   class Null
     def save(_asset, _options = {}); end
 
-    def load(_asset)
-      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
-    end
-
     def presigned_url_for(_asset, _http_method: 'GET')
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -1,0 +1,15 @@
+class S3Storage
+  NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
+
+  class Null
+    def save(_asset, _options = {}); end
+
+    def load(_asset)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
+    def presigned_url_for(_asset, _http_method: 'GET')
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+  end
+end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe S3Storage::Fake do
+  subject(:storage) { described_class.new(root_path) }
+
+  let(:asset) { FactoryGirl.create(:asset) }
+  let(:source_root) { AssetManager.carrier_wave_store_base_dir }
+  let(:root_directory) { Dir.mktmpdir }
+  let(:root_path) { Pathname.new(root_directory.to_s) }
+  let(:relative_path_to_asset) { storage.relative_path_for(asset) }
+
+  after do
+    FileUtils.remove_entry(root_directory)
+  end
+
+  it 'implements all public methods defined on S3Storage' do
+    methods = S3Storage.public_instance_methods(false)
+    expect(described_class.public_instance_methods(false)).to include(*methods)
+  end
+
+  describe '#save' do
+    let(:asset_path) { root_path.join(relative_path_to_asset) }
+
+    it 'writes file to fake S3 storage directory' do
+      storage.save(asset)
+
+      expect(File.exist?(asset_path)).to be_truthy
+    end
+  end
+
+  describe '#presigned_url_for' do
+    before do
+      storage.save(asset)
+    end
+
+    it 'returns URL with path starting with fake S3 path prefix' do
+      url = storage.presigned_url_for(asset)
+      path = URI(url).path
+
+      expect(path).to start_with(AssetManager.fake_s3_path_prefix)
+    end
+
+    it 'returns URL with path ending with relative path to asset' do
+      url = storage.presigned_url_for(asset)
+      path = URI(url).path
+
+      expect(path).to end_with(relative_path_to_asset.to_s)
+    end
+
+    it 'returns URL with host set to AssetManager.app_host' do
+      url = storage.presigned_url_for(asset)
+      scheme, domain, port = URI(url).select(:scheme, :host, :port)
+      host = "#{scheme}://#{domain}:#{port}"
+
+      expect(host).to eq(AssetManager.app_host)
+    end
+  end
+end

--- a/spec/lib/s3_storage/null_spec.rb
+++ b/spec/lib/s3_storage/null_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe S3Storage::Null do
+  subject(:storage) { described_class.new }
+
+  let(:asset) { FactoryGirl.build(:asset) }
+
+  it 'implements all public methods defined on S3Storage' do
+    methods = S3Storage.public_instance_methods(false)
+    expect(described_class.public_instance_methods(false)).to include(*methods)
+  end
+
+  (described_class.public_instance_methods(false) - %i(save)).each do |method|
+    it "raises NotConfiguredError exception when #{method} is called" do
+      expect {
+        storage.send(method, asset)
+      }.to raise_error(S3Storage::NotConfiguredError)
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -89,20 +89,6 @@ RSpec.describe S3Storage do
     end
   end
 
-  describe '#load' do
-    let(:get_object_output) { instance_double(Aws::S3::Types::GetObjectOutput) }
-    let(:io) { StringIO.new('s3-object-data') }
-
-    before do
-      allow(s3_object).to receive(:get).and_return(get_object_output)
-      allow(get_object_output).to receive(:body).and_return(io)
-    end
-
-    it 'downloads file from S3 bucket' do
-      expect(subject.load(asset)).to eq(io)
-    end
-  end
-
   describe '#presigned_url_for' do
     before do
       allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 's3_storage'
 
 RSpec.describe S3Storage do
-  subject { described_class.build(bucket_name) }
+  subject { described_class.new(bucket_name) }
 
   let(:bucket_name) { 'bucket-name' }
   let(:s3_client) { instance_double(Aws::S3::Client) }
@@ -15,6 +15,22 @@ RSpec.describe S3Storage do
   before do
     allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
     allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
+  end
+
+  describe '.build' do
+    subject { described_class.build(bucket_name) }
+
+    it 'builds an instance of S3Storage' do
+      expect(subject).to be_instance_of(described_class)
+    end
+
+    context 'when bucket_name is blank' do
+      let(:bucket_name) { '' }
+
+      it 'builds an instance of S3Storage::Null' do
+        expect(subject).to be_instance_of(S3Storage::Null)
+      end
+    end
   end
 
   describe '#save' do
@@ -71,16 +87,6 @@ RSpec.describe S3Storage do
         end
       end
     end
-
-    context 'when bucket name is blank' do
-      let(:bucket_name) { '' }
-
-      it 'does not upload file to S3 bucket' do
-        expect(Aws::S3::Object).not_to receive(:new)
-
-        subject.save(asset)
-      end
-    end
   end
 
   describe '#load' do
@@ -94,16 +100,6 @@ RSpec.describe S3Storage do
 
     it 'downloads file from S3 bucket' do
       expect(subject.load(asset)).to eq(io)
-    end
-
-    context 'when bucket name is blank' do
-      let(:bucket_name) { '' }
-
-      it 'raises NotConfiguredError exception' do
-        expect {
-          subject.load(asset)
-        }.to raise_error(S3Storage::NotConfiguredError)
-      end
     end
   end
 
@@ -124,16 +120,6 @@ RSpec.describe S3Storage do
         allow(s3_object).to receive(:presigned_url).with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
         expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
       end
-
-      context 'when bucket name is blank' do
-        let(:bucket_name) { '' }
-
-        it 'raises NotConfiguredError exception' do
-          expect {
-            subject.presigned_url_for(asset)
-          }.to raise_error(S3Storage::NotConfiguredError)
-        end
-      end
     end
 
     context 'when configured to use virtual host' do
@@ -147,9 +133,19 @@ RSpec.describe S3Storage do
   end
 
   describe 'S3Storage::Null' do
+    subject { S3Storage::Null.new }
+
     it 'implements all public methods defined on S3Storage' do
       methods = described_class.public_instance_methods(false)
       expect(S3Storage::Null.public_instance_methods(false)).to include(*methods)
+    end
+
+    (described_class.public_instance_methods(false) - %i(save)).each do |method|
+      it "raises NotConfiguredError exception when #{method} is called" do
+        expect {
+          subject.send(method, asset)
+        }.to raise_error(S3Storage::NotConfiguredError)
+      end
     end
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -131,21 +131,4 @@ RSpec.describe S3Storage do
       end
     end
   end
-
-  describe 'S3Storage::Null' do
-    subject { S3Storage::Null.new }
-
-    it 'implements all public methods defined on S3Storage' do
-      methods = described_class.public_instance_methods(false)
-      expect(S3Storage::Null.public_instance_methods(false)).to include(*methods)
-    end
-
-    (described_class.public_instance_methods(false) - %i(save)).each do |method|
-      it "raises NotConfiguredError exception when #{method} is called" do
-        expect {
-          subject.send(method, asset)
-        }.to raise_error(S3Storage::NotConfiguredError)
-      end
-    end
-  end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -26,9 +26,27 @@ RSpec.describe S3Storage do
 
     context 'when bucket_name is blank' do
       let(:bucket_name) { '' }
+      let(:rails_env) { double('rails-env') }
 
-      it 'builds an instance of S3Storage::Null' do
-        expect(subject).to be_instance_of(S3Storage::Null)
+      before do
+        allow(Rails).to receive(:env).and_return(rails_env)
+        allow(rails_env).to receive(:development?).and_return(is_development)
+      end
+
+      context 'and Rails environment is development' do
+        let(:is_development) { true }
+
+        it 'builds an instance of S3Storage::Fake' do
+          expect(subject).to be_instance_of(S3Storage::Fake)
+        end
+      end
+
+      context 'and Rails environment is not development' do
+        let(:is_development) { false }
+
+        it 'builds an instance of S3Storage::Null' do
+          expect(subject).to be_instance_of(S3Storage::Null)
+        end
       end
     end
   end

--- a/spec/routing/fake_s3_route_spec.rb
+++ b/spec/routing/fake_s3_route_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for S3Storage::Fake', type: :routing do
+  let(:fake_s3_route) { Rails.application.routes.named_routes.get('fake_s3') }
+  let(:rails_env) { double('rails-env') }
+
+  before do
+    allow(Rails).to receive(:env).and_return(rails_env)
+    allow(rails_env).to receive(:development?).and_return(is_development)
+    Rails.application.reload_routes!
+  end
+
+  context 'and Rails environment is development' do
+    let(:is_development) { true }
+
+    it 'sets up fake_s3 route' do
+      expect(fake_s3_route).to be_present
+    end
+  end
+
+  context 'and Rails environment is not development' do
+    let(:is_development) { false }
+
+    it 'does not set up fake_s3 route' do
+      expect(fake_s3_route).not_to be_present
+    end
+  end
+end

--- a/spec/support/carrier_wave.rb
+++ b/spec/support/carrier_wave.rb
@@ -1,11 +1,5 @@
-AssetUploader.class_eval do
-  def store_base_dir
-    "#{Rails.root}/tmp/test_uploads"
-  end
-end
-
 def clean_upload_directory!
-  FileUtils.rm_rf(Dir["#{Rails.root}/tmp/test_uploads/[^.]*"])
+  FileUtils.rm_rf(Dir["#{AssetManager.carrier_wave_store_base_dir}/[^.]*"])
 end
 
 RSpec.configuration.after(:suite) do


### PR DESCRIPTION
This introduces a new `S3Storage::Fake` class and configures the app to use an instance of this class in development environments if S3 is not configured.

We want to remove support for serving asset requests from NFS and proxy all of them to S3. However, having to set up the necessary S3 resources in a development environment seems rather onerous. The changes in this PR mean that by default development environments will use a *fake* version of `S3Storage` which stores the files in the local filesystem and serves them via a `Rack::File` instance mounted in the Rails app.

I did consider a couple of other options:

* The [fake-s3][3] gem allows you to run a separate server process which acts like S3 but is backed by the local file system. I chose not to use it for two reasons: (a) although it's open-source and free, it requires you to obtain a commercial-looking license which I thought might be problematic for GDS; and (b) running a separate process is a lot more hassle to setup and there are more things to go wrong.

* Retaining the `send_file` behaviour that we currently use to serve assets from NFS. The problem with this would've been that the code path in development would've been really quite different to that used in all other environments. This would've meant an extra maintenance overhead and an increased likelihood you'd need to setup S3 in order to diagnose problems with serving assets.

I'm happy with the solution I've chosen, because requests are genuinely proxied to a fake S3 which just happens to be served in-process by the Rails app backed by the local file system.

Note that if the `X-Accel-Mapping` header is set in a request to the `Rack::File` endpoint, this will trigger the `Rack::Sendfile` middleware in the default Rails stack to send a response with the `X-Accel-Redirect` header instead of the body of the file. This is currently a problem, because [the Nginx config for Asset Manager sets the `X-Accel-Mapping` request header whether or not the request is going to be served from NFS or proxied to S3][1]. Since the `X-Accel-Mapping` value is not set with the fake S3 paths in mind, this results in an attempt to serve a non-existent file and a 404 Not Found.

We will need to address this issue before merging this PR into master. However, since we are planning to move towards proxying all asset requests to S3, it should be possible to remove the setting of `X-Sendfile-Type` & `X-Accel-Mapping` headers shortly. I have confirmed that doing this solves the problem on my development VM.

Alternatively, if we want to merge this sooner, we could consider trying to remove these headers from the proxying request sent to S3 or fake S3, i.e. within [the "cloud-storage-proxy" location in the Nginx configuration][2]. However, I think we might've had problems trying to remove headers in this way in the past, so I'm reluctant to attempt it for now.

Closes #155.

[1]: https://github.com/alphagov/govuk-puppet/blob/1b99dbc24b0ac477fadb75ef8d1356dbfd58bf2e/modules/govuk/manifests/apps/asset_manager.pp#L91-L92
[2]: https://github.com/alphagov/govuk-puppet/blob/1b99dbc24b0ac477fadb75ef8d1356dbfd58bf2e/modules/govuk/manifests/apps/asset_manager.pp#L116-L173
[3]: https://github.com/jubos/fake-s3