### PR TITLE
Introduce "uploaded" state for assets

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,7 +29,7 @@ protected
 
   def asset_servable?
     asset.filename_valid?(params[:filename]) &&
-      asset.clean? &&
+      (asset.clean? || asset.uploaded?) &&
       asset.accessible_by?(current_user) &&
       asset.mainstream?
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -52,6 +52,10 @@ class Asset
     event :scanned_infected do
       transition any => :infected
     end
+
+    event :upload_success do
+      transition clean: :uploaded
+    end
   end
 
   def public_url_path

--- a/app/workers/asset_upload_state_worker.rb
+++ b/app/workers/asset_upload_state_worker.rb
@@ -1,0 +1,13 @@
+require 'services'
+
+class AssetUploadStateWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def perform(asset_id)
+    asset = Asset.unscoped.find(asset_id)
+    if Services.cloud_storage.exists?(asset)
+      asset.upload_success!
+    end
+  end
+end

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -6,5 +6,6 @@ class SaveToCloudStorageWorker
   def perform(asset_id)
     asset = Asset.find(asset_id)
     Services.cloud_storage.save(asset)
+    asset.upload_success!
   end
 end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,0 +1,25 @@
+class AssetProcessor
+  def initialize(scope: Asset, output: STDOUT, report_progress_every: 1000)
+    @scope = scope
+    @output = output
+    @report_progress_every = report_progress_every
+  end
+
+  def process_all_assets_with
+    @output.sync = true
+    asset_ids = @scope.pluck(:id).to_a
+    total = asset_ids.count
+    asset_ids.each_with_index do |asset_id, index|
+      count = index + 1
+      percent = "%0.0f" % (count / total.to_f * 100)
+      if (count % @report_progress_every).zero?
+        @output.puts "#{count} of #{total} (#{percent}%) assets"
+      end
+      yield asset_id.to_s
+    end
+    unless (total % @report_progress_every).zero?
+      @output.puts "#{total} of #{total} (100%) assets"
+    end
+    @output.puts "\nFinished!"
+  end
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -22,8 +22,13 @@ class S3Storage
     metadata = exists?(asset) ? metadata_for(asset) : {}
     if force || metadata['md5-hexdigest'] != asset.md5_hexdigest
       metadata['md5-hexdigest'] = asset.md5_hexdigest
-      unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
-        error_message = "Aws::S3::Object#upload_file returned false for asset ID: #{asset.id}"
+      begin
+        unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
+          error_message = "Aws::S3::Object#upload_file returned false for asset ID: #{asset.id}"
+          raise ObjectUploadFailedError.new(error_message)
+        end
+      rescue Aws::S3::MultipartUploadError => e
+        error_message = "Aws::S3::Object#upload_file raised #{e.inspect} for asset ID: #{asset.id}"
         raise ObjectUploadFailedError.new(error_message)
       end
     end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -2,6 +2,7 @@ require 's3_storage/fake'
 
 class S3Storage
   ObjectNotFoundError = Class.new(StandardError)
+  ObjectUploadFailedError = Class.new(StandardError)
 
   def self.build
     if AssetManager.s3.configured?
@@ -21,7 +22,10 @@ class S3Storage
     metadata = exists?(asset) ? metadata_for(asset) : {}
     if force || metadata['md5-hexdigest'] != asset.md5_hexdigest
       metadata['md5-hexdigest'] = asset.md5_hexdigest
-      object_for(asset).upload_file(asset.file.path, metadata: metadata)
+      unless object_for(asset).upload_file(asset.file.path, metadata: metadata)
+        error_message = "Aws::S3::Object#upload_file returned false for asset ID: #{asset.id}"
+        raise ObjectUploadFailedError.new(error_message)
+      end
     end
   end
 

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,0 +1,12 @@
+require 'services'
+require 'asset_processor'
+
+namespace :govuk_assets do
+  desc 'Update state for clean assets with S3 object to uploaded'
+  task update_state_for_clean_assets_with_s3_object_to_uploaded: :environment do
+    processor = AssetProcessor.new(scope: Asset.unscoped.where(state: 'clean'))
+    processor.process_all_assets_with do |asset_id|
+      AssetUploadStateWorker.perform_async(asset_id)
+    end
+  end
+end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -1,6 +1,45 @@
 require "rails_helper"
 
 RSpec.describe MediaController, type: :controller do
+  shared_examples 'handles valid asset request' do
+    it "proxies asset to S3 via Nginx" do
+      expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+      get :download, params
+    end
+
+    it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
+      get :download, params
+
+      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+    end
+
+    context "when the file name in the URL represents an old version" do
+      let(:old_file_name) { "an_old_filename.pdf" }
+
+      before do
+        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(asset).to receive(:filename_valid?).and_return(true)
+      end
+
+      it "redirects to the new file name" do
+        get :download, params: { id: asset, filename: old_file_name }
+
+        expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
+      end
+    end
+
+    context "when the file name in the URL is invalid" do
+      let(:invalid_file_name) { "invalid_file_name.pdf" }
+
+      it "responds with 404 Not Found" do
+        get :download, params: { id: asset, filename: invalid_file_name }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "GET 'download'" do
     let(:params) { { params: { id: asset, filename: asset.filename } } }
 
@@ -11,42 +50,13 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
 
-      it "proxies asset to S3 via Nginx" do
-        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+      include_examples('handles valid asset request')
+    end
 
-        get :download, params
-      end
+    context "with a valid uploaded file" do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
 
-      it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-        get :download, params
-
-        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
-      end
-
-      context "when the file name in the URL represents an old version" do
-        let(:old_file_name) { "an_old_filename.pdf" }
-
-        before do
-          allow(Asset).to receive(:find).with(asset.id).and_return(asset)
-          allow(asset).to receive(:filename_valid?).and_return(true)
-        end
-
-        it "redirects to the new file name" do
-          get :download, params: { id: asset, filename: old_file_name }
-
-          expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
-        end
-      end
-
-      context "when the file name in the URL is invalid" do
-        let(:invalid_file_name) { "invalid_file_name.pdf" }
-
-        it "responds with 404 Not Found" do
-          get :download, params: { id: asset, filename: invalid_file_name }
-
-          expect(response).to have_http_status(:not_found)
-        end
-      end
+      include_examples('handles valid asset request')
     end
 
     context "with an unscanned file" do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe WhitehallMediaController, type: :controller do
+  shared_examples 'handles valid asset request' do
+    it "proxies asset to S3 via Nginx" do
+      expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+      get :download, params: { path: path, format: format }
+    end
+
+    context 'and legacy_url_path has no format' do
+      let(:legacy_url_path) { "/government/uploads/#{path}" }
+
+      it "proxies asset to S3 via Nginx" do
+        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+        get :download, params: { path: path, format: nil }
+      end
+    end
+  end
+
   describe '#download' do
     let(:path) { 'path/to/asset' }
     let(:format) { 'png' }
@@ -13,21 +31,13 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is clean' do
       let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
 
-      it "proxies asset to S3 via Nginx" do
-        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+      include_examples 'handles valid asset request'
+    end
 
-        get :download, params: { path: path, format: format }
-      end
+    context 'when asset is uploaded' do
+      let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'uploaded') }
 
-      context 'and legacy_url_path has no format' do
-        let(:legacy_url_path) { "/government/uploads/#{path}" }
-
-        it "proxies asset to S3 via Nginx" do
-          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
-          get :download, params: { path: path, format: nil }
-        end
-      end
+      include_examples 'handles valid asset request'
     end
 
     context 'when asset is unscanned image' do

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -8,6 +8,9 @@ FactoryBot.define do
   factory :infected_asset, parent: :asset do
     after :create, &:scanned_infected!
   end
+  factory :uploaded_asset, parent: :clean_asset do
+    after :create, &:upload_success!
+  end
 
   factory :access_limited_asset, parent: :clean_asset do
     access_limited true

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'asset_processor'
+
+RSpec.describe AssetProcessor do
+  subject(:processor) { described_class.new(**args) }
+
+  let(:args) { { output: output, report_progress_every: report_progress_every } }
+  let(:output) { StringIO.new }
+  let(:report_progress_every) { 1 }
+
+  let!(:asset_1) { FactoryBot.create(:asset) }
+  let!(:asset_2) { FactoryBot.create(:asset) }
+
+  it 'iterates over all assets' do
+    asset_ids = []
+    processor.process_all_assets_with do |asset_id|
+      asset_ids << asset_id
+    end
+    expect(asset_ids).to contain_exactly(asset_1.id.to_s, asset_2.id.to_s)
+  end
+
+  it 'reports progress for every asset' do
+    processor.process_all_assets_with {}
+
+    expect(output_lines[0]).to eq('1 of 2 (50%) assets')
+    expect(output_lines[1]).to eq('2 of 2 (100%) assets')
+    expect(output_lines[2]).to be_blank
+    expect(output_lines[3]).to eq('Finished!')
+  end
+
+  context 'when report_progress_every option is set to 2' do
+    let(:report_progress_every) { 2 }
+
+    it 'only reports progress for every 2 assets' do
+      processor.process_all_assets_with {}
+
+      expect(output_lines[0]).to eq('2 of 2 (100%) assets')
+      expect(output_lines[1]).to be_blank
+      expect(output_lines[2]).to eq('Finished!')
+    end
+
+    context 'and number of assets is not a multiple of 2' do
+      before do
+        FactoryBot.create(:asset)
+      end
+
+      it 'still reports 100% progress' do
+        processor.process_all_assets_with {}
+
+        expect(output_lines[0]).to eq('2 of 3 (67%) assets')
+        expect(output_lines[1]).to eq('3 of 3 (100%) assets')
+        expect(output_lines[2]).to be_blank
+        expect(output_lines[3]).to eq('Finished!')
+      end
+    end
+  end
+
+  context 'when scope is set to deleted assets' do
+    let(:args) { { scope: scope, output: output } }
+    let(:scope) { Asset.deleted }
+
+    before do
+      asset_1.destroy
+    end
+
+    it 'iterates over all deleted assets' do
+      asset_ids = []
+      processor.process_all_assets_with do |asset_id|
+        asset_ids << asset_id
+      end
+      expect(asset_ids).to contain_exactly(asset_1.id.to_s)
+    end
+  end
+
+  def output_lines
+    @output_lines ||= begin
+      output.rewind
+      output.readlines.map(&:chomp)
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe S3Storage do
       end
     end
 
+    context 'when Aws::S3::Object#upload_file raises Aws::S3::MultipartUploadError' do
+      let(:exception) { Aws::S3::MultipartUploadError.new('message', [RuntimeError.new]) }
+
+      before do
+        allow(s3_object).to receive(:upload_file)
+          .and_raise(exception)
+      end
+
+      it 'raises ObjectUploadFailedError exception' do
+        error_message = "Aws::S3::Object#upload_file raised #{exception.inspect} for asset ID: #{asset.id}"
+
+        expect { subject.save(asset) }
+          .to raise_error(S3Storage::ObjectUploadFailedError, error_message)
+      end
+    end
+
     context 'when S3 object already exists' do
       let(:default_metadata) { { 'md5-hexdigest' => md5_hexdigest } }
       let(:metadata) { default_metadata }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -501,4 +501,43 @@ RSpec.describe Asset, type: :model do
       expect(asset).to be_mainstream
     end
   end
+
+  describe '#upload_success!' do
+    context 'when asset is unscanned' do
+      let(:asset) { FactoryBot.create(:asset) }
+
+      it 'does not allow asset state change to uploaded' do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is clean' do
+      let(:asset) { FactoryBot.create(:clean_asset) }
+
+      it 'changes asset state to uploaded' do
+        asset.upload_success!
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+
+    context 'when asset is infected' do
+      let(:asset) { FactoryBot.create(:infected_asset) }
+
+      it 'does not allow asset state change to uploaded' do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context 'when asset is uploaded' do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      it 'does not allow asset state change to uploaded' do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
 end

--- a/spec/routing/fake_s3_route_spec.rb
+++ b/spec/routing/fake_s3_route_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe 'routes for S3Storage::Fake', type: :routing do
     Rails.application.reload_routes!
   end
 
+  after do
+    allow(AssetManager).to receive(:s3).and_call_original
+    Rails.application.reload_routes!
+  end
+
   context 'when fake S3 is enabled' do
     let(:s3_fake_enabled) { true }
 

--- a/spec/workers/asset_upload_state_worker_spec.rb
+++ b/spec/workers/asset_upload_state_worker_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe AssetUploadStateWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryBot.create(:clean_asset) }
+  let(:cloud_storage) { instance_double(S3Storage) }
+
+  before do
+    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+    allow(cloud_storage).to receive(:exists?).with(asset).and_return(asset_exists)
+  end
+
+  context 'when file has been uploaded to cloud storage' do
+    let(:asset_exists) { true }
+
+    it 'sets state to uploaded' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload).to be_uploaded
+    end
+
+    context 'even when asset is marked as deleted' do
+      before do
+        asset.destroy
+      end
+
+      it 'still sets state to uploaded' do
+        worker.perform(asset.id.to_s)
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+  end
+
+  context 'when file has not been uploaded to cloud storage' do
+    let(:asset_exists) { false }
+
+    it 'leaves state set to clean' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload).to be_clean
+    end
+  end
+end


### PR DESCRIPTION
This supersedes #363.

This introduces a new "uploaded" asset state. New assets are still scanned for viruses and if no viruses are found they are marked as "clean". However, now they will be marked as "uploaded" or if the subsequent upload to cloud storage is successful.

For the moment, assets in the "clean" and "uploaded" states are treated the same. I've made use of shared examples in the two media controller specs to check this without introducing duplication. However, once the `govuk:update_state_for_clean_assets_with_s3_object_to_uploaded` Rake task included in this PR has been run, we'll be in a position to treat these states differently and at that point we should be able to do away with the shared examples.

The motivation behind this PR is two-fold:

1. Now that all asset requests are proxied to S3, we shouldn't attempt to make an asset available via the media controllers until the asset has been successfully uploaded to S3. See #281 for details.

2. We want to remove files from NFS once they have been uploaded to S3. Having these new separate asset states should make this easier to reason about. See #323 for details.

Differences compared to #363 (mostly addressing comments from @chrisroos):

* Only add a single "uploaded" state; not "not_uploaded" as well. Failed uploads leave the asset in the "clean" state.
* Stricter constraints on state transition; only allow transition from "clean" to "uploaded".
* No need for generic `CloudStorage` exception base classes, because no explicit rescue block needed in `SaveToCloudStorageWorker.perform`.
* Include deleted assets in `govuk:update_state_for_clean_assets_with_s3_object_to_uploaded` Rake task.
* Better error messages in `S3Storage::ObjectUploadFailedError` exceptions.
* Extended/more representative end-to-end example in `spec/requests/virus_scanning_spec.rb`.
