### PR TITLE
Trigger replication for non-replicated S3 objects

### DIFF
--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -8,7 +8,7 @@ class AssetTriggerReplicationWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    if @cloud_storage.exists?(asset)
+    if @cloud_storage.exists?(asset) && @cloud_storage.never_replicated?(asset)
       @cloud_storage.save(asset, force: true)
     end
   end

--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -1,0 +1,15 @@
+class AssetTriggerReplicationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def initialize(cloud_storage: Services.cloud_storage)
+    @cloud_storage = cloud_storage
+  end
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    if @cloud_storage.exists?(asset)
+      @cloud_storage.save(asset)
+    end
+  end
+end

--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -9,7 +9,7 @@ class AssetTriggerReplicationWorker
   def perform(asset_id)
     asset = Asset.find(asset_id)
     if @cloud_storage.exists?(asset)
-      @cloud_storage.save(asset)
+      @cloud_storage.save(asset, force: true)
     end
   end
 end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,0 +1,15 @@
+class AssetProcessor
+  def process_all_assets_with
+    STDOUT.sync = true
+    asset_ids = Asset.pluck(:id).to_a
+    total = asset_ids.count
+    asset_ids.each_with_index do |asset_id, index|
+      percent = "%0.0f" % (index / total.to_f * 100)
+      if (index % 1000).zero?
+        puts "#{index} of #{total} (#{percent}%) assets"
+      end
+      yield asset_id.to_s
+    end
+    puts "\nFinished!"
+  end
+end

--- a/lib/asset_replication_checker.rb
+++ b/lib/asset_replication_checker.rb
@@ -1,0 +1,27 @@
+class AssetReplicationChecker
+  def initialize(cloud_storage: Services.cloud_storage)
+    @cloud_storage = cloud_storage
+    @processor = AssetProcessor.new
+  end
+
+  def check_all_assets
+    @ids_of_assets_with_no_s3_object = []
+    @ids_of_assets_with_s3_object_not_replicated = []
+    @processor.process_all_assets_with do |asset_id|
+      check(asset_id)
+    end
+    puts "Assets with no S3 object: #{@ids_of_assets_with_no_s3_object}"
+    puts "Assets with S3 object not replicated: #{@ids_of_assets_with_s3_object_not_replicated}"
+  end
+
+  def check(asset_id)
+    asset = Asset.find(asset_id)
+    if @cloud_storage.exists?(asset)
+      unless @cloud_storage.replicated?(asset)
+        @ids_of_assets_with_s3_object_not_replicated << asset_id
+      end
+    else
+      @ids_of_assets_with_no_s3_object << asset_id
+    end
+  end
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,6 +39,12 @@ class S3Storage
     object_for(asset).exists?
   end
 
+  def never_replicated?(asset)
+    head_object_for(asset).replication_status.nil?
+  rescue Aws::S3::Errors::NotFound
+    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+  end
+
   def metadata_for(asset)
     result = head_object_for(asset)
     result.metadata

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -40,9 +40,12 @@ class S3Storage
   end
 
   def never_replicated?(asset)
-    head_object_for(asset).replication_status.nil?
-  rescue Aws::S3::Errors::NotFound
-    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+    replication_status(asset).nil?
+  end
+
+  def replicated?(asset)
+    status = replication_status(asset)
+    status && (status == 'COMPLETED')
   end
 
   def metadata_for(asset)
@@ -53,6 +56,12 @@ class S3Storage
   end
 
 private
+
+  def replication_status(asset)
+    head_object_for(asset).replication_status
+  rescue Aws::S3::Errors::NotFound
+    raise ObjectNotFoundError.new("S3 object not found for asset: #{asset.id}")
+  end
 
   def object_for(asset)
     Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.uuid)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -19,9 +19,9 @@ class S3Storage
     @bucket_name = bucket_name
   end
 
-  def save(asset)
+  def save(asset, force: false)
     metadata = exists?(asset) ? metadata_for(asset) : {}
-    unless metadata['md5-hexdigest'] == asset.md5_hexdigest
+    if force || metadata['md5-hexdigest'] != asset.md5_hexdigest
       metadata['md5-hexdigest'] = asset.md5_hexdigest
       object_for(asset).upload_file(asset.file.path, metadata: metadata)
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -24,6 +24,10 @@ class S3Storage
       File.exist?(target_path)
     end
 
+    def never_replicated?(_asset)
+      raise NotImplementedError
+    end
+
     def metadata_for(_asset)
       raise NotImplementedError
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -28,6 +28,10 @@ class S3Storage
       raise NotImplementedError
     end
 
+    def replicated?(_asset)
+      raise NotImplementedError
+    end
+
     def metadata_for(_asset)
       raise NotImplementedError
     end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -12,6 +12,10 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
+    def never_replicated?(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
     def metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/s3_storage/null.rb
+++ b/lib/s3_storage/null.rb
@@ -16,6 +16,10 @@ class S3Storage
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end
 
+    def replicated?(*)
+      raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
+    end
+
     def metadata_for(*)
       raise NotConfiguredError.new(NOT_CONFIGURED_ERROR_MESSAGE)
     end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -6,8 +6,8 @@ namespace :govuk_assets do
     end
   end
 
-  desc 'Trigger backup for all assets'
-  task trigger_backup_for_all_assets: :environment do
+  desc 'Trigger replication for all non-replicated GOV.UK assets'
+  task trigger_replication_for_non_replicated_assets: :environment do
     process_all_assets_with do |asset_id|
       AssetTriggerReplicationWorker.perform_async(asset_id)
     end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,29 +1,19 @@
+require 'asset_processor'
+
 namespace :govuk_assets do
+  processor = AssetProcessor.new
+
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
-    process_all_assets_with do |asset_id|
+    processor.process_all_assets_with do |asset_id|
       AssetFileMetadataWorker.perform_async(asset_id)
     end
   end
 
   desc 'Trigger replication for all non-replicated GOV.UK assets'
   task trigger_replication_for_non_replicated_assets: :environment do
-    process_all_assets_with do |asset_id|
+    processor.process_all_assets_with do |asset_id|
       AssetTriggerReplicationWorker.perform_async(asset_id)
     end
-  end
-
-  def process_all_assets_with
-    STDOUT.sync = true
-    asset_ids = Asset.pluck(:id).to_a
-    total = asset_ids.count
-    asset_ids.each_with_index do |asset_id, index|
-      percent = "%0.0f" % (index / total.to_f * 100)
-      if (index % 1000).zero?
-        puts "#{index} of #{total} (#{percent}%) assets"
-      end
-      yield asset_id.to_s
-    end
-    puts "\nFinished!"
   end
 end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -6,6 +6,13 @@ namespace :govuk_assets do
     end
   end
 
+  desc 'Trigger backup for all assets'
+  task trigger_backup_for_all_assets: :environment do
+    process_all_assets_with do |asset_id|
+      AssetTriggerReplicationWorker.perform_async(asset_id)
+    end
+  end
+
   def process_all_assets_with
     STDOUT.sync = true
     asset_ids = Asset.pluck(:id).to_a

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,15 +1,21 @@
 namespace :govuk_assets do
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
+    process_all_assets_with do |asset_id|
+      AssetFileMetadataWorker.perform_async(asset_id)
+    end
+  end
+
+  def process_all_assets_with
     STDOUT.sync = true
     asset_ids = Asset.pluck(:id).to_a
     total = asset_ids.count
     asset_ids.each_with_index do |asset_id, index|
       percent = "%0.0f" % (index / total.to_f * 100)
       if (index % 1000).zero?
-        puts "#{index} of #{total} (#{percent}%) assets queued"
+        puts "#{index} of #{total} (#{percent}%) assets"
       end
-      AssetFileMetadataWorker.perform_async(asset_id.to_s)
+      yield asset_id.to_s
     end
     puts "\nFinished!"
   end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,4 +1,5 @@
 require 'asset_processor'
+require 'asset_replication_checker'
 
 namespace :govuk_assets do
   processor = AssetProcessor.new
@@ -15,5 +16,11 @@ namespace :govuk_assets do
     processor.process_all_assets_with do |asset_id|
       AssetTriggerReplicationWorker.perform_async(asset_id)
     end
+  end
+
+  desc 'Check all GOV.UK assets have been replicated'
+  task check_all_assets_have_been_replicated: :environment do
+    checker = AssetReplicationChecker.new
+    checker.check_all_assets
   end
 end

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe S3Storage::Fake do
     end
   end
 
+  describe '#never_replicated?' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.never_replicated?(asset) }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#metadata_for' do
     it 'raises exception to indicate method not implemented' do
       expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe S3Storage::Fake do
     end
   end
 
+  describe '#replicated?' do
+    it 'raises exception to indicate method not implemented' do
+      expect { storage.replicated?(asset) }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#metadata_for' do
     it 'raises exception to indicate method not implemented' do
       expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe S3Storage do
 
           subject.save(asset)
         end
+
+        context 'but force options is set' do
+          it 'uploads file to S3' do
+            expect(s3_object).to receive(:upload_file)
+
+            subject.save(asset, force: true)
+          end
+        end
       end
 
       context 'and MD5 hex digest does not match' do

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -177,6 +177,48 @@ RSpec.describe S3Storage do
     end
   end
 
+  describe '#never_replicated?' do
+    context 'when asset does not exist on S3' do
+      let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_raise(not_found_error)
+      end
+
+      it 'raises exception' do
+        expect { subject.never_replicated?(asset) }
+          .to raise_error(S3Storage::ObjectNotFoundError)
+      end
+    end
+
+    context 'when asset does exist on S3' do
+      let(:attributes) { { replication_status: replication_status } }
+      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_return(s3_result)
+      end
+
+      context 'and asset has no replication status' do
+        let(:replication_status) { nil }
+
+        it 'returns truthy' do
+          expect(subject.never_replicated?(asset)).to be_truthy
+        end
+      end
+
+      context 'and asset has replication status' do
+        let(:replication_status) { 'COMPLETED' }
+
+        it 'returns falsey' do
+          expect(subject.never_replicated?(asset)).to be_falsey
+        end
+      end
+    end
+  end
+
   describe '#metadata_for' do
     context 'when S3 object does not exist' do
       let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -219,6 +219,48 @@ RSpec.describe S3Storage do
     end
   end
 
+  describe '#replicated?' do
+    context 'when asset does not exist on S3' do
+      let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_raise(not_found_error)
+      end
+
+      it 'raises exception' do
+        expect { subject.replicated?(asset) }
+          .to raise_error(S3Storage::ObjectNotFoundError)
+      end
+    end
+
+    context 'when asset does exist on S3' do
+      let(:attributes) { { replication_status: replication_status } }
+      let(:s3_result) { Aws::S3::Types::HeadObjectOutput.new(attributes) }
+
+      before do
+        allow(s3_client).to receive(:head_object)
+          .with(s3_head_object_params).and_return(s3_result)
+      end
+
+      context 'and asset has no replication status' do
+        let(:replication_status) { nil }
+
+        it 'returns falsey' do
+          expect(subject.replicated?(asset)).to be_falsey
+        end
+      end
+
+      context 'and asset replication status is COMPLETED' do
+        let(:replication_status) { 'COMPLETED' }
+
+        it 'returns truthy' do
+          expect(subject.replicated?(asset)).to be_truthy
+        end
+      end
+    end
+  end
+
   describe '#metadata_for' do
     context 'when S3 object does not exist' do
       let(:not_found_error) { Aws::S3::Errors::NotFound.new(nil, nil) }

--- a/spec/workers/asset_trigger_replication_worker_spec.rb
+++ b/spec/workers/asset_trigger_replication_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AssetTriggerReplicationWorker, type: :worker do
     let(:exists_on_s3) { true }
 
     it 're-saves S3 object to trigger replication' do
-      expect(s3_storage).to receive(:save).with(asset)
+      expect(s3_storage).to receive(:save).with(asset, force: true)
 
       worker.perform(asset.id.to_s)
     end

--- a/spec/workers/asset_trigger_replication_worker_spec.rb
+++ b/spec/workers/asset_trigger_replication_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec::Matchers.define_negated_matcher :exclude, :include
+
+RSpec.describe AssetTriggerReplicationWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryGirl.create(:asset) }
+  let(:s3_storage) { instance_double(S3Storage) }
+
+  before do
+    allow(Services).to receive(:cloud_storage).and_return(s3_storage)
+    allow(s3_storage).to receive(:exists?).and_return(exists_on_s3)
+  end
+
+  context 'when asset has no corresponding S3 object' do
+    let(:exists_on_s3) { false }
+
+    it 'does not re-save S3 object' do
+      expect(s3_storage).to receive(:save).never
+
+      worker.perform(asset.id.to_s)
+    end
+  end
+
+  context 'when asset has corresponding S3 object' do
+    let(:exists_on_s3) { true }
+
+    it 're-saves S3 object to trigger replication' do
+      expect(s3_storage).to receive(:save).with(asset)
+
+      worker.perform(asset.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
S3 objects for some assets were added to the production S3 bucket *before* replication was enabled on the bucket. Enabling replication did not automatically replicate these S3 objects, so we need to do it manually.

The simplest way to do this appears to be to re-save the S3 object. This feels better than manually syncing/copying the relevant S3 objects to the target bucket, because it uses the same mechanism (replication) to sync to the backup bucket with all the same users, roles & permissions.

One possible downside of this approach is that the `Last-Modified` timestamp updated when the metadata on an S3 object is modified. However, at the moment, we're not making use of this metadata - the Rails app sets the `Last-Modified` response header using a value stored in the database.

This PR introduces a new Rake task, `govuk_assets:trigger_replication_for_non_replicated_assets`, which iterates through all the assets and (for all those that have a corresponding S3 object which has never been replicated) re-uploads the content to the corresponding S3 object in order to trigger replication for that object. Since doing this involves a number of requests to S3 for each asset and the one that uploads the content might take a while, the Rake task queues up a Sidekiq job for each asset on a low priority queue to be processed asynchronously.

This PR also adds a `govuk_assets:check_all_assets_have_been_replicated` Rake task which iterates over all the assets and lists IDs for those which are missing an S3 object and for those which have not been successfully replicated. Since this only needs to send a couple of `HEAD` requests for each asset, it seemed OK to do this synchronously especially as this made it easier to aggregate and report the results. The idea is to run this task after running the `govuk_assets:trigger_replication_for_non_replicated_assets` task to check that all assets have been successfully replicated.

Note that at the moment, cross-region replication is only setup on the production S3 bucket and so this Rake task only needs to be run in production, not integration or staging. Having said that, running it in the other environments shouldn't cause any problems.

I have tested these Rake tasks as follows:

1. Use the `govuk-terraform-provisioning` repo to create the production S3 buckets in my own AWS account, but [without enabling replication][1].
2. Run the Asset Manager app pointing it at my version of the production S3 bucket.
3. Use `curl` to create a couple of assets via the Asset Manager API.
4. Observe that the S3 objects for these assets are created in the production bucket after being virus scanned, but that they are not replicated to the backup S3 bucket.
5. Run the `govuk_assets:check_all_assets_have_been_replicated` Rake task and see that no assets are missing S3 objects, but both have S3 objects which have not been replicated.
6. Use the `govuk-terraform-provisioning` repo to [enable replication][1].
7. Observe that the S3 objects for the two assets still haven't been replicated.
8. Run the `govuk_assets:trigger_replication_for_non_replicated_assets` Rake task.
9. Observe that the timestamps on the S3 objects for the two assets are updated and that they have been replicated to the backup S3 bucket. Also observe that the content and metadata of the two S3 objects match that of the corresponding objects in the backup bucket.
10. Run the `govuk_assets:check_all_assets_have_been_replicated` Rake task again and see that no assets are missing S3 objects and no assets have S3 objects which have not been replicated, i.e. they have all been replicated successfully.

[1]: https://github.com/alphagov/govuk-terraform-provisioning/pull/140
[2]: https://github.com/alphagov/govuk-terraform-provisioning/pull/141
