### PR TITLE
Trigger replication for all non-replicated assets on S3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,6 +69,7 @@ RSpec/NestedGroups:
 RSpec/PredicateMatcher:
   Exclude:
     - 'spec/models/asset_spec.rb'
+    - 'spec/lib/s3_storage_spec.rb'
     - 'spec/lib/s3_storage/fake_spec.rb'
 
 # Offense count: 12

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,3 +85,7 @@ RSpec/VerifiedDoubles:
     - 'spec/workers/save_to_cloud_storage_worker_spec.rb'
     - 'spec/lib/s3_storage_spec.rb'
     - 'spec/routing/fake_s3_route_spec.rb'
+
+RSpec/SubjectStub:
+  Exclude:
+      - 'spec/lib/s3_storage_spec.rb'

--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -10,7 +10,7 @@ class AssetTriggerReplicationWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    if @cloud_storage.exists?(asset)
+    if @cloud_storage.exists?(asset) && @cloud_storage.never_replicated?(asset)
       @cloud_storage.add_metadata_to(asset, key: KEY, value: Time.now.httpdate)
       @cloud_storage.remove_metadata_from(asset, key: KEY)
     end

--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -1,0 +1,18 @@
+class AssetTriggerReplicationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  KEY = 'replication-triggered-at'.freeze
+
+  def initialize(cloud_storage: Services.cloud_storage)
+    @cloud_storage = cloud_storage
+  end
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    if @cloud_storage.exists?(asset)
+      @cloud_storage.add_metadata_to(asset, key: KEY, value: Time.now.httpdate)
+      @cloud_storage.remove_metadata_from(asset, key: KEY)
+    end
+  end
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,18 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def add_metadata_to(asset, key:, value:)
+    existing_metadata = metadata_for(asset)
+    new_metadata = existing_metadata.merge(key => value)
+    set_metadata_for(asset, new_metadata)
+  end
+
+  def remove_metadata_from(asset, key:)
+    existing_metadata = metadata_for(asset)
+    new_metadata = existing_metadata.reject { |k, _| k == key }
+    set_metadata_for(asset, new_metadata)
+  end
+
   def set_metadata_for(asset, new_metadata)
     if exists?(asset)
       object_for(asset).put(metadata: new_metadata)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -34,6 +34,10 @@ class S3Storage
     object_for(asset).presigned_url(http_method, options)
   end
 
+  def exists?(asset)
+    object_for(asset).exists?
+  end
+
 private
 
   def object_for(asset)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,13 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def metadata_for(asset)
+    result = head_object_for(asset)
+    result.metadata
+  rescue Aws::S3::Errors::NotFound
+    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+  end
+
 private
 
   def object_for(asset)
@@ -47,13 +54,6 @@ private
 
   def head_object_for(asset)
     client.head_object(bucket: @bucket_name, key: asset.uuid)
-  end
-
-  def metadata_for(asset)
-    result = head_object_for(asset)
-    result.metadata
-  rescue Aws::S3::Errors::NotFound
-    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
   end
 
   def client

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,12 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def never_replicated?(asset)
+    head_object_for(asset).replication_status.nil?
+  rescue Aws::S3::Errors::NotFound
+    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+  end
+
   def add_metadata_to(asset, key:, value:)
     existing_metadata = metadata_for(asset)
     new_metadata = existing_metadata.merge(key => value)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,14 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def set_metadata_for(asset, new_metadata)
+    if exists?(asset)
+      object_for(asset).put(metadata: new_metadata)
+    else
+      raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+    end
+  end
+
   def metadata_for(asset)
     result = head_object_for(asset)
     result.metadata

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,10 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def metadata_for(_asset)
+      raise NotImplementedError
+    end
+
     def source_path_for(asset)
       Pathname.new(asset.file.path)
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,10 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def set_metadata_for(_asset, _new_metadata)
+      raise NotImplementedError
+    end
+
     def metadata_for(_asset)
       raise NotImplementedError
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -20,6 +20,12 @@ class S3Storage
       "#{AssetManager.app_host}#{url_path}"
     end
 
+    def exists?(asset)
+      relative_path = relative_path_for(asset)
+      target_path = @target_root.join(relative_path)
+      File.exist?(target_path)
+    end
+
     def source_path_for(asset)
       Pathname.new(asset.file.path)
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,10 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def never_replicated?(_asset)
+      raise NotImplementedError
+    end
+
     def add_metadata_to(*)
       raise NotImplementedError
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,14 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def add_metadata_to(*)
+      raise NotImplementedError
+    end
+
+    def remove_metadata_from(*)
+      raise NotImplementedError
+    end
+
     def set_metadata_for(_asset, _new_metadata)
       raise NotImplementedError
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -7,8 +7,7 @@ class S3Storage
 
     def save(asset, **_args)
       source_path = source_path_for(asset)
-      relative_path = relative_path_for(asset)
-      target_path = @target_root.join(relative_path)
+      target_path = target_path_for(asset)
       FileUtils.mkdir_p(File.dirname(target_path))
       File.write(target_path, File.read(source_path))
     end
@@ -21,13 +20,17 @@ class S3Storage
     end
 
     def exists?(asset)
-      relative_path = relative_path_for(asset)
-      target_path = @target_root.join(relative_path)
+      target_path = target_path_for(asset)
       File.exist?(target_path)
     end
 
     def source_path_for(asset)
       Pathname.new(asset.file.path)
+    end
+
+    def target_path_for(asset)
+      relative_path = relative_path_for(asset)
+      @target_root.join(relative_path)
     end
 
     def relative_path_for(asset)

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -7,5 +7,9 @@ class S3Storage
     def presigned_url_for(_asset, _http_method: 'GET')
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
+
+    def exists?(_asset)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
   end
 end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -11,5 +11,9 @@ class S3Storage
     def exists?(_asset)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
+
+    def metadata_for(_asset)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
   end
 end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -12,6 +12,10 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
+    def set_metadata_for(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
     def metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -2,17 +2,17 @@ class S3Storage
   NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
 
   class Null
-    def save(_asset, _options = {}); end
+    def save(*); end
 
-    def presigned_url_for(_asset, _http_method: 'GET')
+    def presigned_url_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
-    def exists?(_asset)
+    def exists?(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
-    def metadata_for(_asset)
+    def metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
   end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -12,6 +12,14 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
+    def add_metadata_to(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
+    def remove_metadata_from(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
     def set_metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -12,6 +12,10 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
+    def never_replicated?(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
     def add_metadata_to(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,6 +1,15 @@
 namespace :govuk_assets do
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
+    process_all_assets_asynchronously_with(AssetFileMetadataWorker)
+  end
+
+  desc 'Trigger backup for all assets'
+  task trigger_backup_for_all_assets: :environment do
+    process_all_assets_asynchronously_with(AssetTriggerReplicationWorker)
+  end
+
+  def process_all_assets_asynchronously_with(worker_class)
     STDOUT.sync = true
     asset_ids = Asset.pluck(:id).to_a
     total = asset_ids.count
@@ -9,7 +18,7 @@ namespace :govuk_assets do
       if (index % 1000).zero?
         puts "#{index} of #{total} (#{percent}%) assets queued"
       end
-      AssetFileMetadataWorker.perform_async(asset_id.to_s)
+      worker_class.perform_async(asset_id.to_s)
     end
     puts "\nFinished!"
   end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -4,8 +4,8 @@ namespace :govuk_assets do
     process_all_assets_asynchronously_with(AssetFileMetadataWorker)
   end
 
-  desc 'Trigger backup for all assets'
-  task trigger_backup_for_all_assets: :environment do
+  desc 'Trigger replication for all non-replicated GOV.UK assets'
+  task trigger_replication_for_non_replicated_assets: :environment do
     process_all_assets_asynchronously_with(AssetTriggerReplicationWorker)
   end
 

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -75,4 +75,10 @@ RSpec.describe S3Storage::Fake do
       end
     end
   end
+
+  describe '#metadata_for' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe S3Storage::Fake do
     end
   end
 
+  describe '#set_metadata_for' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.set_metadata_for(asset, {}) }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#metadata_for' do
     it 'raises exception to indicate method not implemented' do
       expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe S3Storage::Fake do
       expect(host).to eq(AssetManager.app_host)
     end
   end
+
+  describe '#exists?' do
+    let(:asset_path) { root_path.join(relative_path_to_asset) }
+
+    context 'when file is not saved in storage' do
+      it 'returns falsey' do
+        expect(storage.exists?(asset)).to be_falsey
+      end
+    end
+
+    context 'when file is saved in storage' do
+      before do
+        storage.save(asset)
+      end
+
+      it 'returns truthy' do
+        expect(storage.exists?(asset)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe S3Storage::Fake do
     end
   end
 
+  describe '#add_metadata_to' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.add_metadata_to(asset, key: 'key', value: 'value') }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#remove_metadata_from' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.remove_metadata_from(asset, key: 'key') }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#set_metadata_for' do
     it 'raises exception to indicate method not implemented' do
       expect { storage.set_metadata_for(asset, {}) }.to raise_error(NotImplementedError)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -74,13 +74,11 @@ RSpec.describe S3Storage do
     context 'when S3 object already exists' do
       let(:default_metadata) { { 'md5-hexdigest' => md5_hexdigest } }
       let(:metadata) { default_metadata }
-      let(:attributes) { { metadata: metadata } }
-      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
 
       before do
         allow(s3_object).to receive(:exists?).and_return(true)
-        allow(s3_client).to receive(:head_object)
-          .with(s3_head_object_params).and_return(s3_result)
+        allow(subject).to receive(:metadata_for)
+          .with(asset).and_return(metadata)
       end
 
       context 'and MD5 hex digest does match' do
@@ -183,6 +181,21 @@ RSpec.describe S3Storage do
       it 'raises exception' do
         expect { subject.metadata_for(asset) }
           .to raise_error(S3Storage::ObjectNotFoundError)
+      end
+    end
+
+    context 'when S3 object does exist' do
+      let(:metadata) { { 'key' => 'value' } }
+      let(:attributes) { { metadata: metadata } }
+      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_return(s3_result)
+      end
+
+      it 'returns metadata from S3 object' do
+        expect(subject.metadata_for(asset)).to eq(metadata)
       end
     end
   end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -150,4 +150,26 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe '#exists?' do
+    before do
+      allow(s3_object).to receive(:exists?).and_return(exists_on_s3)
+    end
+
+    context 'when asset does not exist on S3' do
+      let(:exists_on_s3) { false }
+
+      it 'returns falsey' do
+        expect(subject.exists?(asset)).to be_falsey
+      end
+    end
+
+    context 'when asset does exist on S3' do
+      let(:exists_on_s3) { true }
+
+      it 'returns truthy' do
+        expect(subject.exists?(asset)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe S3Storage do
       end
 
       it 'raises exception' do
-        expect { subject.send(:metadata_for, asset) }
+        expect { subject.metadata_for(asset) }
           .to raise_error(S3Storage::ObjectNotFoundError)
       end
     end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -232,4 +232,56 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe '#add_metadata_to' do
+    let(:existing_metadata) { { 'key' => 'value' } }
+    let(:new_key) { 'new-key' }
+    let(:new_value) { 'new-value' }
+    let(:new_metadata) { { new_key => new_value } }
+
+    before do
+      allow(subject).to receive(:metadata_for)
+        .with(asset).and_return(existing_metadata)
+    end
+
+    it 'adds new key/value pair to metadata' do
+      expect(subject).to receive(:set_metadata_for)
+        .with(asset, include(new_metadata))
+
+      subject.add_metadata_to(asset, key: new_key, value: new_value)
+    end
+
+    it 'retains existing metadata' do
+      expect(subject).to receive(:set_metadata_for)
+        .with(asset, include(existing_metadata))
+
+      subject.add_metadata_to(asset, key: new_key, value: new_value)
+    end
+  end
+
+  describe '#remove_metadata_from' do
+    let(:key_to_remove) { 'key-1' }
+    let(:metadata_to_remove) { { key_to_remove => 'value-1' } }
+    let(:other_metadata) { { 'key-2' => 'value-2' } }
+    let(:existing_metadata) { metadata_to_remove.merge(other_metadata) }
+
+    before do
+      allow(subject).to receive(:metadata_for)
+        .with(asset).and_return(existing_metadata)
+    end
+
+    it 'removes key/value pair from metadata' do
+      expect(subject).to receive(:set_metadata_for)
+        .with(asset, exclude(metadata_to_remove))
+
+      subject.remove_metadata_from(asset, key: key_to_remove)
+    end
+
+    it 'retains other metadata' do
+      expect(subject).to receive(:set_metadata_for)
+        .with(asset, include(other_metadata))
+
+      subject.remove_metadata_from(asset, key: key_to_remove)
+    end
+  end
 end

--- a/spec/support/matchers/exclude.rb
+++ b/spec/support/matchers/exclude.rb
@@ -1,0 +1,1 @@
+RSpec::Matchers.define_negated_matcher :exclude, :include

--- a/spec/workers/asset_trigger_replication_worker_spec.rb
+++ b/spec/workers/asset_trigger_replication_worker_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec::Matchers.define_negated_matcher :exclude, :include
+
+RSpec.describe AssetTriggerReplicationWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryGirl.create(:asset) }
+  let(:s3_storage) { instance_double(S3Storage) }
+  let(:now) { Time.parse('2017-01-01 00:00:00') }
+
+  before do
+    allow(Services).to receive(:cloud_storage).and_return(s3_storage)
+    allow(Time).to receive(:now).and_return(now)
+    allow(s3_storage).to receive(:exists?).and_return(exists_on_s3)
+  end
+
+  context 'when asset has no corresponding S3 object' do
+    let(:exists_on_s3) { false }
+
+    it 'does not add/remove metadata to/from S3 object' do
+      expect(s3_storage).to receive(:add_metadata_to).never
+      expect(s3_storage).to receive(:remove_metadata_from).never
+
+      worker.perform(asset.id.to_s)
+    end
+  end
+
+  context 'when asset has corresponding S3 object' do
+    let(:exists_on_s3) { true }
+
+    it 'adds and then removes metadata entry to trigger replication' do
+      expect(s3_storage).to receive(:add_metadata_to)
+        .with(asset, key: described_class::KEY, value: now.httpdate).ordered
+      expect(s3_storage).to receive(:remove_metadata_from)
+        .with(asset, key: described_class::KEY).ordered
+
+      worker.perform(asset.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
S3 objects for some assets were added to the production S3 bucket *before* replication was enabled on the bucket. Enabling replication does not automatically replicate these S3 objects, so we need to do it manually.

The simplest way to achieve this seems to be to modify the metadata on the relevant S3 objects. This feels better than manually syncing/copying the relevant S3 objects to the backup bucket, because it uses the same mechanism (replication) to sync to the target bucket using all the same users, roles & permissions.

One possible downside of the approach is that the `Last-Modified` timestamp is updated when the metadata on an S3 object is modified. However, at the moment, we're not making use of this metadata; the Rails app sets a `Last-Modified` response header using a value stored in the database.

Another possible downside is that the new metadata entry will be sent as a response header when the S3 object is requested. However, the worker immediately removes the new metadata entry, so it will only ever be a very transient issue and in any case, the extra response header shouldn't cause any problems.

This PR introduces a new Rake task, `govuk_assets:trigger_replication_for_non_replicated_assets`, which iterates through all the assets and (for all those that have a corresponding S3 object which has never been replicated) updates the metadata on the corresponding S3 object in order to trigger replication for that object. Since doing this involves a number of requests to S3 for each asset, the Rake task queues up a Sidekiq job for each asset on a low priority queue to be processed asynchronously.

Note that at the moment, cross-region replication is only setup on the production S3 bucket and so this Rake task only needs to be run in production, not integration or staging. Having said that, running it in the other environments shouldn't cause any problems.