### PR TITLE
Add in Healthcheck to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
Moving this check from the docker-compose.yml in publishing-e2e-tests to each repo makes the Dockerfile more useful if used outside of publishing-e2e-tests.