### PR TITLE
Avoid "X-Accel-Mapping header missing" warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,8 +32,6 @@ module AssetManager
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
 
-    config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
-
     config.assets.prefix = '/asset-manager'
   end
 


### PR DESCRIPTION
Since alphagov/asset-manager#328 the Rails app only ever proxies asset requests to S3; it no longer instructs Nginx to serve asset files from NFS. And so this setting is no longer needed. It seems as if it is this setting which is causing `Rack::Sendfile` to emit the warning mentioned above.

We're planning to remove the redundant `Sendfile`-related config from the asset-manager Nginx virtual host in alphagov/govuk-puppet#6971, but this change doesn't need to wait until that is deployed/applied.

Note that The x_sendfile_header configuration option was originally set to `X-Sendfile` in [this commit][1] and then to `X-Accel-Redirect` in [this commit][2].

[1]: https://github.com/alphagov/asset-manager/commit/9be379ed8a8f5622a67151884325d21d52c8f3a3
[2]: https://github.com/alphagov/asset-manager/commit/9be379ed8a8f5622a67151884325d21d52c8f3a3
