### PR TITLE
Allow override of fake S3 host via environment variable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,6 +59,7 @@ RSpec/NestedGroups:
     - 'spec/controllers/media_controller_spec.rb'
     - 'spec/controllers/whitehall_media_controller_spec.rb'
     - 'spec/lib/s3_storage_spec.rb'
+    - 'spec/lib/fake_s3_configuration_spec.rb'
     - 'spec/models/asset_spec.rb'
     - 'spec/models/whitehall_asset_spec.rb'
     - 'spec/workers/save_to_cloud_storage_worker_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -93,3 +93,4 @@ RSpec/SubjectStub:
 RSpec/DescribeClass:
   Exclude:
       - 'spec/lib/govuk_configuration_spec.rb'
+      - 'spec/lib/fake_s3_configuration_spec.rb'

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,5 @@ module AssetManager
   mattr_accessor :frame_options
   mattr_accessor :whitehall_frame_options
 
-  mattr_accessor :fake_s3_root
-  mattr_accessor :fake_s3_path_prefix
+  mattr_accessor :fake_s3
 end

--- a/config/initializers/fake_s3.rb
+++ b/config/initializers/fake_s3.rb
@@ -1,2 +1,3 @@
-AssetManager.fake_s3_root = Rails.root.join('fake-s3')
-AssetManager.fake_s3_path_prefix = '/fake-s3'
+require 'fake_s3_configuration'
+
+AssetManager.fake_s3 = FakeS3Configuration.new

--- a/config/initializers/govuk.rb
+++ b/config/initializers/govuk.rb
@@ -1,4 +1,0 @@
-require 'govuk_configuration'
-
-config = GovukConfiguration.new
-AssetManager.app_host = config.app_host

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get "/government/uploads/*path" => "whitehall_media#download"
 
   if Rails.env.development?
-    mount Rack::File.new(AssetManager.fake_s3_root), at: AssetManager.fake_s3_path_prefix, as: 'fake_s3'
+    mount Rack::File.new(AssetManager.fake_s3.root), at: AssetManager.fake_s3.path_prefix, as: 'fake_s3'
   end
 
   get "/healthcheck" => Proc.new { [200, { "Content-type" => "text/plain" }, ["OK"]] }

--- a/lib/fake_s3_configuration.rb
+++ b/lib/fake_s3_configuration.rb
@@ -1,0 +1,9 @@
+class FakeS3Configuration
+  def root
+    Rails.root.join('fake-s3')
+  end
+
+  def path_prefix
+    '/fake-s3'
+  end
+end

--- a/lib/fake_s3_configuration.rb
+++ b/lib/fake_s3_configuration.rb
@@ -14,6 +14,6 @@ class FakeS3Configuration
   end
 
   def host
-    @govuk_config.app_host
+    @govuk_config.app_host || 'http://localhost:3000'
   end
 end

--- a/lib/fake_s3_configuration.rb
+++ b/lib/fake_s3_configuration.rb
@@ -1,7 +1,8 @@
 require 'govuk_configuration'
 
 class FakeS3Configuration
-  def initialize(govuk_config = GovukConfiguration.new)
+  def initialize(env = ENV, govuk_config = GovukConfiguration.new)
+    @env = env
     @govuk_config = govuk_config
   end
 
@@ -14,6 +15,6 @@ class FakeS3Configuration
   end
 
   def host
-    @govuk_config.app_host || 'http://localhost:3000'
+    @env['FAKE_S3_HOST'] || @govuk_config.app_host || 'http://localhost:3000'
   end
 end

--- a/lib/fake_s3_configuration.rb
+++ b/lib/fake_s3_configuration.rb
@@ -1,9 +1,19 @@
+require 'govuk_configuration'
+
 class FakeS3Configuration
+  def initialize(govuk_config = GovukConfiguration.new)
+    @govuk_config = govuk_config
+  end
+
   def root
     Rails.root.join('fake-s3')
   end
 
   def path_prefix
     '/fake-s3'
+  end
+
+  def host
+    @govuk_config.app_host
   end
 end

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -6,8 +6,8 @@ class GovukConfiguration
   def app_host
     app_name = @env.fetch('GOVUK_APP_NAME')
     app_domain = @env.fetch('GOVUK_APP_DOMAIN')
-    AssetManager.app_host = "http://#{app_name}.#{app_domain}"
+    "http://#{app_name}.#{app_domain}"
   rescue KeyError
-    AssetManager.app_host = 'http://localhost:3000'
+    'http://localhost:3000'
   end
 end

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -4,14 +4,10 @@ class GovukConfiguration
   end
 
   def app_host
-    app_name = @env.fetch('GOVUK_APP_NAME', nil)
-    app_domain = @env.fetch('GOVUK_APP_DOMAIN', nil)
-    if app_name && app_domain
-      "http://#{app_name}.#{app_domain}"
-    elsif app_domain
-      "http://#{app_domain}"
-    else
-      "http://localhost:3000"
-    end
+    app_name = @env.fetch('GOVUK_APP_NAME')
+    app_domain = @env.fetch('GOVUK_APP_DOMAIN')
+    AssetManager.app_host = "http://#{app_name}.#{app_domain}"
+  rescue KeyError
+    AssetManager.app_host = 'http://localhost:3000'
   end
 end

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -8,6 +8,6 @@ class GovukConfiguration
     app_domain = @env.fetch('GOVUK_APP_DOMAIN')
     "http://#{app_name}.#{app_domain}"
   rescue KeyError
-    'http://localhost:3000'
+    nil
   end
 end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -9,7 +9,7 @@ class S3Storage
     if bucket_name.present?
       new(bucket_name)
     elsif Rails.env.development?
-      Fake.new(AssetManager.fake_s3_root)
+      Fake.new(AssetManager.fake_s3.root)
     else
       Null.new
     end

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -16,7 +16,7 @@ class S3Storage
       relative_path = relative_path_for(asset)
       url_path_prefix = Pathname.new(AssetManager.fake_s3.path_prefix)
       url_path = url_path_prefix.join(relative_path)
-      "#{AssetManager.app_host}#{url_path}"
+      "#{AssetManager.fake_s3.host}#{url_path}"
     end
 
     def exists?(asset)

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -14,7 +14,7 @@ class S3Storage
 
     def presigned_url_for(asset, **_args)
       relative_path = relative_path_for(asset)
-      url_path_prefix = Pathname.new(AssetManager.fake_s3_path_prefix)
+      url_path_prefix = Pathname.new(AssetManager.fake_s3.path_prefix)
       url_path = url_path_prefix.join(relative_path)
       "#{AssetManager.app_host}#{url_path}"
     end

--- a/spec/lib/fake_s3_configuration_spec.rb
+++ b/spec/lib/fake_s3_configuration_spec.rb
@@ -20,11 +20,23 @@ RSpec.describe FakeS3Configuration do
 
   describe '#host' do
     before do
-      allow(govuk_config).to receive(:app_host).and_return('http://example.com')
+      allow(govuk_config).to receive(:app_host).and_return(app_host)
     end
 
-    it 'returns host to be used in fake S3 URLs' do
-      expect(config.host).to eq('http://example.com')
+    context 'when app_host is set' do
+      let(:app_host) { 'http://example.com' }
+
+      it 'returns fake S3 host obtained from GOV.UK app_host' do
+        expect(config.host).to eq('http://example.com')
+      end
+    end
+
+    context 'when app_host is not set' do
+      let(:app_host) { nil }
+
+      it 'returns default fake S3 host for Rails app in development' do
+        expect(config.host).to eq('http://localhost:3000')
+      end
     end
   end
 end

--- a/spec/lib/fake_s3_configuration_spec.rb
+++ b/spec/lib/fake_s3_configuration_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 require 'fake_s3_configuration'
 
 RSpec.describe FakeS3Configuration do
-  subject(:config) { described_class.new }
+  subject(:config) { described_class.new(govuk_config) }
+
+  let(:govuk_config) { instance_double(GovukConfiguration) }
 
   describe '#root' do
     it 'returns directory path to fake S3 storage' do
@@ -13,6 +15,16 @@ RSpec.describe FakeS3Configuration do
   describe '#path_prefix' do
     it 'returns path prefix to fake S3 route' do
       expect(config.path_prefix).to eq('/fake-s3')
+    end
+  end
+
+  describe '#host' do
+    before do
+      allow(govuk_config).to receive(:app_host).and_return('http://example.com')
+    end
+
+    it 'returns host to be used in fake S3 URLs' do
+      expect(config.host).to eq('http://example.com')
     end
   end
 end

--- a/spec/lib/fake_s3_configuration_spec.rb
+++ b/spec/lib/fake_s3_configuration_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'fake_s3_configuration'
+
+RSpec.describe FakeS3Configuration do
+  subject(:config) { described_class.new }
+
+  describe '#root' do
+    it 'returns directory path to fake S3 storage' do
+      expect(config.root).to eq(Rails.root.join('fake-s3'))
+    end
+  end
+
+  describe '#path_prefix' do
+    it 'returns path prefix to fake S3 route' do
+      expect(config.path_prefix).to eq('/fake-s3')
+    end
+  end
+end

--- a/spec/lib/fake_s3_configuration_spec.rb
+++ b/spec/lib/fake_s3_configuration_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 require 'fake_s3_configuration'
 
 RSpec.describe FakeS3Configuration do
-  subject(:config) { described_class.new(govuk_config) }
+  subject(:config) { described_class.new(env, govuk_config) }
 
+  let(:env) { {} }
   let(:govuk_config) { instance_double(GovukConfiguration) }
 
   describe '#root' do
@@ -19,23 +20,33 @@ RSpec.describe FakeS3Configuration do
   end
 
   describe '#host' do
-    before do
-      allow(govuk_config).to receive(:app_host).and_return(app_host)
-    end
+    context 'when FAKE_S3_HOST is set in environment' do
+      let(:env) { { 'FAKE_S3_HOST' => 'http://fake-s3-host' } }
 
-    context 'when app_host is set' do
-      let(:app_host) { 'http://example.com' }
-
-      it 'returns fake S3 host obtained from GOV.UK app_host' do
-        expect(config.host).to eq('http://example.com')
+      it 'returns fake S3 host obtained from FAKE_S3_HOST value' do
+        expect(config.host).to eq('http://fake-s3-host')
       end
     end
 
-    context 'when app_host is not set' do
-      let(:app_host) { nil }
+    context 'when FAKE_S3_HOST is not set in environment' do
+      before do
+        allow(govuk_config).to receive(:app_host).and_return(app_host)
+      end
 
-      it 'returns default fake S3 host for Rails app in development' do
-        expect(config.host).to eq('http://localhost:3000')
+      context 'when app_host is set' do
+        let(:app_host) { 'http://example.com' }
+
+        it 'returns fake S3 host obtained from GOV.UK app_host' do
+          expect(config.host).to eq('http://example.com')
+        end
+      end
+
+      context 'when app_host is not set' do
+        let(:app_host) { nil }
+
+        it 'returns default fake S3 host for Rails app in development' do
+          expect(config.host).to eq('http://localhost:3000')
+        end
       end
     end
   end

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe GovukConfiguration do
         }
       }
 
-      it 'returns default application host for Rails app in development' do
-        expect(config.app_host).to eq('http://localhost:3000')
+      it 'returns nil' do
+        expect(config.app_host).to be_nil
       end
     end
 
@@ -37,16 +37,16 @@ RSpec.describe GovukConfiguration do
         }
       }
 
-      it 'returns default application host for Rails app in development' do
-        expect(config.app_host).to eq('http://localhost:3000')
+      it 'returns nil' do
+        expect(config.app_host).to be_nil
       end
     end
 
     context 'when environment does not include GOVUK_APP_NAME or GOVUK_APP_DOMAIN' do
       let(:env) { {} }
 
-      it 'returns default application host for Rails app in development' do
-        expect(config.app_host).to eq('http://localhost:3000')
+      it 'returns nil' do
+        expect(config.app_host).to be_nil
       end
     end
   end

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe GovukConfiguration do
     context 'when environment only includes GOVUK_APP_DOMAIN' do
       let(:env) {
         {
-          'GOVUK_APP_DOMAIN' => '127.0.0.1:9292'
+          'GOVUK_APP_DOMAIN' => 'dev.gov.uk'
         }
       }
 
-      it 'returns application host based on app domain' do
-        expect(config.app_host).to eq('http://127.0.0.1:9292')
+      it 'returns default application host for Rails app in development' do
+        expect(config.app_host).to eq('http://localhost:3000')
       end
     end
 

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe S3Storage::Fake do
       url = storage.presigned_url_for(asset)
       path = URI(url).path
 
-      expect(path).to start_with(AssetManager.fake_s3_path_prefix)
+      expect(path).to start_with(AssetManager.fake_s3.path_prefix)
     end
 
     it 'returns URL with path ending with relative path to asset' do

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe S3Storage::Fake do
       expect(path).to end_with(relative_path_to_asset.to_s)
     end
 
-    it 'returns URL with host set to AssetManager.app_host' do
+    it 'returns URL with host set to AssetManager.fake_s3.host' do
       url = storage.presigned_url_for(asset)
       scheme, domain, port = URI(url).select(:scheme, :host, :port)
       host = "#{scheme}://#{domain}:#{port}"
 
-      expect(host).to eq(AssetManager.app_host)
+      expect(host).to eq(AssetManager.fake_s3.host)
     end
   end
 


### PR DESCRIPTION
Following on from #333, I realised I still couldn't do what I need to do in the `publishing-e2e-tests` project. So I've re-jigged things a bit and now it's possible to override the host used by the fake S3 "service" using the `FAKE_S3_HOST` environment variable.

I want to be able to do this in the `publishing-e2e-tests` project, because I want to set the fake S3 host to http://localhost and that isn't possible without this change.