### PR TITLE
Add Rake task to permanently delete asset

### DIFF
--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -40,5 +40,24 @@ namespace :govuk_assets do
       DeletedAssetSaveToCloudStorageWorker.perform_async(asset_id)
     end
   end
+
+  desc 'Permanently delete asset by ID (asset must already be marked as deleted)'
+  task :permanently_delete_asset, [:asset_id] => :environment do |_, args|
+    asset_id = args.fetch(:asset_id) do
+      raise '*** Error: Please supply asset_id argument to Rake task'
+    end
+    asset = Asset.unscoped.where(id: asset_id).first
+    if asset.present?
+      if asset.deleted?
+        print "Permanently deleting asset ID: #{asset_id}..."
+        asset.destroy!
+        puts '[OK]'
+      else
+        raise "*** Error: Asset not marked as deleted: #{asset_id}"
+      end
+    else
+      raise "*** Error: Asset not found: #{asset_id}"
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The app uses the `mongoid_paranoia` gem which means that assets deleted via the API are only marked as deleted. This is so they can be restored via the API.

Sometimes it's desirable to permanently remove an asset, e.g. if an asset containing sensitive information is accidentally uploaded. This Rake task allows us to permanently delete an asset which has already been marked as deleted.

I've tested this on my dev VM as follows:

```
vagrant@development:/var/apps/asset-manager$ govuk_setenv asset-manager bundle exec rake govuk_assets:permanently_delete_asset
rake aborted!
*** Error: Please supply asset_id

vagrant@development:/var/apps/asset-manager$ govuk_setenv asset-manager bundle exec rake govuk_assets:permanently_delete_asset[x]
rake aborted!
*** Error: Asset not found: x

vagrant@development:/var/apps/asset-manager$ govuk_setenv asset-manager bundle exec rake govuk_assets:permanently_delete_asset[513a0efbed915d425e000002]
rake aborted!
*** Error: Asset not marked as deleted: 513a0efbed915d425e000002

vagrant@development:/var/apps/asset-manager$ govuk_setenv asset-manager bundle exec rake govuk_assets:permanently_delete_asset[5a0ae429ed915d0adcdf4731]
Permanently deleting asset ID: 5a0ae429ed915d0adcdf4731...[OK]
```

I'm hoping to use this to resolve #310.