### PR TITLE
Improve consistency of methods in the S3Storage class

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,6 +69,7 @@ RSpec/NestedGroups:
 RSpec/PredicateMatcher:
   Exclude:
     - 'spec/models/asset_spec.rb'
+    - 'spec/lib/s3_storage_spec.rb'
     - 'spec/lib/s3_storage/fake_spec.rb'
 
 # Offense count: 12

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,3 +85,7 @@ RSpec/VerifiedDoubles:
     - 'spec/workers/save_to_cloud_storage_worker_spec.rb'
     - 'spec/lib/s3_storage_spec.rb'
     - 'spec/routing/fake_s3_route_spec.rb'
+
+RSpec/SubjectStub:
+  Exclude:
+      - 'spec/lib/s3_storage_spec.rb'

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -34,6 +34,10 @@ class S3Storage
     object_for(asset).presigned_url(http_method, options)
   end
 
+  def exists?(asset)
+    object_for(asset).exists?
+  end
+
 private
 
   def object_for(asset)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,13 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def metadata_for(asset)
+    result = head_object_for(asset)
+    result.metadata
+  rescue Aws::S3::Errors::NotFound
+    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+  end
+
 private
 
   def object_for(asset)
@@ -47,13 +54,6 @@ private
 
   def head_object_for(asset)
     client.head_object(bucket: @bucket_name, key: asset.uuid)
-  end
-
-  def metadata_for(asset)
-    result = head_object_for(asset)
-    result.metadata
-  rescue Aws::S3::Errors::NotFound
-    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
   end
 
   def client

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,10 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def metadata_for(_asset)
+      raise NotImplementedError
+    end
+
     def source_path_for(asset)
       Pathname.new(asset.file.path)
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -20,6 +20,12 @@ class S3Storage
       "#{AssetManager.app_host}#{url_path}"
     end
 
+    def exists?(asset)
+      relative_path = relative_path_for(asset)
+      target_path = @target_root.join(relative_path)
+      File.exist?(target_path)
+    end
+
     def source_path_for(asset)
       Pathname.new(asset.file.path)
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -7,8 +7,7 @@ class S3Storage
 
     def save(asset, **_args)
       source_path = source_path_for(asset)
-      relative_path = relative_path_for(asset)
-      target_path = @target_root.join(relative_path)
+      target_path = target_path_for(asset)
       FileUtils.mkdir_p(File.dirname(target_path))
       File.write(target_path, File.read(source_path))
     end
@@ -21,13 +20,17 @@ class S3Storage
     end
 
     def exists?(asset)
-      relative_path = relative_path_for(asset)
-      target_path = @target_root.join(relative_path)
+      target_path = target_path_for(asset)
       File.exist?(target_path)
     end
 
     def source_path_for(asset)
       Pathname.new(asset.file.path)
+    end
+
+    def target_path_for(asset)
+      relative_path = relative_path_for(asset)
+      @target_root.join(relative_path)
     end
 
     def relative_path_for(asset)

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -7,5 +7,9 @@ class S3Storage
     def presigned_url_for(_asset, _http_method: 'GET')
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
+
+    def exists?(_asset)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
   end
 end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -11,5 +11,9 @@ class S3Storage
     def exists?(_asset)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
+
+    def metadata_for(_asset)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
   end
 end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -2,17 +2,17 @@ class S3Storage
   NOT_CONFIGURED_ERROR_MESSAGE = 'AWS S3 bucket not correctly configured'.freeze
 
   class Null
-    def save(_asset, _options = {}); end
+    def save(*); end
 
-    def presigned_url_for(_asset, _http_method: 'GET')
+    def presigned_url_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
-    def exists?(_asset)
+    def exists?(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
-    def metadata_for(_asset)
+    def metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
   end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -75,4 +75,10 @@ RSpec.describe S3Storage::Fake do
       end
     end
   end
+
+  describe '#metadata_for' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe S3Storage::Fake do
       expect(host).to eq(AssetManager.app_host)
     end
   end
+
+  describe '#exists?' do
+    let(:asset_path) { root_path.join(relative_path_to_asset) }
+
+    context 'when file is not saved in storage' do
+      it 'returns falsey' do
+        expect(storage.exists?(asset)).to be_falsey
+      end
+    end
+
+    context 'when file is saved in storage' do
+      before do
+        storage.save(asset)
+      end
+
+      it 'returns truthy' do
+        expect(storage.exists?(asset)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -74,13 +74,11 @@ RSpec.describe S3Storage do
     context 'when S3 object already exists' do
       let(:default_metadata) { { 'md5-hexdigest' => md5_hexdigest } }
       let(:metadata) { default_metadata }
-      let(:attributes) { { metadata: metadata } }
-      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
 
       before do
         allow(s3_object).to receive(:exists?).and_return(true)
-        allow(s3_client).to receive(:head_object)
-          .with(s3_head_object_params).and_return(s3_result)
+        allow(subject).to receive(:metadata_for)
+          .with(asset).and_return(metadata)
       end
 
       context 'and MD5 hex digest does match' do
@@ -183,6 +181,21 @@ RSpec.describe S3Storage do
       it 'raises exception' do
         expect { subject.metadata_for(asset) }
           .to raise_error(S3Storage::ObjectNotFoundError)
+      end
+    end
+
+    context 'when S3 object does exist' do
+      let(:metadata) { { 'key' => 'value' } }
+      let(:attributes) { { metadata: metadata } }
+      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_return(s3_result)
+      end
+
+      it 'returns metadata from S3 object' do
+        expect(subject.metadata_for(asset)).to eq(metadata)
       end
     end
   end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -150,4 +150,26 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe '#exists?' do
+    before do
+      allow(s3_object).to receive(:exists?).and_return(exists_on_s3)
+    end
+
+    context 'when asset does not exist on S3' do
+      let(:exists_on_s3) { false }
+
+      it 'returns falsey' do
+        expect(subject.exists?(asset)).to be_falsey
+      end
+    end
+
+    context 'when asset does exist on S3' do
+      let(:exists_on_s3) { true }
+
+      it 'returns truthy' do
+        expect(subject.exists?(asset)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe S3Storage do
       end
 
       it 'raises exception' do
-        expect { subject.send(:metadata_for, asset) }
+        expect { subject.metadata_for(asset) }
           .to raise_error(S3Storage::ObjectNotFoundError)
       end
     end


### PR DESCRIPTION
These are some tidying-up commits from #286 which I still think are generally useful. Also I'm going to need the `S3Storage#exists?` method which this PR introduces when I implement the new version of #286.