### PR TITLE
Allow use of fake S3 in non-development environments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,6 +49,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Exclude:
     - spec/lib/s3_storage_spec.rb
+    - spec/lib/s3_configuration_spec.rb
     - spec/models/whitehall_asset_spec.rb
 
 # Offense count: 13

--- a/lib/s3_configuration.rb
+++ b/lib/s3_configuration.rb
@@ -1,6 +1,6 @@
 class S3Configuration
-  def self.build
-    config = new
+  def self.build(env = ENV)
+    config = new(env)
     config.check!
     config
   end
@@ -10,18 +10,18 @@ class S3Configuration
   end
 
   def bucket_name
-    if Rails.env.production?
-      @env.fetch('AWS_S3_BUCKET_NAME')
-    else
-      @env['AWS_S3_BUCKET_NAME']
-    end
+    @env['AWS_S3_BUCKET_NAME']
   end
 
   def configured?
     bucket_name.present?
   end
 
-  alias_method :check!, :configured?
+  def check!
+    if !configured? && Rails.env.production?
+      raise 'S3 bucket name not set in production environment'
+    end
+  end
 
   def fake?
     !configured? && Rails.env.development?

--- a/lib/s3_configuration.rb
+++ b/lib/s3_configuration.rb
@@ -18,7 +18,7 @@ class S3Configuration
   end
 
   def check!
-    if !configured? && !allow_fake?
+    unless configured? || allow_fake?
       raise 'S3 bucket name not set'
     end
   end

--- a/lib/s3_configuration.rb
+++ b/lib/s3_configuration.rb
@@ -24,6 +24,6 @@ class S3Configuration
   end
 
   def fake?
-    !configured? && Rails.env.development?
+    !configured? && !Rails.env.production?
   end
 end

--- a/lib/s3_configuration.rb
+++ b/lib/s3_configuration.rb
@@ -18,12 +18,17 @@ class S3Configuration
   end
 
   def check!
-    if !configured? && Rails.env.production?
-      raise 'S3 bucket name not set in production environment'
+    if !configured? && !allow_fake?
+      raise 'S3 bucket name not set'
     end
   end
 
   def fake?
-    !configured? && !Rails.env.production?
+    !configured? && allow_fake?
+  end
+
+  def allow_fake?
+    !Rails.env.production? ||
+      @env['ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS'].present?
   end
 end

--- a/spec/lib/s3_configuration_spec.rb
+++ b/spec/lib/s3_configuration_spec.rb
@@ -91,20 +91,20 @@ RSpec.describe S3Configuration do
 
   describe '#fake?' do
     before do
-      allow(Rails.env).to receive(:development?).and_return(development)
+      allow(Rails.env).to receive(:production?).and_return(production)
     end
 
     context 'when not configured' do
-      context 'when Rails environment is development' do
-        let(:development) { true }
+      context 'when Rails environment is not production' do
+        let(:production) { false }
 
         it 'is fake' do
           expect(config).to be_fake
         end
       end
 
-      context 'when Rails environment is not development' do
-        let(:development) { false }
+      context 'when Rails environment is production' do
+        let(:production) { true }
 
         it 'is not fake' do
           expect(config).not_to be_fake
@@ -115,16 +115,16 @@ RSpec.describe S3Configuration do
     context 'when configured' do
       let(:env) { { 'AWS_S3_BUCKET_NAME' => 's3-bucket-name' } }
 
-      context 'when Rails environment is development' do
-        let(:development) { true }
+      context 'when Rails environment is not production' do
+        let(:production) { false }
 
         it 'is not fake' do
           expect(config).not_to be_fake
         end
       end
 
-      context 'when Rails environment is not development' do
-        let(:development) { false }
+      context 'when Rails environment is production' do
+        let(:production) { true }
 
         it 'is not fake' do
           expect(config).not_to be_fake

--- a/spec/lib/s3_configuration_spec.rb
+++ b/spec/lib/s3_configuration_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe S3Configuration do
     end
 
     it 'returns instance of configuration' do
-      expect(config_class.build).to be_instance_of(config_class)
+      expect(config_class.build(env)).to be_instance_of(config_class)
     end
 
     context 'when Rails environment is production' do
@@ -24,31 +24,16 @@ RSpec.describe S3Configuration do
 
       context 'when AWS_S3_BUCKET_NAME env var is not present' do
         it 'fails fast by raising an exception' do
-          expect { config_class.build }.to raise_error(KeyError)
+          expect { config_class.build(env) }
+            .to raise_error('S3 bucket name not set in production environment')
         end
       end
-    end
-  end
-
-  describe '#bucket_name' do
-    before do
-      allow(Rails.env).to receive(:production?).and_return(production)
-    end
-
-    context 'when Rails environment is production' do
-      let(:production) { true }
 
       context 'when AWS_S3_BUCKET_NAME env var is present' do
         let(:env) { { 'AWS_S3_BUCKET_NAME' => 's3-bucket-name' } }
 
-        it 'returns S3 bucket name' do
-          expect(config.bucket_name).to eq('s3-bucket-name')
-        end
-      end
-
-      context 'when AWS_S3_BUCKET_NAME env var is not present' do
-        it 'fails fast by raising an exception' do
-          expect { config.bucket_name }.to raise_error(KeyError)
+        it 'does not fail fast' do
+          expect { config_class.build(env) }.not_to raise_error
         end
       end
     end
@@ -56,18 +41,34 @@ RSpec.describe S3Configuration do
     context 'when Rails environment is not production' do
       let(:production) { false }
 
-      context 'when AWS_S3_BUCKET_NAME env var is present' do
-        let(:env) { { 'AWS_S3_BUCKET_NAME' => 's3-bucket-name' } }
-
-        it 'returns S3 bucket name' do
-          expect(config.bucket_name).to eq('s3-bucket-name')
+      context 'when AWS_S3_BUCKET_NAME env var is not present' do
+        it 'does not fail fast' do
+          expect { config_class.build(env) }.not_to raise_error
         end
       end
 
-      context 'when AWS_S3_BUCKET_NAME env var is not present' do
-        it 'returns nil and does not fail fast' do
-          expect(config.bucket_name).to eq(nil)
+      context 'when AWS_S3_BUCKET_NAME env var is present' do
+        let(:env) { { 'AWS_S3_BUCKET_NAME' => 's3-bucket-name' } }
+
+        it 'does not fail fast' do
+          expect { config_class.build(env) }.not_to raise_error
         end
+      end
+    end
+  end
+
+  describe '#bucket_name' do
+    context 'when AWS_S3_BUCKET_NAME env var is present' do
+      let(:env) { { 'AWS_S3_BUCKET_NAME' => 's3-bucket-name' } }
+
+      it 'returns S3 bucket name' do
+        expect(config.bucket_name).to eq('s3-bucket-name')
+      end
+    end
+
+    context 'when AWS_S3_BUCKET_NAME env var is not present' do
+      it 'returns nil' do
+        expect(config.bucket_name).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
The motivation behind this is two-fold:

1. I want to be able to use the fake S3 functionality in the Rails test environment in order to write some integration testing which involve uploading to S3.
2. The team working on the publishing-e2e-tests project want to be able to use the fake S3 functionality in the tests when running the app in the Rails production environment.

The idea is to make the methods on `S3Configuration` as self-explanatory as possible and to make it hard to enable the fake S3 functionality in production by accident.

I've intentionally not added the new environment variable, `ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS` to the documentation, because I don't want to encourage its use and in any case, its name makes its purpose pretty clear.

This supersedes #338.