### PR TITLE
Introduce uploaded states for assets

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,7 +29,7 @@ protected
 
   def asset_servable?
     asset.filename_valid?(params[:filename]) &&
-      asset.clean? &&
+      (asset.clean? || asset.uploaded? || asset.not_uploaded?) &&
       asset.accessible_by?(current_user) &&
       asset.mainstream?
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -52,6 +52,14 @@ class Asset
     event :scanned_infected do
       transition any => :infected
     end
+
+    event :upload_success do
+      transition %i(clean uploaded not_uploaded) => :uploaded
+    end
+
+    event :upload_failure do
+      transition %i(clean uploaded not_uploaded) => :not_uploaded
+    end
   end
 
   def public_url_path

--- a/app/workers/asset_upload_state_worker.rb
+++ b/app/workers/asset_upload_state_worker.rb
@@ -1,0 +1,15 @@
+require 'services'
+
+class AssetUploadStateWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    if Services.cloud_storage.exists?(asset)
+      asset.upload_success!
+    else
+      asset.upload_failure!
+    end
+  end
+end

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -6,5 +6,9 @@ class SaveToCloudStorageWorker
   def perform(asset_id)
     asset = Asset.find(asset_id)
     Services.cloud_storage.save(asset)
+    asset.upload_success!
+  rescue CloudStorage::ObjectUploadFailedError
+    asset.upload_failure!
+    raise
   end
 end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,0 +1,25 @@
+class AssetProcessor
+  def initialize(scope: Asset, output: STDOUT, report_progress_every: 1000)
+    @scope = scope
+    @output = output
+    @report_progress_every = report_progress_every
+  end
+
+  def process_all_assets_with
+    @output.sync = true
+    asset_ids = @scope.pluck(:id).to_a
+    total = asset_ids.count
+    asset_ids.each_with_index do |asset_id, index|
+      count = index + 1
+      percent = "%0.0f" % (count / total.to_f * 100)
+      if (count % @report_progress_every).zero?
+        @output.puts "#{count} of #{total} (#{percent}%) assets"
+      end
+      yield asset_id.to_s
+    end
+    unless (total % @report_progress_every).zero?
+      @output.puts "#{total} of #{total} (100%) assets"
+    end
+    @output.puts "\nFinished!"
+  end
+end

--- a/lib/cloud_storage.rb
+++ b/lib/cloud_storage.rb
@@ -1,0 +1,4 @@
+class CloudStorage
+  ObjectNotFoundError = Class.new(StandardError)
+  ObjectUploadFailedError = Class.new(StandardError)
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -22,7 +22,11 @@ class S3Storage
     metadata = exists?(asset) ? metadata_for(asset) : {}
     if force || metadata['md5-hexdigest'] != asset.md5_hexdigest
       metadata['md5-hexdigest'] = asset.md5_hexdigest
-      unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
+      begin
+        unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
+          raise ObjectUploadFailedError
+        end
+      rescue Aws::S3::MultipartUploadError
         raise ObjectUploadFailedError
       end
     end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,8 +1,9 @@
+require 'cloud_storage'
 require 's3_storage/fake'
 
 class S3Storage
-  ObjectNotFoundError = Class.new(StandardError)
-  ObjectUploadFailedError = Class.new(StandardError)
+  ObjectNotFoundError = Class.new(CloudStorage::ObjectNotFoundError)
+  ObjectUploadFailedError = Class.new(CloudStorage::ObjectUploadFailedError)
 
   def self.build
     if AssetManager.s3.configured?

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -2,6 +2,7 @@ require 's3_storage/fake'
 
 class S3Storage
   ObjectNotFoundError = Class.new(StandardError)
+  ObjectUploadFailedError = Class.new(StandardError)
 
   def self.build
     if AssetManager.s3.configured?
@@ -21,7 +22,9 @@ class S3Storage
     metadata = exists?(asset) ? metadata_for(asset) : {}
     if force || metadata['md5-hexdigest'] != asset.md5_hexdigest
       metadata['md5-hexdigest'] = asset.md5_hexdigest
-      object_for(asset).upload_file(asset.file.path, metadata: metadata)
+      unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
+        raise ObjectUploadFailedError
+      end
     end
   end
 

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,0 +1,12 @@
+require 'services'
+require 'asset_processor'
+
+namespace :govuk_assets do
+  desc 'Set uploaded state for all clean assets (uploaded/not_uploaded)'
+  task set_uploaded_state_for_all_clean_assets: :environment do
+    processor = AssetProcessor.new(scope: Asset.where(state: 'clean'))
+    processor.process_all_assets_with do |asset_id|
+      AssetUploadStateWorker.perform_async(asset_id)
+    end
+  end
+end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -1,6 +1,45 @@
 require "rails_helper"
 
 RSpec.describe MediaController, type: :controller do
+  shared_examples 'handles valid asset request' do
+    it "proxies asset to S3 via Nginx" do
+      expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+      get :download, params
+    end
+
+    it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
+      get :download, params
+
+      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+    end
+
+    context "when the file name in the URL represents an old version" do
+      let(:old_file_name) { "an_old_filename.pdf" }
+
+      before do
+        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(asset).to receive(:filename_valid?).and_return(true)
+      end
+
+      it "redirects to the new file name" do
+        get :download, params: { id: asset, filename: old_file_name }
+
+        expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
+      end
+    end
+
+    context "when the file name in the URL is invalid" do
+      let(:invalid_file_name) { "invalid_file_name.pdf" }
+
+      it "responds with 404 Not Found" do
+        get :download, params: { id: asset, filename: invalid_file_name }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "GET 'download'" do
     let(:params) { { params: { id: asset, filename: asset.filename } } }
 
@@ -11,42 +50,19 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
 
-      it "proxies asset to S3 via Nginx" do
-        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+      include_examples('handles valid asset request')
+    end
 
-        get :download, params
-      end
+    context "with a valid uploaded file" do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
 
-      it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-        get :download, params
+      include_examples('handles valid asset request')
+    end
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
-      end
+    context "with a valid not_uploaded file" do
+      let(:asset) { FactoryBot.create(:not_uploaded_asset) }
 
-      context "when the file name in the URL represents an old version" do
-        let(:old_file_name) { "an_old_filename.pdf" }
-
-        before do
-          allow(Asset).to receive(:find).with(asset.id).and_return(asset)
-          allow(asset).to receive(:filename_valid?).and_return(true)
-        end
-
-        it "redirects to the new file name" do
-          get :download, params: { id: asset, filename: old_file_name }
-
-          expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
-        end
-      end
-
-      context "when the file name in the URL is invalid" do
-        let(:invalid_file_name) { "invalid_file_name.pdf" }
-
-        it "responds with 404 Not Found" do
-          get :download, params: { id: asset, filename: invalid_file_name }
-
-          expect(response).to have_http_status(:not_found)
-        end
-      end
+      include_examples('handles valid asset request')
     end
 
     context "with an unscanned file" do

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -8,6 +8,12 @@ FactoryBot.define do
   factory :infected_asset, parent: :asset do
     after :create, &:scanned_infected!
   end
+  factory :uploaded_asset, parent: :clean_asset do
+    after :create, &:upload_success!
+  end
+  factory :not_uploaded_asset, parent: :clean_asset do
+    after :create, &:upload_failure!
+  end
 
   factory :access_limited_asset, parent: :clean_asset do
     access_limited true

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'asset_processor'
+
+RSpec.describe AssetProcessor do
+  subject(:processor) { described_class.new(**args) }
+
+  let(:args) { { output: output, report_progress_every: report_progress_every } }
+  let(:output) { StringIO.new }
+  let(:report_progress_every) { 1 }
+
+  let!(:asset_1) { FactoryBot.create(:asset) }
+  let!(:asset_2) { FactoryBot.create(:asset) }
+
+  it 'iterates over all assets' do
+    asset_ids = []
+    processor.process_all_assets_with do |asset_id|
+      asset_ids << asset_id
+    end
+    expect(asset_ids).to contain_exactly(asset_1.id.to_s, asset_2.id.to_s)
+  end
+
+  it 'reports progress for every asset' do
+    processor.process_all_assets_with {}
+
+    expect(output_lines[0]).to eq('1 of 2 (50%) assets')
+    expect(output_lines[1]).to eq('2 of 2 (100%) assets')
+    expect(output_lines[2]).to be_blank
+    expect(output_lines[3]).to eq('Finished!')
+  end
+
+  context 'when report_progress_every option is set to 2' do
+    let(:report_progress_every) { 2 }
+
+    it 'only reports progress for every 2 assets' do
+      processor.process_all_assets_with {}
+
+      expect(output_lines[0]).to eq('2 of 2 (100%) assets')
+      expect(output_lines[1]).to be_blank
+      expect(output_lines[2]).to eq('Finished!')
+    end
+
+    context 'and number of assets is not a multiple of 2' do
+      before do
+        FactoryBot.create(:asset)
+      end
+
+      it 'still reports 100% progress' do
+        processor.process_all_assets_with {}
+
+        expect(output_lines[0]).to eq('2 of 3 (67%) assets')
+        expect(output_lines[1]).to eq('3 of 3 (100%) assets')
+        expect(output_lines[2]).to be_blank
+        expect(output_lines[3]).to eq('Finished!')
+      end
+    end
+  end
+
+  context 'when scope is set to deleted assets' do
+    let(:args) { { scope: scope, output: output } }
+    let(:scope) { Asset.deleted }
+
+    before do
+      asset_1.destroy
+    end
+
+    it 'iterates over all deleted assets' do
+      asset_ids = []
+      processor.process_all_assets_with do |asset_id|
+        asset_ids << asset_id
+      end
+      expect(asset_ids).to contain_exactly(asset_1.id.to_s)
+    end
+  end
+
+  def output_lines
+    @output_lines ||= begin
+      output.rewind
+      output.readlines.map(&:chomp)
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe S3Storage do
       end
     end
 
+    context 'when Aws::S3::Object#upload_file raises Aws::S3::MultipartUploadError' do
+      before do
+        allow(s3_object).to receive(:upload_file)
+          .and_raise(Aws::S3::MultipartUploadError.new('message', [RuntimeError.new]))
+      end
+
+      it 'raises ObjectUploadFailedError exception' do
+        expect { subject.save(asset) }
+          .to raise_error(S3Storage::ObjectUploadFailedError)
+      end
+    end
+
     context 'when S3 object already exists' do
       let(:default_metadata) { { 'md5-hexdigest' => md5_hexdigest } }
       let(:metadata) { default_metadata }

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -300,4 +300,16 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe S3Storage::ObjectNotFoundError do
+    it 'inherits from CloudStorage::ObjectNotFoundError' do
+      expect(subject).to be_kind_of(CloudStorage::ObjectNotFoundError)
+    end
+  end
+
+  describe S3Storage::ObjectUploadFailedError do
+    it 'inherits from CloudStorage::ObjectUploadFailedError' do
+      expect(subject).to be_kind_of(CloudStorage::ObjectUploadFailedError)
+    end
+  end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe S3Storage do
 
     it 'uploads file to S3 bucket' do
       expect(s3_object).to receive(:upload_file).with(asset.file.path, anything)
+        .and_return(true)
 
       subject.save(asset)
     end
@@ -69,8 +70,20 @@ RSpec.describe S3Storage do
       expected_metadata = { 'md5-hexdigest' => asset.md5_hexdigest }
       expect(s3_object).to receive(:upload_file)
         .with(anything, include(metadata: include(expected_metadata)))
+        .and_return(true)
 
       subject.save(asset)
+    end
+
+    context 'when Aws::S3::Object#upload_file returns false' do
+      before do
+        allow(s3_object).to receive(:upload_file).and_return(false)
+      end
+
+      it 'raises ObjectUploadFailedError exception' do
+        expect { subject.save(asset) }
+          .to raise_error(S3Storage::ObjectUploadFailedError)
+      end
     end
 
     context 'when S3 object already exists' do
@@ -94,7 +107,7 @@ RSpec.describe S3Storage do
 
         context 'but force options is set' do
           it 'uploads file to S3' do
-            expect(s3_object).to receive(:upload_file)
+            expect(s3_object).to receive(:upload_file).and_return(true)
 
             subject.save(asset, force: true)
           end
@@ -105,7 +118,7 @@ RSpec.describe S3Storage do
         let(:md5_hexdigest) { 'does-not-match' }
 
         it 'uploads file to S3' do
-          expect(s3_object).to receive(:upload_file)
+          expect(s3_object).to receive(:upload_file).and_return(true)
 
           subject.save(asset)
         end
@@ -115,7 +128,7 @@ RSpec.describe S3Storage do
           let(:metadata) { default_metadata.merge(existing_metadata) }
 
           it 'uploads file to S3 with existing metadata' do
-            expect(s3_object).to receive(:upload_file)
+            expect(s3_object).to receive(:upload_file).and_return(true)
               .with(anything, include(metadata: include(existing_metadata)))
 
             subject.save(asset)

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -501,4 +501,104 @@ RSpec.describe Asset, type: :model do
       expect(asset).to be_mainstream
     end
   end
+
+  describe '#upload_success!' do
+    context 'when asset is unscanned' do
+      let(:asset) { FactoryBot.create(:asset) }
+
+      it 'does not change asset state to uploaded' do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is clean' do
+      let(:asset) { FactoryBot.create(:clean_asset) }
+
+      it 'changes asset state to uploaded' do
+        asset.upload_success!
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+
+    context 'when asset is infected' do
+      let(:asset) { FactoryBot.create(:infected_asset) }
+
+      it 'does not change asset state to uploaded' do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is uploaded' do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      it 'leaves asset state as uploaded' do
+        asset.upload_success!
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+
+    context 'when asset is not_uploaded' do
+      let(:asset) { FactoryBot.create(:not_uploaded_asset) }
+
+      it 'changes asset state to uploaded' do
+        asset.upload_success!
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+  end
+
+  describe '#upload_failure!' do
+    context 'when asset is unscanned' do
+      let(:asset) { FactoryBot.create(:asset) }
+
+      it 'does not change asset state to not_uploaded' do
+        expect { asset.upload_failure! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is clean' do
+      let(:asset) { FactoryBot.create(:clean_asset) }
+
+      it 'changes asset state to not_uploaded' do
+        asset.upload_failure!
+
+        expect(asset.reload).to be_not_uploaded
+      end
+    end
+
+    context 'when asset is infected' do
+      let(:asset) { FactoryBot.create(:infected_asset) }
+
+      it 'does not change asset state to not_uploaded' do
+        expect { asset.upload_failure! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is uploaded' do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      it 'changes asset state to not_uploaded' do
+        asset.upload_failure!
+
+        expect(asset.reload).to be_not_uploaded
+      end
+    end
+
+    context 'when asset is not_uploaded' do
+      let(:asset) { FactoryBot.create(:not_uploaded_asset) }
+
+      it 'leaves asset state as not_uploaded' do
+        asset.upload_failure!
+
+        expect(asset.reload).to be_not_uploaded
+      end
+    end
+  end
 end

--- a/spec/workers/asset_upload_state_worker_spec.rb
+++ b/spec/workers/asset_upload_state_worker_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe AssetUploadStateWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryBot.create(:clean_asset) }
+  let(:cloud_storage) { instance_double(S3Storage) }
+
+  before do
+    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+    allow(cloud_storage).to receive(:exists?).with(asset).and_return(asset_exists)
+  end
+
+  context 'when file has been uploaded to cloud storage' do
+    let(:asset_exists) { true }
+
+    it 'sets state to uploaded' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload).to be_uploaded
+    end
+  end
+
+  context 'when file has not been uploaded to cloud storage' do
+    let(:asset_exists) { false }
+
+    it 'sets state to not_uploaded' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload).to be_not_uploaded
+    end
+  end
+end

--- a/spec/workers/save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/save_to_cloud_storage_worker_spec.rb
@@ -9,12 +9,53 @@ RSpec.describe SaveToCloudStorageWorker, type: :worker do
 
     before do
       allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+      allow(cloud_storage).to receive(:save)
     end
 
     it 'saves the asset to cloud storage' do
       expect(cloud_storage).to receive(:save).with(asset)
 
       worker.perform(asset)
+    end
+
+    it 'changes the state of the asset to uploaded' do
+      worker.perform(asset)
+
+      expect(asset.reload).to be_uploaded
+    end
+
+    context 'when CloudStorage::ObjectUploadFailedError is raised' do
+      before do
+        allow(cloud_storage).to receive(:save)
+          .and_raise(CloudStorage::ObjectUploadFailedError)
+      end
+
+      it 'changes the state of the asset to not_uploaded' do
+        worker.perform(asset) rescue nil
+
+        expect(asset.reload).to be_not_uploaded
+      end
+
+      it 're-raises the original exception so job will be retried' do
+        expect { worker.perform(asset) }
+          .to raise_error(CloudStorage::ObjectUploadFailedError)
+      end
+    end
+
+    context 'when asset is in not_uploaded state, i.e. previous upload failed' do
+      let(:asset) { FactoryBot.create(:not_uploaded_asset) }
+
+      it 'saves the asset to cloud storage' do
+        expect(cloud_storage).to receive(:save).with(asset)
+
+        worker.perform(asset)
+      end
+
+      it 'changes the state of the asset to uploaded' do
+        worker.perform(asset)
+
+        expect(asset.reload).to be_uploaded
+      end
     end
   end
 end


### PR DESCRIPTION
This introduces two new asset states: "uploaded" and "not_uploaded". New assets are still scanned for viruses and if no viruses are found they are marked as "clean". However, now they will be marked as "uploaded" or "not_uploaded" depending on whether the upload to cloud storage is successful.

For the moment, assets in the "clean", "uploaded" and "not_uploaded" states are treated the same. I've made use of shared examples in the two media controller specs to check this without introducing duplication. However, once the `govuk:set_uploaded_state_for_all_clean_assets` Rake task included in this PR has been run, we'll be in a position to treat these states differently and at that point we should be able to do away with the shared examples.

The motivation behind this PR is two-fold:

1. Now that all asset requests are proxied to S3, we shouldn't attempt to make an asset available via the media controllers until the asset has been successfully uploaded to S3. See #281 for details.

2. We want to remove files from NFS once they have been uploaded to S3. Having these new separate asset states should make this easier to reason about. See #323 for details.
