### PR TITLE
Add scripts to list and delete orphan S3 objects

### DIFF
--- a/bin/delete_s3_objects
+++ b/bin/delete_s3_objects
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+xargs -I {} aws s3api delete-object --bucket $1 --key {} --output text

--- a/bin/list_short_s3_object_keys
+++ b/bin/list_short_s3_object_keys
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+aws s3api list-objects-v2 --bucket $1 --query 'Contents[?length(@.Key) == `24`].[Key]' --output text


### PR DESCRIPTION
These two scripts assume access to the AWS CLI tool configured with the appropriate credentials.

* `list_short_s3_object_keys` lists S3 object keys with length 24 vs 36. The former were introduced before we switched to using 36-char UUIDs and are now surplus to requirements. The script expects a single command-line argument for the S3 bucket name, e.g. `govuk-assets-production`.

* `delete_s3_objects` expects stdin to have one S3 object key per line as output by `list_short_s3_object_keys`. It will delete the S3 object corresponding to each key. The script expects a single command-line argument for the S3 bucket name, e.g. `govuk-assets-production`.

I tested these scripts against integration, although changed `delete-object` to `head-object` in `delete_s3_objects`:

```
$ bin/list_short_s3_object_keys govuk-assets-integration >orphan-s3-object-keys.txt
$ wc -l orphan-s3-object-keys.txt 
    1137 orphan-s3-object-keys.txt
$ cat orphan-s3-object-keys.txt | bin/delete_s3_objects govuk-assets-integration >deleted-s3-objects.txt
```

I'm planning to ask someone with the appropriate credentials to run these scripts against the integration, staging & production S3 buckets.
