### PR TITLE
Set AWS_S3_BUCKET_NAME to a placeholder on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ node ('mongodb-2.4') {
       govuk.setEnvar('TEST_COVERAGE', 'true')
     },
     sassLint: false,
-    publishingE2ETests: true
+    publishingE2ETests: true,
+    afterTest: {
+      govuk.setEnvar('AWS_S3_BUCKET_NAME', 'asset-precompilation-test')
+    }
   )
 }


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

In CI we want to run asset compilation in production mode to catch any
errors before we deploy as there are differences between dev/test mode
compilation and production mode (see: https://github.com/alphagov/govuk-puppet/pull/6821).  This app requires that
AWS_S3_BUCKET_NAME is set in production, so we set that envvar in the
Jenkinsfile after we've run the tests (asset compilation is done after
the other tests).