### PR TITLE
Increase Max option for RSpec/NestedGroups cop from 2 -> 4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
+
+RSpec/NestedGroups:
+  Max: 4

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,14 +48,8 @@ RSpec/NamedSubject:
 # Configuration parameters: Max.
 RSpec/NestedGroups:
   Exclude:
-    - 'spec/controllers/assets_controller_spec.rb'
-    - 'spec/controllers/base_media_controller_spec.rb'
-    - 'spec/controllers/media_controller_spec.rb'
-    - 'spec/controllers/whitehall_media_controller_spec.rb'
-    - 'spec/lib/fake_s3_configuration_spec.rb'
-    - 'spec/lib/s3_storage_spec.rb'
-    - 'spec/models/asset_spec.rb'
-    - 'spec/models/whitehall_asset_spec.rb'
+    - spec/lib/s3_storage_spec.rb
+    - spec/models/whitehall_asset_spec.rb
 
 # Offense count: 13
 # Configuration parameters: Strict, EnforcedStyle, SupportedStyles.


### PR DESCRIPTION
I was triggering violations of this cop quite regularly. I think the default value of 2 is a bit draconian and rather than continuing to add files to the exclusion list, I think it's more sensible to bump up the value to 4.

Meanwhile I've opened [an issue][1] to suggest this should become the default for govuk-lint.

[1]: https://github.com/alphagov/govuk-lint/issues/91