### PR TITLE
Prevent nginx unnecessarily downloading assets from S3

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -4,23 +4,25 @@ class BaseMediaController < ApplicationController
 protected
 
   def proxy_to_s3_via_nginx(asset)
+    headers['ETag'] = %{"#{asset.etag}"}
+    headers['Last-Modified'] = asset.last_modified.httpdate
+    headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
+
     last_modified_from_request = request.headers['If-Modified-Since']
     etag_from_request = request.headers['If-None-Match']
 
     request_is_fresh = false
     if last_modified_from_request || etag_from_request
       request_is_fresh = true
-      request_is_fresh &&= (Time.parse(last_modified_from_request) >= asset.last_modified) if last_modified_from_request
-      request_is_fresh &&= (etag_from_request == %{"#{asset.etag}"}) if etag_from_request
+      request_is_fresh &&= (Time.parse(last_modified_from_request) >= Time.parse(headers['Last-Modified'])) if last_modified_from_request
+      request_is_fresh &&= (etag_from_request == headers['ETag']) if etag_from_request
     end
 
     unless request_is_fresh
       url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
       headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
     end
-    headers['ETag'] = %{"#{asset.etag}"}
-    headers['Last-Modified'] = asset.last_modified.httpdate
-    headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
+
     head :ok, content_type: asset.content_type
   end
 end

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -8,17 +8,7 @@ protected
     headers['Last-Modified'] = asset.last_modified.httpdate
     headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)
 
-    last_modified_from_request = request.headers['If-Modified-Since']
-    etag_from_request = request.headers['If-None-Match']
-
-    request_is_fresh = false
-    if last_modified_from_request || etag_from_request
-      request_is_fresh = true
-      request_is_fresh &&= (Time.parse(last_modified_from_request) >= Time.parse(headers['Last-Modified'])) if last_modified_from_request
-      request_is_fresh &&= (etag_from_request == headers['ETag']) if etag_from_request
-    end
-
-    unless request_is_fresh
+    unless request.fresh?(response)
       url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
       headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
     end

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -4,8 +4,20 @@ class BaseMediaController < ApplicationController
 protected
 
   def proxy_to_s3_via_nginx(asset)
-    url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
-    headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
+    last_modified_from_request = request.headers['If-Modified-Since']
+    etag_from_request = request.headers['If-None-Match']
+
+    request_is_fresh = false
+    if last_modified_from_request || etag_from_request
+      request_is_fresh = true
+      request_is_fresh &&= (Time.parse(last_modified_from_request) >= asset.last_modified) if last_modified_from_request
+      request_is_fresh &&= (etag_from_request == %{"#{asset.etag}"}) if etag_from_request
+    end
+
+    unless request_is_fresh
+      url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
+      headers['X-Accel-Redirect'] = "/cloud-storage-proxy/#{url}"
+    end
     headers['ETag'] = %{"#{asset.etag}"}
     headers['Last-Modified'] = asset.last_modified.httpdate
     headers['Content-Disposition'] = AssetManager.content_disposition.header_for(asset)


### PR DESCRIPTION
This should avoid the problem captured in issue #238 ("Binary file content being displaying in Internet Explorer").

We believe that the problem was being triggered when Fastly made a conditional GET request for an asset that it had stored in its cache. Rails (or more specifically, [`Rack::ConditionalGet`][1]) would respond with a 304 Not Modified and an empty `Content-Type` and empty `Content-Length` header. This would've been fine if it didn't also send the `X-Accel-Redirect` header. The presence of this header was telling Nginx to request the file from S3 again. Nginx would then send a 200 response containing the asset but with an empty `Content-Type` header!

By not sending the `X-Accel-Redirect` header along with a 304 response, we ensure that Nginx passes the 304 back to Fastly as expected.

Note that I test-drove a hand-rolled implementation of `request.fresh?(response)` to give myself confidence that it was behaving as I expected, before then switching to the Rails implementation.

[1]: https://github.com/rack/rack/blob/master/lib/rack/conditional_get.rb