### PR TITLE
Remove unused S3 virtual host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ All assets are uploaded to the S3 bucket via a separate `govuk_sidekiq` job trig
 ##### AWS
 
 * `AWS_S3_BUCKET_NAME` - name of bucket where assets are to be stored (required in production)
-* `AWS_S3_USE_VIRTUAL_HOST` - generate URLs for virtual host (assumes CNAME has been setup for bucket)
 
 ### Testing
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,6 @@ module AssetManager
   mattr_accessor :app_host
 
   mattr_accessor :aws_s3_bucket_name
-  mattr_accessor :aws_s3_use_virtual_host
 
   mattr_accessor :carrier_wave_store_base_dir
 

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -4,8 +4,6 @@ AssetManager.aws_s3_bucket_name = if Rails.env.production?
                                     ENV['AWS_S3_BUCKET_NAME']
                                   end
 
-AssetManager.aws_s3_use_virtual_host = ENV['AWS_S3_USE_VIRTUAL_HOST'].present?
-
 Aws.config.update(
   logger: Rails.logger
 )

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -28,10 +28,7 @@ class S3Storage
   end
 
   def presigned_url_for(asset, http_method: 'GET')
-    options = {
-      expires_in: 1.minute
-    }
-    object_for(asset).presigned_url(http_method, options)
+    object_for(asset).presigned_url(http_method, expires_in: 1.minute)
   end
 
   def exists?(asset)

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -29,8 +29,7 @@ class S3Storage
 
   def presigned_url_for(asset, http_method: 'GET')
     options = {
-      expires_in: 1.minute,
-      virtual_host: AssetManager.aws_s3_use_virtual_host
+      expires_in: 1.minute
     }
     object_for(asset).presigned_url(http_method, options)
   end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -124,18 +124,16 @@ RSpec.describe S3Storage do
   end
 
   describe '#presigned_url_for' do
-    context 'when configured not to use virtual host' do
-      it 'returns presigned URL for GET request to asset on S3 by default' do
-        allow(s3_object).to receive(:presigned_url)
-          .with('GET', expires_in: 1.minute).and_return('presigned-url')
-        expect(subject.presigned_url_for(asset)).to eq('presigned-url')
-      end
+    it 'returns presigned URL for GET request to asset on S3 by default' do
+      allow(s3_object).to receive(:presigned_url)
+        .with('GET', expires_in: 1.minute).and_return('presigned-url')
+      expect(subject.presigned_url_for(asset)).to eq('presigned-url')
+    end
 
-      it 'returns presigned URL for HEAD request to asset on S3 when http_method specified' do
-        allow(s3_object).to receive(:presigned_url)
-          .with('HEAD', expires_in: 1.minute).and_return('presigned-url')
-        expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
-      end
+    it 'returns presigned URL for HEAD request to asset on S3 when http_method specified' do
+      allow(s3_object).to receive(:presigned_url)
+        .with('HEAD', expires_in: 1.minute).and_return('presigned-url')
+      expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
     end
   end
 

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -124,33 +124,17 @@ RSpec.describe S3Storage do
   end
 
   describe '#presigned_url_for' do
-    before do
-      allow(AssetManager).to receive(:aws_s3_use_virtual_host).and_return(use_virtual_host)
-    end
-
     context 'when configured not to use virtual host' do
-      let(:use_virtual_host) { false }
-
       it 'returns presigned URL for GET request to asset on S3 by default' do
         allow(s3_object).to receive(:presigned_url)
-          .with('GET', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+          .with('GET', expires_in: 1.minute).and_return('presigned-url')
         expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
 
       it 'returns presigned URL for HEAD request to asset on S3 when http_method specified' do
         allow(s3_object).to receive(:presigned_url)
-          .with('HEAD', expires_in: 1.minute, virtual_host: false).and_return('presigned-url')
+          .with('HEAD', expires_in: 1.minute).and_return('presigned-url')
         expect(subject.presigned_url_for(asset, http_method: 'HEAD')).to eq('presigned-url')
-      end
-    end
-
-    context 'when configured to use virtual host' do
-      let(:use_virtual_host) { true }
-
-      it 'returns presigned URL for asset on S3 using virtual host' do
-        allow(s3_object).to receive(:presigned_url)
-          .with('GET', expires_in: 1.minute, virtual_host: true).and_return('presigned-url')
-        expect(subject.presigned_url_for(asset)).to eq('presigned-url')
       end
     end
   end


### PR DESCRIPTION
This option was [added for experimental use in development only][1] and has never been enabled in any other environments. Although eventually we might end up wanting to use this functionality, at the moment it's just making the code more complicated for no good reason.

[1]: https://github.com/alphagov/asset-manager/commit/552e396ae5200c38852674b7dafcdc65467b5cb5