### PR TITLE
Convert from factory_girl to factory_bot gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 group :development, :test do
   gem 'database_cleaner'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'govuk-lint'
   gem 'rspec-rails'
   gem 'simplecov-rcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,10 +69,10 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -323,7 +323,7 @@ DEPENDENCIES
   carrierwave (~> 0.10.0)
   carrierwave-mongoid (~> 0.10.0)
   database_cleaner
-  factory_girl_rails
+  factory_bot_rails
   gds-sso (~> 13.2)
   govuk-lint
   govuk_app_config (~> 0.3.0)

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AssetsController, type: :controller do
   describe "PUT update" do
     context "a valid asset" do
       let(:attributes) { { file: load_fixture_file("asset2.jpg") } }
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
 
       it "updates attributes" do
         put :update, params: { id: asset.id, asset: attributes }
@@ -106,7 +106,7 @@ RSpec.describe AssetsController, type: :controller do
 
   describe "DELETE destroy" do
     context "a valid asset" do
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
 
       it "deletes the asset" do
         delete :destroy, params: { id: asset.id }
@@ -129,7 +129,7 @@ RSpec.describe AssetsController, type: :controller do
     end
 
     context "when Asset#destroy fails" do
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
       let(:errors) { ActiveModel::Errors.new(asset) }
 
       before do
@@ -151,7 +151,7 @@ RSpec.describe AssetsController, type: :controller do
 
   describe "GET show" do
     context "an asset which exists" do
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
 
       it "is a successful request" do
         get :show, params: { id: asset.id }
@@ -183,7 +183,7 @@ RSpec.describe AssetsController, type: :controller do
     end
 
     describe "POST restore" do
-      let(:asset) { FactoryGirl.create(:asset, deleted_at: 10.minutes.ago) }
+      let(:asset) { FactoryBot.create(:asset, deleted_at: 10.minutes.ago) }
 
       context "an asset which has been soft deleted" do
         before do
@@ -222,7 +222,7 @@ RSpec.describe AssetsController, type: :controller do
     end
 
     describe "cache headers" do
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
 
       it "sets the cache-control headers to 0 for an unscanned asset" do
         get :show, params: { id: asset.id }

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe BaseMediaController, type: :controller do
   end
 
   describe '#proxy_to_s3_via_nginx' do
-    let(:asset) { FactoryGirl.build(:asset, id: '123') }
+    let(:asset) { FactoryBot.build(:asset, id: '123') }
     let(:cloud_storage) { double(:cloud_storage) }
     let(:presigned_url) { 'https://s3-host.test/presigned-url' }
     let(:last_modified) { Time.zone.parse('2017-01-01 00:00') }
@@ -188,7 +188,7 @@ RSpec.describe BaseMediaController, type: :controller do
   end
 
   describe '#serve_from_nfs_via_nginx' do
-    let(:asset) { FactoryGirl.build(:asset, id: '123') }
+    let(:asset) { FactoryBot.build(:asset, id: '123') }
     let(:content_disposition) { instance_double(ContentDispositionConfiguration) }
 
     before do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with a valid clean file" do
-      let(:asset) { FactoryGirl.create(:clean_asset) }
+      let(:asset) { FactoryBot.create(:clean_asset) }
 
       context "when proxy_to_s3_via_nginx? is falsey (default)" do
         before do
@@ -76,7 +76,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with an unscanned file" do
-      let(:asset) { FactoryGirl.create(:asset) }
+      let(:asset) { FactoryBot.create(:asset) }
 
       it "responds with 404 Not Found" do
         get :download, params
@@ -86,7 +86,7 @@ RSpec.describe MediaController, type: :controller do
 
     context "with an otherwise servable whitehall asset" do
       let(:path) { '/government/uploads/asset.png' }
-      let(:asset) { FactoryGirl.create(:clean_whitehall_asset, legacy_url_path: path) }
+      let(:asset) { FactoryBot.create(:clean_whitehall_asset, legacy_url_path: path) }
 
       it "responds with 404 Not Found" do
         get :download, params
@@ -95,7 +95,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with an infected file" do
-      let(:asset) { FactoryGirl.create(:infected_asset) }
+      let(:asset) { FactoryBot.create(:infected_asset) }
 
       it "responds with 404 Not Found" do
         get :download, params
@@ -111,8 +111,8 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "access limiting on the public interface" do
-      let(:restricted_asset) { FactoryGirl.create(:access_limited_asset, organisation_slug: 'example-slug') }
-      let(:unrestricted_asset) { FactoryGirl.create(:clean_asset) }
+      let(:restricted_asset) { FactoryBot.create(:access_limited_asset, organisation_slug: 'example-slug') }
+      let(:unrestricted_asset) { FactoryBot.create(:clean_asset) }
 
       it "responds with 404 Not Found for access-limited documents" do
         get :download, params: { id: restricted_asset, filename: 'asset.png' }
@@ -126,7 +126,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "access limiting on the private interface" do
-      let(:asset) { FactoryGirl.create(:access_limited_asset, organisation_slug: 'correct-organisation-slug') }
+      let(:asset) { FactoryBot.create(:access_limited_asset, organisation_slug: 'correct-organisation-slug') }
 
       before do
         allow(controller).to receive_messages(requested_via_private_vhost?: true)
@@ -139,7 +139,7 @@ RSpec.describe MediaController, type: :controller do
       end
 
       it "responds with 404 Not Found for access-limited documents if the user has the wrong organisation" do
-        user = FactoryGirl.create(:user, organisation_slug: 'incorrect-organisation-slug')
+        user = FactoryBot.create(:user, organisation_slug: 'incorrect-organisation-slug')
         login_as(user)
 
         get :download, params: { id: asset, filename: 'asset.png' }
@@ -148,7 +148,7 @@ RSpec.describe MediaController, type: :controller do
       end
 
       it "responds with 200 OK for access-limited documents if the user has the right organisation" do
-        user = FactoryGirl.create(:user, organisation_slug: 'correct-organisation-slug')
+        user = FactoryBot.create(:user, organisation_slug: 'correct-organisation-slug')
         login_as(user)
 
         get :download, params: { id: asset, filename: 'asset.png' }
@@ -158,7 +158,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with a soft deleted file" do
-      let(:asset) { FactoryGirl.create(:deleted_asset) }
+      let(:asset) { FactoryBot.create(:deleted_asset) }
 
       before do
         get :download, params

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
 
   describe "POST create" do
     context "a valid asset" do
-      let(:attributes) { FactoryGirl.attributes_for(:whitehall_asset, :with_legacy_metadata) }
+      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata) }
 
       it "is persisted" do
         post :create, params: { asset: attributes }
@@ -97,7 +97,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
   end
 
   describe 'GET show' do
-    let(:asset) { FactoryGirl.create(:whitehall_asset, legacy_url_path: '/government/uploads/image.png') }
+    let(:asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: '/government/uploads/image.png') }
     let(:presenter) { instance_double(AssetPresenter) }
 
     before do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is clean' do
-      let(:asset) { FactoryGirl.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
+      let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
 
       context "when proxy_to_s3_via_nginx? is falsey (default)" do
         before do
@@ -41,7 +41,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is unscanned image' do
-      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'unscanned') }
+      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'unscanned') }
 
       before do
         allow(asset).to receive(:image?).and_return(true)
@@ -55,7 +55,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is unscanned non-image' do
-      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'unscanned') }
+      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'unscanned') }
 
       before do
         allow(asset).to receive(:image?).and_return(false)
@@ -69,7 +69,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is infected' do
-      let(:asset) { FactoryGirl.build(:whitehall_asset, state: 'infected') }
+      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'infected') }
 
       it 'responds with 404 Not Found' do
         get :download, params: { path: path, format: format }

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :asset do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "asset.png")) }
   end

--- a/spec/lib/content_disposition_configuration_spec.rb
+++ b/spec/lib/content_disposition_configuration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ContentDispositionConfiguration do
   subject { described_class.new(type: type) }
 
   let(:type) { 'inline' }
-  let(:asset) { FactoryGirl.build(:asset) }
+  let(:asset) { FactoryBot.build(:asset) }
 
   describe '#type' do
     let(:type) { 'attachment' }

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe S3Storage::Fake do
   subject(:storage) { described_class.new(root_path) }
 
-  let(:asset) { FactoryGirl.create(:asset) }
+  let(:asset) { FactoryBot.create(:asset) }
   let(:source_root) { AssetManager.carrier_wave_store_base_dir }
   let(:root_directory) { Dir.mktmpdir }
   let(:root_path) { Pathname.new(root_directory.to_s) }

--- a/spec/lib/s3_storage/null_spec.rb
+++ b/spec/lib/s3_storage/null_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe S3Storage::Null do
   subject(:storage) { described_class.new }
 
-  let(:asset) { FactoryGirl.build(:asset) }
+  let(:asset) { FactoryBot.build(:asset) }
 
   it 'implements all public methods defined on S3Storage' do
     methods = S3Storage.public_instance_methods(false)

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe S3Storage do
   let(:bucket_name) { 'bucket-name' }
   let(:s3_client) { instance_double(Aws::S3::Client) }
   let(:s3_object) { instance_double(Aws::S3::Object) }
-  let(:asset) { FactoryGirl.create(:asset) }
+  let(:asset) { FactoryBot.create(:asset) }
   let(:key) { asset.uuid }
   let(:s3_object_params) { { bucket_name: bucket_name, key: key } }
   let(:s3_head_object_params) { { bucket: bucket_name, key: key } }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe Asset, type: :model do
   describe 'validation' do
-    subject(:asset) { FactoryGirl.build(:asset) }
+    subject(:asset) { FactoryBot.build(:asset) }
 
     it 'is valid when built from factory' do
       expect(asset).to be_valid
     end
 
     context 'when file is not specified' do
-      subject(:asset) { FactoryGirl.build(:asset, file: nil) }
+      subject(:asset) { FactoryBot.build(:asset, file: nil) }
 
       it 'is not valid' do
         expect(asset).not_to be_valid
@@ -22,7 +22,7 @@ RSpec.describe Asset, type: :model do
     end
 
     context 'when access-limited' do
-      subject(:asset) { FactoryGirl.build(:access_limited_asset) }
+      subject(:asset) { FactoryBot.build(:access_limited_asset) }
 
       it 'is valid when built from factory' do
         expect(asset).to be_valid
@@ -36,7 +36,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe 'creation' do
-    subject(:asset) { FactoryGirl.build(:asset) }
+    subject(:asset) { FactoryBot.build(:asset) }
 
     before do
       asset.save!
@@ -60,26 +60,26 @@ RSpec.describe Asset, type: :model do
 
     it 'cannot be changed after creation' do
       uuid = '11111111-1111-1111-1111-11111111111111'
-      asset = FactoryGirl.create(:asset, uuid: uuid)
+      asset = FactoryBot.create(:asset, uuid: uuid)
       expect { asset.uuid = '22222222-2222-2222-2222-222222222222' }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
     end
 
     it 'cannot be empty' do
-      asset = FactoryGirl.build(:asset, uuid: '')
+      asset = FactoryBot.build(:asset, uuid: '')
       expect(asset).not_to be_valid
       expect(asset.errors[:uuid]).to include("can't be blank")
     end
 
     it 'must be unique' do
       uuid = '11111111-1111-1111-1111-11111111111111'
-      FactoryGirl.create(:asset, uuid: uuid)
-      asset = FactoryGirl.build(:asset, uuid: uuid)
+      FactoryBot.create(:asset, uuid: uuid)
+      asset = FactoryBot.build(:asset, uuid: uuid)
       expect(asset).not_to be_valid
       expect(asset.errors[:uuid]).to include("is already taken")
     end
 
     it 'must be in the format defined in rfc4122' do
-      asset = FactoryGirl.build(:asset, uuid: 'uuid')
+      asset = FactoryBot.build(:asset, uuid: 'uuid')
       expect(asset).not_to be_valid
       expect(asset.errors[:uuid]).to include('must match the format defined in rfc4122')
     end
@@ -142,7 +142,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it "schedules a scan after save if the file is changed" do
-      a = FactoryGirl.create(:clean_asset)
+      a = FactoryBot.create(:clean_asset)
       a.file = load_fixture_file("lorem.txt")
 
       expect(VirusScanWorker).to receive(:perform_async).with(a.id)
@@ -151,7 +151,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it "schedules a scan after save if the file is changed even if filename is unchanged" do
-      a = FactoryGirl.create(:clean_asset)
+      a = FactoryBot.create(:clean_asset)
       original_filename = a.file.send(:original_filename)
       a.file = load_fixture_file("lorem.txt", named: original_filename)
 
@@ -161,7 +161,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it "does not schedule a scan after update if the file is unchanged" do
-      a = FactoryGirl.create(:clean_asset)
+      a = FactoryBot.create(:clean_asset)
       a.created_at = 5.days.ago
 
       expect(VirusScanWorker).not_to receive(:perform_async)
@@ -171,7 +171,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "when an asset is marked as clean" do
-    let!(:asset) { FactoryGirl.create(:asset) }
+    let!(:asset) { FactoryBot.create(:asset) }
 
     before do
       allow(SaveToCloudStorageWorker).to receive(:perform_async)
@@ -185,7 +185,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#accessible_by?(user)" do
-    let(:user) { FactoryGirl.build(:user, organisation_slug: 'example-organisation') }
+    let(:user) { FactoryBot.build(:user, organisation_slug: 'example-organisation') }
 
     it "is always true if the asset is not access limited" do
       expect(Asset.new(access_limited: false)).to be_accessible_by(user)
@@ -205,7 +205,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it "is false if the asset is access limited and the user has no organisation" do
-      unassociated_user = FactoryGirl.build(:user, organisation_slug: nil)
+      unassociated_user = FactoryBot.build(:user, organisation_slug: nil)
       asset = Asset.new(access_limited: true, organisation_slug: user.organisation_slug)
       expect(asset).not_to be_accessible_by(unassociated_user)
     end

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WhitehallAsset, type: :model do
   describe 'validation' do
-    subject(:asset) { FactoryGirl.build(:whitehall_asset, legacy_url_path: nil) }
+    subject(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: nil) }
 
     context 'when legacy_url_path is not set' do
       it 'is not valid' do
@@ -34,7 +34,7 @@ RSpec.describe WhitehallAsset, type: :model do
       end
 
       context 'and legacy_url_path is not unique' do
-        let(:existing_asset) { FactoryGirl.create(:whitehall_asset) }
+        let(:existing_asset) { FactoryBot.create(:whitehall_asset) }
 
         before do
           asset.legacy_url_path = existing_asset.legacy_url_path
@@ -60,7 +60,7 @@ RSpec.describe WhitehallAsset, type: :model do
   end
 
   describe '#legacy_url_path' do
-    subject(:asset) { FactoryGirl.build(:whitehall_asset) }
+    subject(:asset) { FactoryBot.build(:whitehall_asset) }
 
     before do
       asset.legacy_url_path = '/government/uploads/asset.png'

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AssetPresenter do
   subject(:presenter) { described_class.new(asset, view_context) }
 
-  let(:asset) { FactoryGirl.build(:asset) }
+  let(:asset) { FactoryBot.build(:asset) }
   let(:view_context) { instance_double(ActionView::Base) }
 
   context '#as_json' do

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "retrieving an asset" do
     it "retreives details about an existing asset" do
-      asset = FactoryGirl.create(:clean_asset)
+      asset = FactoryBot.create(:clean_asset)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -76,7 +76,7 @@ RSpec.describe "Asset requests", type: :request do
     end
 
     it "returns details about an infected asset" do
-      asset = FactoryGirl.create(:infected_asset)
+      asset = FactoryBot.create(:infected_asset)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -102,7 +102,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "deleting an asset" do
     it "soft deletes an existing asset" do
-      asset = FactoryGirl.create(:clean_asset)
+      asset = FactoryBot.create(:clean_asset)
 
       delete "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -123,7 +123,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "restoring an asset" do
     it "restores a soft deleted asset" do
-      asset = FactoryGirl.create(:clean_asset)
+      asset = FactoryBot.create(:clean_asset)
 
       post "/assets/#{asset.id}/restore"
 

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Media requests", type: :request do
   end
 
   describe "request an asset that does exist" do
-    let(:asset) { FactoryGirl.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:clean_asset) }
 
     before do
       get "/media/#{asset.id}/asset.png", headers: {

--- a/spec/requests/whitehall_asset_requests_spec.rb
+++ b/spec/requests/whitehall_asset_requests_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Asset requests', type: :request do
 
   describe 'requesting an asset' do
     it 'returns a 200 response when the asset is found' do
-      FactoryGirl.create(:whitehall_asset, legacy_url_path: '/government/uploads/asset.png')
+      FactoryBot.create(:whitehall_asset, legacy_url_path: '/government/uploads/asset.png')
 
       get '/whitehall_assets/government/uploads/asset.png'
 

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
     let(:path) { '/government/uploads/asset.png' }
 
     before do
-      FactoryGirl.create(
+      FactoryBot.create(
         :whitehall_asset,
         file: load_fixture_file('asset.png'),
         legacy_url_path: path
@@ -35,7 +35,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
     let(:path) { '/government/uploads/lorem.txt' }
 
     before do
-      FactoryGirl.create(
+      FactoryBot.create(
         :whitehall_asset,
         file: load_fixture_file('lorem.txt'),
         legacy_url_path: path
@@ -55,7 +55,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
 
   describe 'request for a clean asset' do
     let(:path) { '/government/uploads/asset.png' }
-    let!(:asset) { FactoryGirl.create(:clean_whitehall_asset, legacy_url_path: path) }
+    let!(:asset) { FactoryBot.create(:clean_whitehall_asset, legacy_url_path: path) }
 
     before do
       get path, headers: {

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -8,7 +8,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    FactoryGirl.create(:user)
+    FactoryBot.create(:user)
   end
 
   def login_as_stub_user
@@ -23,7 +23,7 @@ module AuthenticationFeatureHelpers
   end
 
   def stub_user
-    FactoryGirl.create(:user)
+    FactoryBot.create(:user)
   end
 
   def login_as_stub_user

--- a/spec/workers/save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/save_to_cloud_storage_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SaveToCloudStorageWorker, type: :worker do
   let(:worker) { described_class.new }
 
   describe "#perform" do
-    let(:asset) { FactoryGirl.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:clean_asset) }
 
     context 'when S3 bucket is configured' do
       let(:cloud_storage) { double(:cloud_storage) }

--- a/spec/workers/virus_scan_worker_spec.rb
+++ b/spec/workers/virus_scan_worker_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe VirusScanWorker do
   let(:worker) { described_class.new }
-  let(:asset) { FactoryGirl.create(:asset) }
+  let(:asset) { FactoryBot.create(:asset) }
 
   it "calls out to the VirusScanner to scan the file" do
     scanner = double("VirusScanner")


### PR DESCRIPTION
And from `factory_girl_rails` to `factory_bot_rails`.

I followed the instructions in the following deprecation warning:

    The factory_girl gem is deprecated. Please upgrade to factory_bot. See
    https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md
    for further instructions.

Note that the latest version of the new gems seems to be v4.8.2 which is why you will see them both "downgraded" from v4.9.0 to v4.8.2 in the `Gemfile.lock`.
