### PR TITLE
Only attempt to serve asset if successfully uploaded to S3

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -29,7 +29,7 @@ protected
 
   def asset_servable?
     asset.filename_valid?(params[:filename]) &&
-      (asset.clean? || asset.uploaded?) &&
+      asset.uploaded? &&
       asset.accessible_by?(current_user) &&
       asset.mainstream?
   end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -4,7 +4,7 @@ class WhitehallMediaController < BaseMediaController
     path += ".#{params[:format]}" if params[:format].present?
     asset = WhitehallAsset.find_by(legacy_url_path: path)
 
-    if asset.unscanned?
+    if asset.unscanned? || asset.clean?
       set_expiry(1.minute)
       if asset.image?
         redirect_to self.class.helpers.image_path('thumbnail-placeholder.png')

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
 
-      include_examples('handles valid asset request')
+      it "responds with 404 Not Found" do
+        get :download, params
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     context "with a valid uploaded file" do
@@ -70,7 +73,7 @@ RSpec.describe MediaController, type: :controller do
 
     context "with an otherwise servable whitehall asset" do
       let(:path) { '/government/uploads/asset.png' }
-      let(:asset) { FactoryBot.create(:clean_whitehall_asset, legacy_url_path: path) }
+      let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: path) }
 
       it "responds with 404 Not Found" do
         get :download, params
@@ -96,7 +99,7 @@ RSpec.describe MediaController, type: :controller do
 
     context "access limiting on the public interface" do
       let(:restricted_asset) { FactoryBot.create(:access_limited_asset, organisation_slug: 'example-slug') }
-      let(:unrestricted_asset) { FactoryBot.create(:clean_asset) }
+      let(:unrestricted_asset) { FactoryBot.create(:uploaded_asset) }
 
       it "responds with 404 Not Found for access-limited documents" do
         get :download, params: { id: restricted_asset, filename: 'asset.png' }

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -8,15 +8,6 @@ RSpec.describe MediaController, type: :controller do
       allow(controller).to receive_messages(requested_via_private_vhost?: false)
     end
 
-    context "with a valid clean file" do
-      let(:asset) { FactoryBot.create(:clean_asset) }
-
-      it "responds with 404 Not Found" do
-        get :download, params
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
     context "with a valid uploaded file" do
       let(:asset) { FactoryBot.create(:uploaded_asset) }
 
@@ -60,6 +51,15 @@ RSpec.describe MediaController, type: :controller do
 
     context "with an unscanned file" do
       let(:asset) { FactoryBot.create(:asset) }
+
+      it "responds with 404 Not Found" do
+        get :download, params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "with a valid clean file" do
+      let(:asset) { FactoryBot.create(:clean_asset) }
 
       it "responds with 404 Not Found" do
         get :download, params

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -1,45 +1,6 @@
 require "rails_helper"
 
 RSpec.describe MediaController, type: :controller do
-  shared_examples 'handles valid asset request' do
-    it "proxies asset to S3 via Nginx" do
-      expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
-      get :download, params
-    end
-
-    it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
-      get :download, params
-
-      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
-    end
-
-    context "when the file name in the URL represents an old version" do
-      let(:old_file_name) { "an_old_filename.pdf" }
-
-      before do
-        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
-        allow(asset).to receive(:filename_valid?).and_return(true)
-      end
-
-      it "redirects to the new file name" do
-        get :download, params: { id: asset, filename: old_file_name }
-
-        expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
-      end
-    end
-
-    context "when the file name in the URL is invalid" do
-      let(:invalid_file_name) { "invalid_file_name.pdf" }
-
-      it "responds with 404 Not Found" do
-        get :download, params: { id: asset, filename: invalid_file_name }
-
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-  end
-
   describe "GET 'download'" do
     let(:params) { { params: { id: asset, filename: asset.filename } } }
 
@@ -59,7 +20,42 @@ RSpec.describe MediaController, type: :controller do
     context "with a valid uploaded file" do
       let(:asset) { FactoryBot.create(:uploaded_asset) }
 
-      include_examples('handles valid asset request')
+      it "proxies asset to S3 via Nginx" do
+        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+        get :download, params
+      end
+
+      it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
+        get :download, params
+
+        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+      end
+
+      context "when the file name in the URL represents an old version" do
+        let(:old_file_name) { "an_old_filename.pdf" }
+
+        before do
+          allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+          allow(asset).to receive(:filename_valid?).and_return(true)
+        end
+
+        it "redirects to the new file name" do
+          get :download, params: { id: asset, filename: old_file_name }
+
+          expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
+        end
+      end
+
+      context "when the file name in the URL is invalid" do
+        let(:invalid_file_name) { "invalid_file_name.pdf" }
+
+        it "responds with 404 Not Found" do
+          get :download, params: { id: asset, filename: invalid_file_name }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
 
     context "with an unscanned file" do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is clean' do
       let(:state) { 'clean' }
 
-      include_examples 'handles valid asset request'
+      include_examples 'redirects to placeholders'
     end
 
     context 'when asset is uploaded' do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -40,31 +40,31 @@ RSpec.describe WhitehallMediaController, type: :controller do
       include_examples 'handles valid asset request'
     end
 
-    context 'when asset is unscanned image' do
+    context 'when asset is unscanned' do
       let(:asset) { FactoryBot.build(:whitehall_asset, state: 'unscanned') }
 
       before do
-        allow(asset).to receive(:image?).and_return(true)
+        allow(asset).to receive(:image?).and_return(image)
       end
 
-      it 'redirects to thumbnail-placeholder image' do
-        get :download, params: { path: path, format: format }
+      context 'and asset is image' do
+        let(:image) { true }
 
-        expect(controller).to redirect_to(described_class.helpers.image_path('thumbnail-placeholder.png'))
-      end
-    end
+        it 'redirects to thumbnail-placeholder image' do
+          get :download, params: { path: path, format: format }
 
-    context 'when asset is unscanned non-image' do
-      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'unscanned') }
-
-      before do
-        allow(asset).to receive(:image?).and_return(false)
+          expect(controller).to redirect_to(described_class.helpers.image_path('thumbnail-placeholder.png'))
+        end
       end
 
-      it 'redirects to government placeholder page' do
-        get :download, params: { path: path, format: format }
+      context 'and asset is not an image' do
+        let(:image) { false }
 
-        expect(controller).to redirect_to('/government/placeholder')
+        it 'redirects to government placeholder page' do
+          get :download, params: { path: path, format: format }
+
+          expect(controller).to redirect_to('/government/placeholder')
+        end
       end
     end
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -19,6 +19,32 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
   end
 
+  shared_examples 'redirects to placeholders' do
+    before do
+      allow(asset).to receive(:image?).and_return(image)
+    end
+
+    context 'and asset is image' do
+      let(:image) { true }
+
+      it 'redirects to thumbnail-placeholder image' do
+        get :download, params: { path: path, format: format }
+
+        expect(controller).to redirect_to(described_class.helpers.image_path('thumbnail-placeholder.png'))
+      end
+    end
+
+    context 'and asset is not an image' do
+      let(:image) { false }
+
+      it 'redirects to government placeholder page' do
+        get :download, params: { path: path, format: format }
+
+        expect(controller).to redirect_to('/government/placeholder')
+      end
+    end
+  end
+
   describe '#download' do
     let(:path) { 'path/to/asset' }
     let(:format) { 'png' }
@@ -44,29 +70,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is unscanned' do
       let(:state) { 'unscanned' }
 
-      before do
-        allow(asset).to receive(:image?).and_return(image)
-      end
-
-      context 'and asset is image' do
-        let(:image) { true }
-
-        it 'redirects to thumbnail-placeholder image' do
-          get :download, params: { path: path, format: format }
-
-          expect(controller).to redirect_to(described_class.helpers.image_path('thumbnail-placeholder.png'))
-        end
-      end
-
-      context 'and asset is not an image' do
-        let(:image) { false }
-
-        it 'redirects to government placeholder page' do
-          get :download, params: { path: path, format: format }
-
-          expect(controller).to redirect_to('/government/placeholder')
-        end
-      end
+      include_examples 'redirects to placeholders'
     end
 
     context 'when asset is infected' do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -1,24 +1,6 @@
 require "rails_helper"
 
 RSpec.describe WhitehallMediaController, type: :controller do
-  shared_examples 'handles valid asset request' do
-    it "proxies asset to S3 via Nginx" do
-      expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
-      get :download, params: { path: path, format: format }
-    end
-
-    context 'and legacy_url_path has no format' do
-      let(:legacy_url_path) { "/government/uploads/#{path}" }
-
-      it "proxies asset to S3 via Nginx" do
-        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
-        get :download, params: { path: path, format: nil }
-      end
-    end
-  end
-
   shared_examples 'redirects to placeholders' do
     before do
       allow(asset).to receive(:image?).and_return(image)
@@ -64,7 +46,21 @@ RSpec.describe WhitehallMediaController, type: :controller do
     context 'when asset is uploaded' do
       let(:state) { 'uploaded' }
 
-      include_examples 'handles valid asset request'
+      it "proxies asset to S3 via Nginx" do
+        expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+        get :download, params: { path: path, format: format }
+      end
+
+      context 'and legacy_url_path has no format' do
+        let(:legacy_url_path) { "/government/uploads/#{path}" }
+
+        it "proxies asset to S3 via Nginx" do
+          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+          get :download, params: { path: path, format: nil }
+        end
+      end
     end
 
     context 'when asset is unscanned' do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -23,25 +23,26 @@ RSpec.describe WhitehallMediaController, type: :controller do
     let(:path) { 'path/to/asset' }
     let(:format) { 'png' }
     let(:legacy_url_path) { "/government/uploads/#{path}.#{format}" }
+    let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: state) }
 
     before do
       allow(WhitehallAsset).to receive(:find_by).with(legacy_url_path: legacy_url_path).and_return(asset)
     end
 
     context 'when asset is clean' do
-      let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'clean') }
+      let(:state) { 'clean' }
 
       include_examples 'handles valid asset request'
     end
 
     context 'when asset is uploaded' do
-      let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: 'uploaded') }
+      let(:state) { 'uploaded' }
 
       include_examples 'handles valid asset request'
     end
 
     context 'when asset is unscanned' do
-      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'unscanned') }
+      let(:state) { 'unscanned' }
 
       before do
         allow(asset).to receive(:image?).and_return(image)
@@ -69,7 +70,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
     end
 
     context 'when asset is infected' do
-      let(:asset) { FactoryBot.build(:whitehall_asset, state: 'infected') }
+      let(:state) { 'infected' }
 
       it 'responds with 404 Not Found' do
         get :download, params: { path: path, format: format }

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe WhitehallMediaController, type: :controller do
       allow(WhitehallAsset).to receive(:find_by).with(legacy_url_path: legacy_url_path).and_return(asset)
     end
 
-    context 'when asset is clean' do
-      let(:state) { 'clean' }
-
-      include_examples 'redirects to placeholders'
-    end
-
     context 'when asset is uploaded' do
       let(:state) { 'uploaded' }
 
@@ -65,6 +59,12 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
     context 'when asset is unscanned' do
       let(:state) { 'unscanned' }
+
+      include_examples 'redirects to placeholders'
+    end
+
+    context 'when asset is clean' do
+      let(:state) { 'clean' }
 
       include_examples 'redirects to placeholders'
     end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     after :create, &:upload_success!
   end
 
-  factory :access_limited_asset, parent: :clean_asset do
+  factory :access_limited_asset, parent: :uploaded_asset do
     access_limited true
     organisation_slug 'example-organisation'
   end
@@ -32,6 +32,10 @@ FactoryBot.define do
 
   factory :clean_whitehall_asset, parent: :whitehall_asset do
     after :create, &:scanned_clean!
+  end
+
+  factory :uploaded_whitehall_asset, parent: :clean_whitehall_asset do
+    after :create, &:upload_success!
   end
 
   factory :user do

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "retrieving an asset" do
     it "retreives details about an existing asset" do
-      asset = FactoryBot.create(:clean_asset)
+      asset = FactoryBot.create(:uploaded_asset)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -72,7 +72,7 @@ RSpec.describe "Asset requests", type: :request do
       expect(body["name"]).to eq("asset.png")
       expect(body["content_type"]).to eq("image/png")
       expect(body["file_url"]).to eq("http://assets.digital.cabinet-office.gov.uk/media/#{asset.id}/asset.png")
-      expect(body["state"]).to eq("clean")
+      expect(body["state"]).to eq("uploaded")
     end
 
     it "returns details about an infected asset" do
@@ -102,7 +102,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "deleting an asset" do
     it "soft deletes an existing asset" do
-      asset = FactoryBot.create(:clean_asset)
+      asset = FactoryBot.create(:uploaded_asset)
 
       delete "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -113,7 +113,7 @@ RSpec.describe "Asset requests", type: :request do
       expect(body["name"]).to eq("asset.png")
       expect(body["content_type"]).to eq("image/png")
       expect(body["file_url"]).to eq("http://assets.digital.cabinet-office.gov.uk/media/#{asset.id}/asset.png")
-      expect(body["state"]).to eq("clean")
+      expect(body["state"]).to eq("uploaded")
 
       get "/assets/#{asset.id}"
 
@@ -123,7 +123,7 @@ RSpec.describe "Asset requests", type: :request do
 
   describe "restoring an asset" do
     it "restores a soft deleted asset" do
-      asset = FactoryBot.create(:clean_asset)
+      asset = FactoryBot.create(:uploaded_asset)
 
       post "/assets/#{asset.id}/restore"
 
@@ -135,7 +135,7 @@ RSpec.describe "Asset requests", type: :request do
       expect(body["name"]).to eq("asset.png")
       expect(body["content_type"]).to eq("image/png")
       expect(body["file_url"]).to eq("http://assets.digital.cabinet-office.gov.uk/media/#{asset.id}/asset.png")
-      expect(body["state"]).to eq("clean")
+      expect(body["state"]).to eq("uploaded")
 
       get "/assets/#{asset.id}"
 

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Media requests", type: :request do
     let(:http_method) { 'GET' }
     let(:presigned_url) { 'https://s3-host.test/presigned-url' }
 
-    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:uploaded_asset) }
 
     before do
       allow(Services).to receive(:cloud_storage).and_return(cloud_storage)

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     login_as_stub_user
   end
 
-  specify "uploading a clean asset, and seeing it available after virus scanning" do
+  specify "a clean asset is available after virus scanning & uploading to cloud storage" do
     post "/assets", params: { asset: { file: load_fixture_file("lorem.txt") } }
     expect(response).to have_http_status(:created)
 
@@ -20,11 +20,7 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     VirusScanWorker.drain
 
     get "/media/#{asset.id}/lorem.txt"
-    expect(response).to have_http_status(:success)
-
-    redirect_url = headers['X-Accel-Redirect']
-    cloud_url = redirect_url.match(%r{^/cloud-storage-proxy/(.*)$})[1]
-    expect { get cloud_url }.to raise_error(ActionController::RoutingError)
+    expect(response).to have_http_status(:not_found)
 
     SaveToCloudStorageWorker.drain
 

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -65,9 +65,15 @@ RSpec.describe 'Whitehall media requests', type: :request do
     include_examples 'redirects to placeholders'
   end
 
-  describe 'request for a clean asset' do
+  describe 'request for an clean asset' do
+    let(:state) { 'clean' }
+
+    include_examples 'redirects to placeholders'
+  end
+
+  describe 'request for an uploaded asset' do
     let(:path) { '/government/uploads/asset.png' }
-    let(:asset) { FactoryBot.create(:clean_whitehall_asset, legacy_url_path: path) }
+    let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: path) }
 
     before do
       allow(cloud_storage).to receive(:presigned_url_for)

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -1,25 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Whitehall media requests', type: :request do
-  let(:cloud_storage) { instance_double(S3Storage) }
-  let(:http_method) { 'GET' }
-  let(:presigned_url) { 'https://s3-host.test/presigned-url' }
-
-  before do
-    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
-  end
-
-  describe 'request for an asset which does not exist' do
-    it 'responds with 404 Not Found status' do
-      get '/government/uploads/asset.png'
-
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
-  describe 'request for an unscanned asset' do
-    let(:state) { 'unscanned' }
-
+  shared_examples 'redirects to placeholders' do
     let(:asset) {
       FactoryBot.create(
         :whitehall_asset,
@@ -59,6 +41,28 @@ RSpec.describe 'Whitehall media requests', type: :request do
         expect(response.headers['Cache-Control']).to eq('max-age=60, public')
       end
     end
+  end
+
+  let(:cloud_storage) { instance_double(S3Storage) }
+  let(:http_method) { 'GET' }
+  let(:presigned_url) { 'https://s3-host.test/presigned-url' }
+
+  before do
+    allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
+  end
+
+  describe 'request for an asset which does not exist' do
+    it 'responds with 404 Not Found status' do
+      get '/government/uploads/asset.png'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'request for an unscanned asset' do
+    let(:state) { 'unscanned' }
+
+    include_examples 'redirects to placeholders'
   end
 
   describe 'request for a clean asset' do

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -18,11 +18,14 @@ RSpec.describe 'Whitehall media requests', type: :request do
   end
 
   describe 'request for an unscanned asset' do
+    let(:state) { 'unscanned' }
+
     let(:asset) {
       FactoryBot.create(
         :whitehall_asset,
         file: load_fixture_file(File.basename(path)),
-        legacy_url_path: path
+        legacy_url_path: path,
+        state: state
       )
     }
 


### PR DESCRIPTION
Previously requests for Whitehall assets which had been virus scanned, but not uploaded to S3, resulted in a `200 OK` response with a `X-Accel-Redirect` header set to a URL for an S3 object which did not exist. The Nginx internal redirect then requested the S3 URL which resulted in a `404 Not Found`. This was at odds with the response for an unscanned asset which is a redirect to a placeholder image/page. This PR changes the behaviour for an asset which has been virus scanned, but not uploaded to S3, to be the same as for an asset which has not yet been virus scanned, i.e. the app will response with a redirect to the placeholder image/page.

The same issue existed for Mainstream assets, but the consequences were less obvious/serious. Requests for such assets which had been virus scanned, but not uploaded to S3, resulted in a `200 OK` response with a `X-Accel-Redirect` header set to a URL for an S3 object which did not exist. The Nginx internal redirect then requested the S3 URL which resulted in a `404 Not Found`. This was the same response as for an unscanned asset. However, this PR changes the behaviour to avoid the Nginx internal redirect and the request to S3 by having the Rails app respond with `404 Not Found` directly.

I've also made a bunch of changes to the specs to try to make the changes in app behaviour easier to follow.

Hopefully this will solve the problem described in #281.