### PR TITLE
Fix Whitehall asset lookup when URL path has no format/file extension

### DIFF
--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,6 +1,7 @@
 class WhitehallMediaController < BaseMediaController
   def download
-    path = "/government/uploads/#{params[:path]}.#{params[:format]}"
+    path = "/government/uploads/#{params[:path]}"
+    path += ".#{params[:format]}" if params[:format].present?
     asset = WhitehallAsset.find_by(legacy_url_path: path)
 
     if asset.unscanned?

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
         get :download, params: { path: path, format: format }
       end
+
+      context 'and legacy_url_path has no format' do
+        let(:legacy_url_path) { "/government/uploads/#{path}" }
+
+        it "proxies asset to S3 via Nginx" do
+          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+          get :download, params: { path: path, format: nil }
+        end
+      end
     end
 
     context 'when asset is unscanned image' do


### PR DESCRIPTION
[We were re-constructing the `legacy_url_path` to search for by assuming there was a format][1]. Thus if an asset had no file extension, e.g. `/government/uploads/foo`, we were attempting to lookup the asset using `/government/uploads/foo.` (note the trailing full-stop). This did not find the asset and the app responded with a `404 Not Found`.

[1]:
https://github.com/alphagov/asset-manager/blob/c14c324b4f41467ab6356599bc95ea92b34b99f6/app/controllers/whitehall_media_controller.rb#L3-L4