### PR TITLE
Generate correct path to thumbnail-placeholder.png

### DIFF
--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,6 +1,4 @@
 class WhitehallMediaController < BaseMediaController
-  include ActionView::Helpers::AssetUrlHelper
-
   def download
     path = "/government/uploads/#{params[:path]}.#{params[:format]}"
     asset = WhitehallAsset.find_by(legacy_url_path: path)
@@ -8,7 +6,7 @@ class WhitehallMediaController < BaseMediaController
     if asset.unscanned?
       set_expiry(1.minute)
       if asset.image?
-        redirect_to image_path('thumbnail-placeholder.png')
+        redirect_to self.class.helpers.image_path('thumbnail-placeholder.png')
       else
         redirect_to '/government/placeholder'
       end

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe WhitehallMediaController, type: :controller do
-  include ActionView::Helpers::AssetUrlHelper
-
   describe '#download' do
     let(:path) { 'path/to/asset' }
     let(:format) { 'png' }
@@ -52,7 +50,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
       it 'redirects to thumbnail-placeholder image' do
         get :download, path: path, format: format
 
-        expect(controller).to redirect_to(image_path('thumbnail-placeholder.png'))
+        expect(controller).to redirect_to(described_class.helpers.image_path('thumbnail-placeholder.png'))
       end
     end
 

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
     end
 
     it 'redirects to placeholder image' do
-      expect(response).to redirect_to('/images/thumbnail-placeholder.png')
+      expect(response).to redirect_to(%r(/asset-manager/thumbnail-placeholder-.*\.png))
     end
 
     it 'sets the Cache-Control response header to 1 minute' do


### PR DESCRIPTION
We redirect to this placeholder in response to requests for unscanned
Whitehall images.

We were incorrectly redirecting to '/images/thumbnail-placeholder.png'
instead of '/asset-manager/thumbnail-placeholder-<digest>.png'. This
appears to be because the `image_path` method from
`ActionView::Helpers::AssetUrlHelper` doesn't take the Asset Pipeline
into account. The code snippets below illustrate the problem and fix:

    # This ignores our assets.prefix config option
    >> Class.new do
         include ActionView::Helpers::AssetUrlHelper
       end.new.image_path('thumbnail-placeholder.png')
    => "/images/thumbnail-placeholder.png"

    # This respects our assets.prefix config option
    >> ActionController::Base.helpers.image_path('thumbnail-placeholder.png')
    => "/asset-manager/thumbnail-placeholder-b0b645c0f44c2fc7d8cc2fee24f576d82256a85ac3c3e0a59d6ff60d2903d6b6.png"

I've confirmed that redirecting to the thumbnail containing a digest is
the same as the behaviour in Whitehall (which is what we're interested
in replicating):

    $ curl -I https://assets.publishing.service.gov.uk/government/uploads/foo.png \
      | grep Location

    Location: //whitehall-admin.publishing.service.gov.uk/government/assets/thumbnail-placeholder-b0b645c0f44c2fc7d8cc2fee24f576d82256a85ac3c3e0a59d6ff60d2903d6b6.png