### PR TITLE
Remove options to serve assets from NFS via Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ All assets are uploaded to the S3 bucket via a separate `govuk_sidekiq` job trig
 
 * `PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* Whitehall asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100. The remaining Whitehall asset requests will be served from NFS via Nginx. The default is to serve all Whitehall asset requests from NFS via Nginx.
 
-#### Request parameters
-
-* Mainstream asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
-
-* Whitehall asset requests can be proxied to S3 via Nginx even if `PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` is not set by adding `proxy_to_s3_via_nginx=true` as a request parameter key-value pair to the query string.
-
 ### Testing
 
 `bundle exec rspec`

--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ All assets are uploaded to the S3 bucket via a separate `govuk_sidekiq` job trig
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored (required in production)
 * `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (assumes CNAME has been setup for bucket)
 
-##### Feature flags
-
-* `PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* Mainstream asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100. The remaining Mainstream asset requests will be served from NFS via Nginx. The default is to serve all Mainstream asset requests from NFS via Nginx.
-
-* `PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX` - causes *a percentage of* Whitehall asset requests to be proxied to S3 via Nginx - the percentage should be an integer between 0 and 100. The remaining Whitehall asset requests will be served from NFS via Nginx. The default is to serve all Whitehall asset requests from NFS via Nginx.
-
 ### Testing
 
 `bundle exec rspec`

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -3,10 +3,6 @@ class BaseMediaController < ApplicationController
 
 protected
 
-  def proxy_to_s3_via_nginx?
-    true
-  end
-
   def proxy_to_s3_via_nginx(asset)
     url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
     headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
@@ -14,9 +10,5 @@ protected
     headers['Last-Modified'] = asset.last_modified.httpdate
     headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
     head :ok, content_type: asset.content_type
-  end
-
-  def serve_from_nfs_via_nginx(asset)
-    send_file(asset.file.path, disposition: AssetManager.content_disposition.type)
   end
 end

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -4,7 +4,7 @@ class BaseMediaController < ApplicationController
 protected
 
   def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    raise NotImplementedError
+    100
   end
 
   def proxy_to_s3_via_nginx?

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -4,9 +4,7 @@ class BaseMediaController < ApplicationController
 protected
 
   def proxy_to_s3_via_nginx?
-    random_number_generator = Random.new
-    percentage = 100
-    random_number_generator.rand(100) < percentage
+    true
   end
 
   def proxy_to_s3_via_nginx(asset)

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -10,8 +10,7 @@ protected
   def proxy_to_s3_via_nginx?
     random_number_generator = Random.new
     percentage = proxy_percentage_of_asset_requests_to_s3_via_nginx
-    proxy_to_s3_via_nginx = random_number_generator.rand(100) < percentage
-    proxy_to_s3_via_nginx || params[:proxy_to_s3_via_nginx].present?
+    random_number_generator.rand(100) < percentage
   end
 
   def proxy_to_s3_via_nginx(asset)

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -3,13 +3,9 @@ class BaseMediaController < ApplicationController
 
 protected
 
-  def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    100
-  end
-
   def proxy_to_s3_via_nginx?
     random_number_generator = Random.new
-    percentage = proxy_percentage_of_asset_requests_to_s3_via_nginx
+    percentage = 100
     random_number_generator.rand(100) < percentage
   end
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -28,7 +28,7 @@ class MediaController < BaseMediaController
 protected
 
   def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx
+    100
   end
 
   def filename_current?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -27,10 +27,6 @@ class MediaController < BaseMediaController
 
 protected
 
-  def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    100
-  end
-
   def filename_current?
     asset.filename == params[:filename]
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -16,11 +16,7 @@ class MediaController < BaseMediaController
       format.any do
         set_expiry(AssetManager.cache_control.max_age)
         headers['X-Frame-Options'] = AssetManager.frame_options
-        if proxy_to_s3_via_nginx?
-          proxy_to_s3_via_nginx(asset)
-        else
-          serve_from_nfs_via_nginx(asset)
-        end
+        proxy_to_s3_via_nginx(asset)
       end
     end
   end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -24,10 +24,4 @@ class WhitehallMediaController < BaseMediaController
       serve_from_nfs_via_nginx(asset)
     end
   end
-
-protected
-
-  def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    100
-  end
 end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -28,6 +28,6 @@ class WhitehallMediaController < BaseMediaController
 protected
 
   def proxy_percentage_of_asset_requests_to_s3_via_nginx
-    AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx
+    100
   end
 end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -18,10 +18,6 @@ class WhitehallMediaController < BaseMediaController
 
     set_expiry(AssetManager.whitehall_cache_control.max_age)
     headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
-    if proxy_to_s3_via_nginx?
-      proxy_to_s3_via_nginx(asset)
-    else
-      serve_from_nfs_via_nginx(asset)
-    end
+    proxy_to_s3_via_nginx(asset)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,9 +44,6 @@ module AssetManager
 
   mattr_accessor :carrier_wave_store_base_dir
 
-  mattr_accessor :proxy_percentage_of_asset_requests_to_s3_via_nginx
-  mattr_accessor :proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx
-
   mattr_accessor :cache_control
   mattr_accessor :whitehall_cache_control
   mattr_accessor :content_disposition

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,2 +1,0 @@
-AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = 100
-AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx = 100

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,4 +1,2 @@
-AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx =
-  ENV['PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
-AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx =
-  ENV['PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX'].to_i
+AssetManager.proxy_percentage_of_asset_requests_to_s3_via_nginx = 100
+AssetManager.proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx = 100

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -38,15 +38,12 @@ RSpec.describe BaseMediaController, type: :controller do
   end
 
   describe "#proxy_to_s3_via_nginx?" do
-    let(:proxy_to_s3_via_nginx) { false }
     let(:random_number_generator) { instance_double(Random) }
     let(:random_number) { 50 }
 
     before do
       allow(controller).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
         .and_return(proxy_percentage_of_asset_requests_to_s3_via_nginx)
-      allow(controller).to receive(:params)
-        .and_return(proxy_to_s3_via_nginx: proxy_to_s3_via_nginx)
       allow(Random).to receive(:new).and_return(random_number_generator)
       allow(random_number_generator).to receive(:rand).with(100).and_return(random_number)
     end
@@ -54,20 +51,8 @@ RSpec.describe BaseMediaController, type: :controller do
     context "when proxy_percentage_of_asset_requests_to_s3_via_nginx is not set" do
       let(:proxy_percentage_of_asset_requests_to_s3_via_nginx) { 0 }
 
-      context "when proxy_to_s3_via_nginx is not set" do
-        let(:proxy_to_s3_via_nginx) { false }
-
-        it "returns falsey" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
-        end
-      end
-
-      context "when proxy_to_s3_via_nginx is set" do
-        let(:proxy_to_s3_via_nginx) { true }
-
-        it "returns truthy" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-        end
+      it "returns falsey" do
+        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
       end
 
       context "even when random number generator returns its minimum value" do
@@ -102,12 +87,8 @@ RSpec.describe BaseMediaController, type: :controller do
     context "when proxy_percentage_of_asset_requests_to_s3_via_nginx is set to 100%" do
       let(:proxy_percentage_of_asset_requests_to_s3_via_nginx) { 100 }
 
-      context "even when proxy_to_s3_via_nginx is not set" do
-        let(:proxy_to_s3_via_nginx) { false }
-
-        it "returns truthy" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-        end
+      it "returns truthy" do
+        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
       end
 
       context "even when random number generator returns its maximum value" do

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -30,10 +30,11 @@ RSpec.describe BaseMediaController, type: :controller do
   end
 
   describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    it 'raises NotImplementedError' do
-      expect {
-        controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-      }.to raise_error(NotImplementedError)
+    let(:percentage) { 100 }
+
+    it 'returns the percentage of asset requests to proxy to S3' do
+      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
+        .to eq(percentage)
     end
   end
 

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -30,24 +30,8 @@ RSpec.describe BaseMediaController, type: :controller do
   end
 
   describe "#proxy_to_s3_via_nginx?" do
-    let(:random_number_generator) { instance_double(Random) }
-    let(:random_number) { 50 }
-
-    before do
-      allow(Random).to receive(:new).and_return(random_number_generator)
-      allow(random_number_generator).to receive(:rand).with(100).and_return(random_number)
-    end
-
     it "returns truthy" do
       expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-    end
-
-    context "even when random number generator returns its maximum value" do
-      let(:random_number) { 99 }
-
-      it "returns truthy" do
-        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-      end
     end
   end
 

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -119,14 +119,12 @@ RSpec.describe BaseMediaController, type: :controller do
     end
 
     it 'uses send_file to instruct Nginx to serve file from NFS' do
-      allow(controller).to receive(:render)
       expect(controller).to receive(:send_file).with(asset.file.path, anything).and_call_original
 
       get :download, params: { id: asset.id }
     end
 
     it 'sets Content-Disposition header to value in configuration' do
-      allow(controller).to receive(:render)
       expect(controller).to receive(:send_file).with(anything, include(disposition: 'content-disposition')).and_call_original
 
       get :download, params: { id: asset.id }

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -29,75 +29,24 @@ RSpec.describe BaseMediaController, type: :controller do
     get :anything
   end
 
-  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    let(:percentage) { 100 }
-
-    it 'returns the percentage of asset requests to proxy to S3' do
-      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
-        .to eq(percentage)
-    end
-  end
-
   describe "#proxy_to_s3_via_nginx?" do
     let(:random_number_generator) { instance_double(Random) }
     let(:random_number) { 50 }
 
     before do
-      allow(controller).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-        .and_return(proxy_percentage_of_asset_requests_to_s3_via_nginx)
       allow(Random).to receive(:new).and_return(random_number_generator)
       allow(random_number_generator).to receive(:rand).with(100).and_return(random_number)
     end
 
-    context "when proxy_percentage_of_asset_requests_to_s3_via_nginx is not set" do
-      let(:proxy_percentage_of_asset_requests_to_s3_via_nginx) { 0 }
-
-      it "returns falsey" do
-        expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
-      end
-
-      context "even when random number generator returns its minimum value" do
-        let(:random_number) { 0 }
-
-        it "returns falsey" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
-        end
-      end
+    it "returns truthy" do
+      expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
     end
 
-    context "when proxy_percentage_of_asset_requests_to_s3_via_nginx is set to 25%" do
-      let(:proxy_percentage_of_asset_requests_to_s3_via_nginx) { 25 }
-
-      context "when random number generator returns a number less than 25" do
-        let(:random_number) { 24 }
-
-        it "returns truthy" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-        end
-      end
-
-      context "when random number generator returns a number equal to or more than 25" do
-        let(:random_number) { 25 }
-
-        it "returns falsey" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_falsey
-        end
-      end
-    end
-
-    context "when proxy_percentage_of_asset_requests_to_s3_via_nginx is set to 100%" do
-      let(:proxy_percentage_of_asset_requests_to_s3_via_nginx) { 100 }
+    context "even when random number generator returns its maximum value" do
+      let(:random_number) { 99 }
 
       it "returns truthy" do
         expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-      end
-
-      context "even when random number generator returns its maximum value" do
-        let(:random_number) { 99 }
-
-        it "returns truthy" do
-          expect(controller.send(:proxy_to_s3_via_nginx?)).to be_truthy
-        end
       end
     end
   end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -169,13 +169,4 @@ RSpec.describe MediaController, type: :controller do
       end
     end
   end
-
-  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    let(:mainstream_percentage) { 100 }
-
-    it 'returns the percentage of Mainstream requests to proxy to S3' do
-      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
-        .to eq(mainstream_percentage)
-    end
-  end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe MediaController, type: :controller do
       context "when proxy_to_s3_via_nginx? is falsey (default)" do
         before do
           allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(false)
-          allow(controller).to receive(:render)
         end
 
         it "serves asset from NFS via Nginx" do
@@ -33,7 +32,6 @@ RSpec.describe MediaController, type: :controller do
       context "when proxy_to_s3_via_nginx? is truthy" do
         before do
           allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(true)
-          allow(controller).to receive(:render)
         end
 
         it "proxies asset to S3 via Nginx" do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -11,18 +11,16 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
 
-      context "when true" do
-        it "proxies asset to S3 via Nginx" do
-          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+      it "proxies asset to S3 via Nginx" do
+        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
 
-          get :download, params
-        end
+        get :download, params
+      end
 
-        it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-          get :download, params
+      it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
+        get :download, params
 
-          expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
-        end
+        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
       end
 
       context "when the file name in the URL represents an old version" do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -171,13 +171,7 @@ RSpec.describe MediaController, type: :controller do
   end
 
   describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    let(:mainstream_percentage) { 55 }
-
-    before do
-      allow(AssetManager)
-        .to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-        .and_return(mainstream_percentage)
-    end
+    let(:mainstream_percentage) { 100 }
 
     it 'returns the percentage of Mainstream requests to proxy to S3' do
       expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -11,29 +11,7 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
 
-      context "when proxy_to_s3_via_nginx? is falsey (default)" do
-        before do
-          allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(false)
-        end
-
-        it "serves asset from NFS via Nginx" do
-          expect(controller).to receive(:serve_from_nfs_via_nginx).with(asset)
-
-          get :download, params
-        end
-
-        it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-          get :download, params
-
-          expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
-        end
-      end
-
-      context "when proxy_to_s3_via_nginx? is truthy" do
-        before do
-          allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(true)
-        end
-
+      context "when true" do
         it "proxies asset to S3 via Nginx" do
           expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -80,13 +80,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
   end
 
   describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    let(:whitehall_percentage) { 45 }
-
-    before do
-      allow(AssetManager)
-        .to receive(:proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx)
-        .and_return(whitehall_percentage)
-    end
+    let(:whitehall_percentage) { 100 }
 
     it 'returns the percentage of Whitehall requests to proxy to S3' do
       expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -13,12 +13,10 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is clean' do
       let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
 
-      context "when true" do
-        it "proxies asset to S3 via Nginx" do
-          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+      it "proxies asset to S3 via Nginx" do
+        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
 
-          get :download, params: { path: path, format: format }
-        end
+        get :download, params: { path: path, format: format }
       end
     end
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -78,13 +78,4 @@ RSpec.describe WhitehallMediaController, type: :controller do
       end
     end
   end
-
-  describe '#proxy_percentage_of_asset_requests_to_s3_via_nginx' do
-    let(:whitehall_percentage) { 100 }
-
-    it 'returns the percentage of Whitehall requests to proxy to S3' do
-      expect(controller.send(:proxy_percentage_of_asset_requests_to_s3_via_nginx))
-        .to eq(whitehall_percentage)
-    end
-  end
 end

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -13,23 +13,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is clean' do
       let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
 
-      context "when proxy_to_s3_via_nginx? is falsey (default)" do
-        before do
-          allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(false)
-        end
-
-        it "serves asset from NFS via Nginx" do
-          expect(controller).to receive(:serve_from_nfs_via_nginx).with(asset)
-
-          get :download, params: { path: path, format: format }
-        end
-      end
-
-      context "when proxy_to_s3_via_nginx? is truthy" do
-        before do
-          allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(true)
-        end
-
+      context "when true" do
         it "proxies asset to S3 via Nginx" do
           expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe WhitehallMediaController, type: :controller do
       context "when proxy_to_s3_via_nginx? is falsey (default)" do
         before do
           allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(false)
-          allow(controller).to receive(:render)
         end
 
         it "serves asset from NFS via Nginx" do
@@ -29,7 +28,6 @@ RSpec.describe WhitehallMediaController, type: :controller do
       context "when proxy_to_s3_via_nginx? is truthy" do
         before do
           allow(controller).to receive(:proxy_to_s3_via_nginx?).and_return(true)
-          allow(controller).to receive(:render)
         end
 
         it "proxies asset to S3 via Nginx" do

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -1,11 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Media requests", type: :request do
-  before do
-    allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-      .and_return(100)
-  end
-
   describe "requesting an asset that doesn't exist" do
     it "responds with not found status" do
       get "/media/34/test.jpg"

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Media requests", type: :request do
+  before do
+    allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
+      .and_return(0)
+  end
+
   describe "requesting an asset that doesn't exist" do
     it "responds with not found status" do
       get "/media/34/test.jpg"

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Virus scanning of uploaded images", type: :request do
     login_as_stub_user
 
     allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-      .and_return(0)
+      .and_return(100)
   end
 
   specify "uploading a clean asset, and seeing it available after virus scanning" do
@@ -24,9 +24,6 @@ RSpec.describe "Virus scanning of uploaded images", type: :request do
 
     get "/media/#{asset.id}/lorem.txt"
     expect(response).to have_http_status(:success)
-
-    expected = File.read(fixture_file_path("lorem.txt"))
-    expect(response.body).to eq(expected)
   end
 
   # Extension to UploadedFile to represent an uploaded virus

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -3,9 +3,6 @@ require "rails_helper"
 RSpec.describe "Virus scanning of uploaded images", type: :request do
   before do
     login_as_stub_user
-
-    allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
-      .and_return(100)
   end
 
   specify "uploading a clean asset, and seeing it available after virus scanning" do

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe "Virus scanning of uploaded images", type: :request do
   before do
     login_as_stub_user
+
+    allow(AssetManager).to receive(:proxy_percentage_of_asset_requests_to_s3_via_nginx)
+      .and_return(0)
   end
 
   specify "uploading a clean asset, and seeing it available after virus scanning" do

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Whitehall media requests', type: :request do
+  before do
+    allow(AssetManager).to receive(:proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx)
+      .and_return(0)
+  end
+
   describe 'request for an asset which does not exist' do
     it 'responds with 404 Not Found status' do
       get '/government/uploads/asset.png'

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe 'Whitehall media requests', type: :request do
   describe 'request for an unscanned image asset' do
     let(:path) { '/government/uploads/asset.png' }
 
-    before do
+    let!(:asset) {
       FactoryBot.create(
         :whitehall_asset,
         file: load_fixture_file('asset.png'),
         legacy_url_path: path
       )
+    }
 
+    before do
       get path
     end
 
@@ -39,13 +41,15 @@ RSpec.describe 'Whitehall media requests', type: :request do
   describe 'request for an unscanned non-image asset' do
     let(:path) { '/government/uploads/lorem.txt' }
 
-    before do
+    let!(:asset) {
       FactoryBot.create(
         :whitehall_asset,
         file: load_fixture_file('lorem.txt'),
         legacy_url_path: path
       )
+    }
 
+    before do
       get path
     end
 

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe 'Whitehall media requests', type: :request do
   let(:presigned_url) { 'https://s3-host.test/presigned-url' }
 
   before do
-    allow(AssetManager).to receive(:proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx)
-      .and_return(100)
-
     allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
   end
 


### PR DESCRIPTION
Currently both feature flags are [set to 100% in all environments][1], so *all* asset requests are being proxied to S3 via Nginx. We're happy that this mechanism is working OK and have no plans to rollback to proxying less than 100% of asset requests to S3 via Nginx, so there's no longer
any need for either the environment variable feature flags nor the request parameter overrides. This pull request hard-codes these configuration options and simplifies the application code accordingly.

My actual motivation for doing this is that I want to [start deleting asset files from NFS when they've been uploaded to S3](https://github.com/alphagov/asset-manager/issues/323). These changes should make that easier, because it removes one key method (`BaseMediaController#serve_from_nfs_via_nginx`) which was relying on the asset's file existing on NFS.

Note that once this has been deployed to all environments, we should remove the environment variables which will be made redundant by this PR from `govuk-puppet` to avoid future confusion.

[1]:
https://github.com/alphagov/govuk-puppet/blob/476d9e764b42348deb8a2253be78d460d44c33c0/hieradata/common.yaml#L523-L524
