### PR TITLE
Standardize on CarrierWave::Uploader::Proxy#path vs #current_path

### DIFF
--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -5,7 +5,7 @@ class VirusScanWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    scanner = VirusScanner.new(asset.file.current_path)
+    scanner = VirusScanner.new(asset.file.path)
     if scanner.clean?
       asset.scanned_clean
     else

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AssetsController, type: :controller do
         post :create, params: { asset: attributes }
 
         expect(assigns(:asset)).to be_persisted
-        expect(assigns(:asset).file.current_path).to match(/asset\.png$/)
+        expect(assigns(:asset).file.path).to match(/asset\.png$/)
       end
 
       it "returns a created status" do
@@ -44,7 +44,7 @@ RSpec.describe AssetsController, type: :controller do
         post :create, params: { asset: attributes }
 
         expect(assigns(:asset)).not_to be_persisted
-        expect(assigns(:asset).file.current_path).to be_nil
+        expect(assigns(:asset).file.path).to be_nil
       end
 
       it "returns an unprocessable entity status" do
@@ -64,7 +64,7 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset)).to be_persisted
-        expect(assigns(:asset).file.current_path).to match(/asset2\.jpg$/)
+        expect(assigns(:asset).file.path).to match(/asset2\.jpg$/)
       end
 
       it "returns a success status" do
@@ -93,7 +93,7 @@ RSpec.describe AssetsController, type: :controller do
         post :create, params: { asset: attributes }
 
         expect(assigns(:asset)).not_to be_persisted
-        expect(assigns(:asset).file.current_path).to be_nil
+        expect(assigns(:asset).file.path).to be_nil
       end
 
       it "returns an unprocessable entity status" do


### PR DESCRIPTION
The former is [an alias of the latter][1] and we were using a mixture of the two. The former is terser and just as meaningful and so I've elected to standardize on that.

[1]:
https://github.com/carrierwaveuploader/carrierwave/blob/v0.10.0/lib/carrierwave/uploader/proxy.rb#L25