### PR TITLE
Add missing require statement to AssetReplicationChecker

### DIFF
--- a/lib/asset_replication_checker.rb
+++ b/lib/asset_replication_checker.rb
@@ -1,3 +1,5 @@
+require 'services'
+
 class AssetReplicationChecker
   def initialize(cloud_storage: Services.cloud_storage)
     @cloud_storage = cloud_storage


### PR DESCRIPTION
We tried running the `rake
govuk_assets:check_all_assets_have_been_replicated` task in production
but it failed with `NameError: uninitialized constant
AssetReplicationChecker::Services`.