### PR TITLE
POST /whitehall_assets replaces existing asset

### DIFF
--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -1,5 +1,9 @@
 class WhitehallAssetsController < ApplicationController
   def create
+    if existing_asset_with_this_legacy_url_path.exists?
+      existing_asset_with_this_legacy_url_path.destroy
+    end
+
     @asset = WhitehallAsset.new(asset_params)
 
     if @asset.save
@@ -24,5 +28,9 @@ private
     params
       .require(:asset)
       .permit(:file, :legacy_url_path, :legacy_etag, :legacy_last_modified)
+  end
+
+  def existing_asset_with_this_legacy_url_path
+    WhitehallAsset.where(legacy_url_path: asset_params[:legacy_url_path])
   end
 end

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe WhitehallAssetsController, type: :controller do
   end
 
   describe "POST create" do
-    context "a valid asset" do
-      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata) }
+    let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata) }
 
+    context "a valid asset" do
       it "is persisted" do
         post :create, params: { asset: attributes }
 
@@ -96,7 +96,6 @@ RSpec.describe WhitehallAssetsController, type: :controller do
     end
 
     context "an asset with the same legacy_url_path as an existing asset" do
-      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata) }
       let!(:existing_asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: attributes[:legacy_url_path]) }
 
       it "marks the existing asset as deleted" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context "an asset with the same legacy_url_path as an existing asset" do
+      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata) }
+      let!(:existing_asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: attributes[:legacy_url_path]) }
+
+      it "marks the existing asset as deleted" do
+        post :create, params: { asset: attributes }
+
+        expect(existing_asset.reload).to be_deleted
+      end
+    end
   end
 
   describe 'GET show' do


### PR DESCRIPTION
Fixes: #229 

Currently in Whitehall images stored using the `ImageUploader` are
stored on NFS only. We want to change Whitehall to store these images
in Asset Manager.

In some circumstances an image using this Uploader (such as the image
associated with a Person[1]) can be replaced. For example

1. A new person is created with an image `foo.jpg`
2. The person is saved
3. The person is edited to have a different image with the same
filename `foo.jpg`
4. The person is saved again

In this sequence of events the new image will be available at the same
URL as the image added in step 1. The image added in step 1. will be
deleted from the file system.

In order to allow this behaviour in Asset Manager this commit modifies
`POST /whitehall_assets` to check whether an asset with the same
`legacy_url_path` already exists and soft-deletes it before creating
the new asset.

This will allow us to maintain the desirable existing behaviour from
Whitehall (a new image served at an existing URL) and also allows the
replaced image to be recovered if required[2].

[1] /government/admin/people/ in Whitehall Admin