### PR TITLE
Make app host configuration more flexible

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,3 +89,7 @@ RSpec/VerifiedDoubles:
 RSpec/SubjectStub:
   Exclude:
       - 'spec/lib/s3_storage_spec.rb'
+
+RSpec/DescribeClass:
+  Exclude:
+      - 'spec/lib/govuk_configuration_spec.rb'

--- a/config/initializers/govuk.rb
+++ b/config/initializers/govuk.rb
@@ -1,7 +1,4 @@
-begin
-  app_name = ENV.fetch('GOVUK_APP_NAME')
-  app_domain = ENV.fetch('GOVUK_APP_DOMAIN')
-  AssetManager.app_host = "http://#{app_name}.#{app_domain}"
-rescue KeyError
-  AssetManager.app_host = 'http://localhost:3000'
-end
+require 'govuk_configuration'
+
+config = GovukConfiguration.new
+AssetManager.app_host = config.app_host

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -1,0 +1,13 @@
+class GovukConfiguration
+  def initialize(env = ENV)
+    @env = env
+  end
+
+  def app_host
+    app_name = @env.fetch('GOVUK_APP_NAME')
+    app_domain = @env.fetch('GOVUK_APP_DOMAIN')
+    AssetManager.app_host = "http://#{app_name}.#{app_domain}"
+  rescue KeyError
+    AssetManager.app_host = 'http://localhost:3000'
+  end
+end

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -4,10 +4,14 @@ class GovukConfiguration
   end
 
   def app_host
-    app_name = @env.fetch('GOVUK_APP_NAME')
-    app_domain = @env.fetch('GOVUK_APP_DOMAIN')
-    AssetManager.app_host = "http://#{app_name}.#{app_domain}"
-  rescue KeyError
-    AssetManager.app_host = 'http://localhost:3000'
+    app_name = @env.fetch('GOVUK_APP_NAME', nil)
+    app_domain = @env.fetch('GOVUK_APP_DOMAIN', nil)
+    if app_name && app_domain
+      "http://#{app_name}.#{app_domain}"
+    elsif app_domain
+      "http://#{app_domain}"
+    else
+      "http://localhost:3000"
+    end
   end
 end

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe GovukConfiguration do
     context 'when environment only includes GOVUK_APP_DOMAIN' do
       let(:env) {
         {
-          'GOVUK_APP_DOMAIN' => 'dev.gov.uk'
+          'GOVUK_APP_DOMAIN' => '127.0.0.1:9292'
         }
       }
 
-      it 'returns default application host for Rails app in development' do
-        expect(config.app_host).to eq('http://localhost:3000')
+      it 'returns application host based on app domain' do
+        expect(config.app_host).to eq('http://127.0.0.1:9292')
       end
     end
 

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require 'govuk_configuration'
+
+RSpec.describe GovukConfiguration do
+  subject(:config) { described_class.new(env) }
+
+  describe '#app_host' do
+    context 'when environment includes GOVUK_APP_NAME & GOVUK_APP_DOMAIN' do
+      let(:env) {
+        {
+          'GOVUK_APP_NAME' => 'asset-manager',
+          'GOVUK_APP_DOMAIN' => 'dev.gov.uk'
+        }
+      }
+
+      it 'returns application host including protocol' do
+        expect(config.app_host).to eq('http://asset-manager.dev.gov.uk')
+      end
+    end
+
+    context 'when environment only includes GOVUK_APP_NAME' do
+      let(:env) {
+        {
+          'GOVUK_APP_NAME' => 'asset-manager'
+        }
+      }
+
+      it 'returns default application host for Rails app in development' do
+        expect(config.app_host).to eq('http://localhost:3000')
+      end
+    end
+
+    context 'when environment only includes GOVUK_APP_DOMAIN' do
+      let(:env) {
+        {
+          'GOVUK_APP_DOMAIN' => 'dev.gov.uk'
+        }
+      }
+
+      it 'returns default application host for Rails app in development' do
+        expect(config.app_host).to eq('http://localhost:3000')
+      end
+    end
+
+    context 'when environment does not include GOVUK_APP_NAME or GOVUK_APP_DOMAIN' do
+      let(:env) { {} }
+
+      it 'returns default application host for Rails app in development' do
+        expect(config.app_host).to eq('http://localhost:3000')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I want to be able to set the app host to "http://localhost" or "http://127.0.0.1" for the [publishing-e2e-tests project](https://github.com/alphagov/publishing-e2e-tests). Previously I could bodge this by setting `GOVUK_APP_NAME` to "127" and `GOVUK_APP_DOMAIN` to "0.0.1", but making this change means we now have the flexibility to just set `GOVUK_APP_DOMAIN` to "localhost" or "127.0.0.1" to achieve the desired result.

I've extracted the logic into a class and added a spec before making the change to highlight how the logic has changed.