### PR TITLE
Respond with 204 if no content when downloading

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -25,6 +25,7 @@ protected
   end
 
   def serve_from_nfs_via_nginx(asset)
-    send_file(asset.file.path, disposition: AssetManager.content_disposition.type)
+    send_file asset.file.path, disposition: AssetManager.content_disposition.type
+    head :no_content if response.body.empty?
   end
 end


### PR DESCRIPTION
In Rails 5 - When the response has no body an error is thrown, this
change makes it so that the error will not be thrown, along with keeping
existing behaviour for files that have data inside the response body
(e.g. a text file)

done in preperation for #298 