### PR TITLE
Upload assets marked as deleted to s3

### DIFF
--- a/app/workers/asset_trigger_replication_worker.rb
+++ b/app/workers/asset_trigger_replication_worker.rb
@@ -1,3 +1,5 @@
+require 'services'
+
 class AssetTriggerReplicationWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'low_priority'

--- a/app/workers/deleted_asset_file_metadata_worker.rb
+++ b/app/workers/deleted_asset_file_metadata_worker.rb
@@ -1,0 +1,13 @@
+class DeletedAssetFileMetadataWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def perform(asset_id)
+    asset = Asset.unscoped.find(asset_id)
+    asset.set(
+      etag: asset.etag_from_file,
+      last_modified: asset.last_modified_from_file,
+      md5_hexdigest: asset.md5_hexdigest_from_file
+    )
+  end
+end

--- a/app/workers/deleted_asset_save_to_cloud_storage_worker.rb
+++ b/app/workers/deleted_asset_save_to_cloud_storage_worker.rb
@@ -1,0 +1,15 @@
+require 'services'
+
+class DeletedAssetSaveToCloudStorageWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def initialize(cloud_storage: Services.cloud_storage)
+    @cloud_storage = cloud_storage
+  end
+
+  def perform(asset_id)
+    asset = Asset.unscoped.find(asset_id)
+    @cloud_storage.save(asset)
+  end
+end

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -1,3 +1,5 @@
+require 'services'
+
 class SaveToCloudStorageWorker
   include Sidekiq::Worker
 

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,15 +1,21 @@
 class AssetProcessor
+  def initialize(output: STDOUT, report_progress_every: 1000)
+    @output = output
+    @report_progress_every = report_progress_every
+  end
+
   def process_all_assets_with
-    STDOUT.sync = true
+    @output.sync = true
     asset_ids = Asset.pluck(:id).to_a
     total = asset_ids.count
     asset_ids.each_with_index do |asset_id, index|
-      percent = "%0.0f" % (index / total.to_f * 100)
-      if (index % 1000).zero?
-        puts "#{index} of #{total} (#{percent}%) assets"
+      count = index + 1
+      percent = "%0.0f" % (count / total.to_f * 100)
+      if (count % @report_progress_every).zero?
+        @output.puts "#{count} of #{total} (#{percent}%) assets"
       end
       yield asset_id.to_s
     end
-    puts "\nFinished!"
+    @output.puts "\nFinished!"
   end
 end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -16,6 +16,9 @@ class AssetProcessor
       end
       yield asset_id.to_s
     end
+    unless (total % @report_progress_every).zero?
+      @output.puts "#{total} of #{total} (100%) assets"
+    end
     @output.puts "\nFinished!"
   end
 end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,12 +1,13 @@
 class AssetProcessor
-  def initialize(output: STDOUT, report_progress_every: 1000)
+  def initialize(scope: Asset, output: STDOUT, report_progress_every: 1000)
+    @scope = scope
     @output = output
     @report_progress_every = report_progress_every
   end
 
   def process_all_assets_with
     @output.sync = true
-    asset_ids = Asset.pluck(:id).to_a
+    asset_ids = @scope.pluck(:id).to_a
     total = asset_ids.count
     asset_ids.each_with_index do |asset_id, index|
       count = index + 1

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -11,6 +11,14 @@ namespace :govuk_assets do
     end
   end
 
+  desc 'Store values generated from file metadata for GOV.UK assets marked as deleted'
+  task store_values_generated_from_file_metadata_for_assets_marked_as_deleted: :environment do
+    processor = AssetProcessor.new(scope: Asset.deleted, report_progress_every: 100)
+    processor.process_all_assets_with do |asset_id|
+      DeletedAssetFileMetadataWorker.perform_async(asset_id)
+    end
+  end
+
   desc 'Trigger replication for all non-replicated GOV.UK assets'
   task trigger_replication_for_non_replicated_assets: :environment do
     processor = AssetProcessor.new

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,6 +1,7 @@
 require 'asset_processor'
 require 'asset_replication_checker'
 
+# rubocop:disable Metrics/BlockLength
 namespace :govuk_assets do
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
@@ -23,4 +24,13 @@ namespace :govuk_assets do
     checker = AssetReplicationChecker.new
     checker.check_all_assets
   end
+
+  desc 'Upload GOV.UK assets marked as deleted to cloud storage'
+  task upload_assets_marked_as_deleted_to_cloud_storage: :environment do
+    processor = AssetProcessor.new(scope: Asset.deleted, report_progress_every: 100)
+    processor.process_all_assets_with do |asset_id|
+      DeletedAssetSaveToCloudStorageWorker.perform_async(asset_id)
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -2,10 +2,9 @@ require 'asset_processor'
 require 'asset_replication_checker'
 
 namespace :govuk_assets do
-  processor = AssetProcessor.new
-
   desc 'Store values generated from file metadata for all GOV.UK assets'
   task store_values_generated_from_file_metadata: :environment do
+    processor = AssetProcessor.new
     processor.process_all_assets_with do |asset_id|
       AssetFileMetadataWorker.perform_async(asset_id)
     end
@@ -13,6 +12,7 @@ namespace :govuk_assets do
 
   desc 'Trigger replication for all non-replicated GOV.UK assets'
   task trigger_replication_for_non_replicated_assets: :environment do
+    processor = AssetProcessor.new
     processor.process_all_assets_with do |asset_id|
       AssetTriggerReplicationWorker.perform_async(asset_id)
     end

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe AssetProcessor do
       expect(output_lines[1]).to be_blank
       expect(output_lines[2]).to eq('Finished!')
     end
+
+    context 'and number of assets is not a multiple of 2' do
+      before do
+        FactoryGirl.create(:asset)
+      end
+
+      it 'still reports 100% progress' do
+        processor.process_all_assets_with {}
+
+        expect(output_lines[0]).to eq('2 of 3 (67%) assets')
+        expect(output_lines[1]).to eq('3 of 3 (100%) assets')
+        expect(output_lines[2]).to be_blank
+        expect(output_lines[3]).to eq('Finished!')
+      end
+    end
   end
 
   def output_lines

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'asset_processor'
+
+RSpec.describe AssetProcessor do
+  subject(:processor) { described_class.new(**args) }
+
+  let(:args) { { output: output, report_progress_every: report_progress_every } }
+  let(:output) { StringIO.new }
+  let(:report_progress_every) { 1 }
+
+  let!(:asset_1) { FactoryGirl.create(:asset) }
+  let!(:asset_2) { FactoryGirl.create(:asset) }
+
+  it 'iterates over all assets' do
+    asset_ids = []
+    processor.process_all_assets_with do |asset_id|
+      asset_ids << asset_id
+    end
+    expect(asset_ids).to contain_exactly(asset_1.id.to_s, asset_2.id.to_s)
+  end
+
+  it 'reports progress for every asset' do
+    processor.process_all_assets_with {}
+
+    expect(output_lines[0]).to eq('1 of 2 (50%) assets')
+    expect(output_lines[1]).to eq('2 of 2 (100%) assets')
+    expect(output_lines[2]).to be_blank
+    expect(output_lines[3]).to eq('Finished!')
+  end
+
+  context 'when report_progress_every option is set to 2' do
+    let(:report_progress_every) { 2 }
+
+    it 'only reports progress for every 2 assets' do
+      processor.process_all_assets_with {}
+
+      expect(output_lines[0]).to eq('2 of 2 (100%) assets')
+      expect(output_lines[1]).to be_blank
+      expect(output_lines[2]).to eq('Finished!')
+    end
+  end
+
+  def output_lines
+    @output_lines ||= begin
+      output.rewind
+      output.readlines.map(&:chomp)
+    end
+  end
+end

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe AssetProcessor do
     end
   end
 
+  context 'when scope is set to deleted assets' do
+    let(:args) { { scope: scope, output: output } }
+    let(:scope) { Asset.deleted }
+
+    before do
+      asset_1.destroy
+    end
+
+    it 'iterates over all deleted assets' do
+      asset_ids = []
+      processor.process_all_assets_with do |asset_id|
+        asset_ids << asset_id
+      end
+      expect(asset_ids).to contain_exactly(asset_1.id.to_s)
+    end
+  end
+
   def output_lines
     @output_lines ||= begin
       output.rewind

--- a/spec/workers/asset_trigger_replication_worker_spec.rb
+++ b/spec/workers/asset_trigger_replication_worker_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 RSpec::Matchers.define_negated_matcher :exclude, :include
 
 RSpec.describe AssetTriggerReplicationWorker, type: :worker do
-  subject(:worker) { described_class.new }
+  subject(:worker) { described_class.new(cloud_storage: s3_storage) }
 
   let(:asset) { FactoryGirl.create(:asset) }
   let(:s3_storage) { instance_double(S3Storage) }
 
   before do
-    allow(Services).to receive(:cloud_storage).and_return(s3_storage)
     allow(s3_storage).to receive(:exists?).and_return(exists_on_s3)
   end
 

--- a/spec/workers/deleted_asset_file_metadata_worker_spec.rb
+++ b/spec/workers/deleted_asset_file_metadata_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe DeletedAssetFileMetadataWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryGirl.create(:asset) }
+
+  before do
+    asset.destroy
+  end
+
+  it 'sets Asset#etag to Asset#etag_from_file in database' do
+    asset.set(etag: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.etag).to eq(asset.etag_from_file)
+  end
+
+  it 'sets Asset#last_modified to Asset#last_modified_from_file in database' do
+    asset.set(last_modified: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.last_modified).to be_within_a_millisecond_of(asset.last_modified_from_file)
+  end
+
+  it 'sets Asset#md5_hexdigest to Asset#md5_hexdigest_from_file in database' do
+    asset.set(md5_hexdigest: nil)
+
+    worker.perform(asset.id.to_s)
+
+    expect(asset.reload.md5_hexdigest).to eq(asset.md5_hexdigest_from_file)
+  end
+end

--- a/spec/workers/deleted_asset_save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/deleted_asset_save_to_cloud_storage_worker_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DeletedAssetSaveToCloudStorageWorker, type: :worker do
+  let(:worker) { described_class.new(cloud_storage: s3_storage) }
+  let(:s3_storage) { instance_double(S3Storage) }
+
+  describe "#perform" do
+    let(:asset) { FactoryGirl.create(:clean_asset) }
+
+    before do
+      asset.destroy
+    end
+
+    it 'saves the deleted asset to S3 storage' do
+      expect(s3_storage).to receive(:save).with(asset)
+
+      worker.perform(asset)
+    end
+  end
+end

--- a/spec/workers/save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/save_to_cloud_storage_worker_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 RSpec.describe SaveToCloudStorageWorker, type: :worker do
   let(:worker) { described_class.new }
 


### PR DESCRIPTION
This introduces a couple of new Rake tasks:

* `upload_assets_marked_as_deleted_to_cloud_storage`
* `store_values_generated_from_file_metadata_for_assets_marked_as_deleted`

Both these Rake tasks operate on assets marked as deleted and for each of these assets the first one uploads the file to S3 and the second one store values generated from file metadata in the database.

Both Rake tasks queue jobs up in a low priority queue in the same way as we've done previously.

I've also taken the opportunity to add test coverage for the `AssetProcessor` and in the process improved its progress reporting. I've also done a bit of tidying up of the workers and their specs.

Closes #304.

