### PR TITLE
Match the Dockerfile ruby version to the .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav && apt-get clean
 RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan


### PR DESCRIPTION
The ruby version was upgraded in a recent PR #313 without bumping the Dockerfile to match.

Dockerfile gets used by the publishing end-to-end tests.  We don't want the version tested against to be different to the version in production.

CC @danielburnley @RoryMacDonald 