### PR TITLE
Add env vars to help end-to-end tests run in rails production mode

### DIFF
--- a/lib/s3_configuration.rb
+++ b/lib/s3_configuration.rb
@@ -10,7 +10,7 @@ class S3Configuration
   end
 
   def bucket_name
-    if Rails.env.production?
+    if Rails.env.production? && !ENV['USE_FAKE_S3']
       @env.fetch('AWS_S3_BUCKET_NAME')
     else
       @env['AWS_S3_BUCKET_NAME']


### PR DESCRIPTION
Hey :wave:,

To help us enable rails production mode when running alphagov/publishing-e2e-tests we've added a new ENV var for using the fake S3 mode while still being in rails prod mode.

Similarly the latest version of gds-sso introduces a similar variable for using mock SSO and also being in rails production mode.