### PR TITLE
Update vs overwrite S3 object metadata

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -27,7 +27,11 @@ class S3Storage
   end
 
   def presigned_url_for(asset, http_method: 'GET')
-    object_for(asset).presigned_url(http_method, expires_in: 1.minute, virtual_host: AssetManager.aws_s3_use_virtual_host)
+    options = {
+      expires_in: 1.minute,
+      virtual_host: AssetManager.aws_s3_use_virtual_host
+    }
+    object_for(asset).presigned_url(http_method, options)
   end
 
 private

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -18,10 +18,10 @@ class S3Storage
     @bucket_name = bucket_name
   end
 
-  def save(asset, options = {})
+  def save(asset)
     metadata = metadata_for(asset)
     unless metadata['md5-hexdigest'] == asset.md5_hexdigest
-      s3_options = { metadata: { 'md5-hexdigest' => asset.md5_hexdigest } }.merge(options)
+      s3_options = { metadata: { 'md5-hexdigest' => asset.md5_hexdigest } }
       object_for(asset).upload_file(asset.file.path, s3_options)
     end
   end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -19,7 +19,8 @@ class S3Storage
   end
 
   def save(asset, options = {})
-    unless md5_from_metadata_for(asset) == asset.md5_hexdigest
+    metadata = metadata_for(asset)
+    unless metadata['md5-hexdigest'] == asset.md5_hexdigest
       s3_options = { metadata: { 'md5-hexdigest' => asset.md5_hexdigest } }.merge(options)
       object_for(asset).upload_file(asset.file.path, s3_options)
     end
@@ -39,11 +40,11 @@ private
     client.head_object(bucket: @bucket_name, key: asset.uuid)
   end
 
-  def md5_from_metadata_for(asset)
+  def metadata_for(asset)
     result = head_object_for(asset)
-    result.metadata['md5-hexdigest']
+    result.metadata
   rescue Aws::S3::Errors::NotFound
-    nil
+    {}
   end
 
   def client

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -21,8 +21,8 @@ class S3Storage
   def save(asset)
     metadata = metadata_for(asset)
     unless metadata['md5-hexdigest'] == asset.md5_hexdigest
-      s3_options = { metadata: { 'md5-hexdigest' => asset.md5_hexdigest } }
-      object_for(asset).upload_file(asset.file.path, s3_options)
+      metadata['md5-hexdigest'] = asset.md5_hexdigest
+      object_for(asset).upload_file(asset.file.path, metadata: metadata)
     end
   end
 

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -71,12 +71,6 @@ RSpec.describe S3Storage do
       subject.save(asset)
     end
 
-    it 'passes options to Aws::S3::Object#upload_file' do
-      expect(s3_object).to receive(:upload_file).with(anything, include(cache_control: 'cache-control-header'))
-
-      subject.save(asset, cache_control: 'cache-control-header')
-    end
-
     context 'when S3 object already exists' do
       let(:attributes) { { metadata: { 'md5-hexdigest' => md5_hexdigest } } }
       let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe S3Storage do
 
   before do
     allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
-    allow(Aws::S3::Object).to receive(:new).with(s3_object_params).and_return(s3_object)
+    allow(Aws::S3::Object).to receive(:new)
+      .with(s3_object_params).and_return(s3_object)
   end
 
   describe '.build' do
@@ -55,7 +56,8 @@ RSpec.describe S3Storage do
     let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }
 
     before do
-      allow(s3_client).to receive(:head_object).with(s3_head_object_params).and_raise(not_found_error)
+      allow(s3_client).to receive(:head_object)
+        .with(s3_head_object_params).and_raise(not_found_error)
     end
 
     it 'uploads file to S3 bucket' do
@@ -65,8 +67,9 @@ RSpec.describe S3Storage do
     end
 
     it 'sets md5-hexdigest custom metadata on S3 object' do
-      expected_metadata = include(metadata: include('md5-hexdigest' => asset.md5_hexdigest))
-      expect(s3_object).to receive(:upload_file).with(anything, expected_metadata)
+      expected_metadata = { 'md5-hexdigest' => asset.md5_hexdigest }
+      expect(s3_object).to receive(:upload_file)
+        .with(anything, include(metadata: include(expected_metadata)))
 
       subject.save(asset)
     end
@@ -78,7 +81,8 @@ RSpec.describe S3Storage do
       let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
 
       before do
-        allow(s3_client).to receive(:head_object).with(s3_head_object_params).and_return(s3_result)
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_return(s3_result)
       end
 
       context 'and MD5 hex digest does match' do
@@ -124,12 +128,14 @@ RSpec.describe S3Storage do
       let(:use_virtual_host) { false }
 
       it 'returns presigned URL for GET request to asset on S3 by default' do
-        allow(s3_object).to receive(:presigned_url).with('GET', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+        allow(s3_object).to receive(:presigned_url)
+          .with('GET', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
 
       it 'returns presigned URL for HEAD request to asset on S3 when http_method specified' do
-        allow(s3_object).to receive(:presigned_url).with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+        allow(s3_object).to receive(:presigned_url)
+          .with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
         expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
       end
     end
@@ -138,7 +144,8 @@ RSpec.describe S3Storage do
       let(:use_virtual_host) { true }
 
       it 'returns presigned URL for asset on S3 using virtual host' do
-        allow(s3_object).to receive(:presigned_url).with('GET', expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
+        allow(s3_object).to receive(:presigned_url)
+          .with('GET', expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
     end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe S3Storage do
     end
 
     context 'when S3 object already exists' do
-      let(:attributes) { { metadata: { 'md5-hexdigest' => md5_hexdigest } } }
+      let(:default_metadata) { { 'md5-hexdigest' => md5_hexdigest } }
+      let(:metadata) { default_metadata }
+      let(:attributes) { { metadata: metadata } }
       let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
 
       before do
@@ -96,6 +98,18 @@ RSpec.describe S3Storage do
           expect(s3_object).to receive(:upload_file)
 
           subject.save(asset)
+        end
+
+        context 'and object has existing metadata' do
+          let(:existing_metadata) { { 'existing-key' => 'existing-value' } }
+          let(:metadata) { default_metadata.merge(existing_metadata) }
+
+          it 'uploads file to S3 with existing metadata' do
+            expect(s3_object).to receive(:upload_file)
+              .with(anything, include(metadata: include(existing_metadata)))
+
+            subject.save(asset)
+          end
         end
       end
     end


### PR DESCRIPTION
Previously calling `S3Object#save` for an existing asset with existing metadata would overwrite the metadata with just the default "md5-hexdigest" key and value - thus any existing metadata would be lost. Now existing metadata is preserved, unless explicitly overwritten.

I've also removed the `options` argument for `S3Storage#save` - we no longer use it and it would've complicated the implementation considerably.

I've also taken the opportunity to reduce the length of a bunch of lines in `S3Storage` and its spec to make the code more readable.
