### PR TITLE
Delete underlying file when upload to S3 succeeds

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -25,7 +25,7 @@ class Asset
   field :md5_hexdigest, type: String
   protected :md5_hexdigest=
 
-  validates :file, presence: true
+  validates :file, presence: true, unless: :uploaded?
   validates :organisation_slug, presence: true, if: :access_limited?
 
   validates :uuid, presence: true,
@@ -37,7 +37,7 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  before_save :store_metadata
+  before_save :store_metadata, unless: :uploaded?
   after_save :schedule_virus_scan
 
   state_machine :state, initial: :unscanned do
@@ -55,6 +55,10 @@ class Asset
 
     event :upload_success do
       transition clean: :uploaded
+    end
+
+    after_transition to: :uploaded do |asset, _|
+      asset.remove_file!
     end
   end
 

--- a/app/workers/delete_asset_file_from_nfs_worker.rb
+++ b/app/workers/delete_asset_file_from_nfs_worker.rb
@@ -1,0 +1,11 @@
+class DeleteAssetFileFromNfsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def perform(asset_id)
+    asset = Asset.unscoped.find(asset_id)
+    if asset.uploaded?
+      asset.remove_file!
+    end
+  end
+end

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,0 +1,25 @@
+class AssetProcessor
+  def initialize(scope: Asset, output: STDOUT, report_progress_every: 1000)
+    @scope = scope
+    @output = output
+    @report_progress_every = report_progress_every
+  end
+
+  def process_all_assets_with
+    @output.sync = true
+    asset_ids = @scope.pluck(:id).to_a
+    total = asset_ids.count
+    asset_ids.each_with_index do |asset_id, index|
+      count = index + 1
+      percent = "%0.0f" % (count / total.to_f * 100)
+      if (count % @report_progress_every).zero?
+        @output.puts "#{count} of #{total} (#{percent}%) assets"
+      end
+      yield asset_id.to_s
+    end
+    unless (total % @report_progress_every).zero?
+      @output.puts "#{total} of #{total} (100%) assets"
+    end
+    @output.puts "\nFinished!"
+  end
+end

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -1,0 +1,11 @@
+require 'asset_processor'
+
+namespace :govuk_assets do
+  desc 'Delete file from NFS for assets uploaded to S3'
+  task delete_file_from_nfs_for_assets_uploaded_to_s3: :environment do
+    processor = AssetProcessor.new(scope: Asset.unscoped.where(state: 'uploaded'))
+    processor.process_all_assets_with do |asset_id|
+      DeleteAssetFileFromNfsWorker.perform_async(asset_id)
+    end
+  end
+end

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'asset_processor'
+
+RSpec.describe AssetProcessor do
+  subject(:processor) { described_class.new(**args) }
+
+  let(:args) { { output: output, report_progress_every: report_progress_every } }
+  let(:output) { StringIO.new }
+  let(:report_progress_every) { 1 }
+
+  let!(:asset_1) { FactoryBot.create(:asset) }
+  let!(:asset_2) { FactoryBot.create(:asset) }
+
+  it 'iterates over all assets' do
+    asset_ids = []
+    processor.process_all_assets_with do |asset_id|
+      asset_ids << asset_id
+    end
+    expect(asset_ids).to contain_exactly(asset_1.id.to_s, asset_2.id.to_s)
+  end
+
+  it 'reports progress for every asset' do
+    processor.process_all_assets_with {}
+
+    expect(output_lines[0]).to eq('1 of 2 (50%) assets')
+    expect(output_lines[1]).to eq('2 of 2 (100%) assets')
+    expect(output_lines[2]).to be_blank
+    expect(output_lines[3]).to eq('Finished!')
+  end
+
+  context 'when report_progress_every option is set to 2' do
+    let(:report_progress_every) { 2 }
+
+    it 'only reports progress for every 2 assets' do
+      processor.process_all_assets_with {}
+
+      expect(output_lines[0]).to eq('2 of 2 (100%) assets')
+      expect(output_lines[1]).to be_blank
+      expect(output_lines[2]).to eq('Finished!')
+    end
+
+    context 'and number of assets is not a multiple of 2' do
+      before do
+        FactoryBot.create(:asset)
+      end
+
+      it 'still reports 100% progress' do
+        processor.process_all_assets_with {}
+
+        expect(output_lines[0]).to eq('2 of 3 (67%) assets')
+        expect(output_lines[1]).to eq('3 of 3 (100%) assets')
+        expect(output_lines[2]).to be_blank
+        expect(output_lines[3]).to eq('Finished!')
+      end
+    end
+  end
+
+  context 'when scope is set to deleted assets' do
+    let(:args) { { scope: scope, output: output } }
+    let(:scope) { Asset.deleted }
+
+    before do
+      asset_1.destroy
+    end
+
+    it 'iterates over all deleted assets' do
+      asset_ids = []
+      processor.process_all_assets_with do |asset_id|
+        asset_ids << asset_id
+      end
+      expect(asset_ids).to contain_exactly(asset_1.id.to_s)
+    end
+  end
+
+  def output_lines
+    @output_lines ||= begin
+      output.rewind
+      output.readlines.map(&:chomp)
+    end
+  end
+end

--- a/spec/workers/delete_asset_file_from_nfs_worker_spec.rb
+++ b/spec/workers/delete_asset_file_from_nfs_worker_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe DeleteAssetFileFromNfsWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryBot.create(:asset, state: state) }
+  let(:path) { asset.file.path }
+
+  context 'when asset is not uploaded' do
+    let(:state) { 'unscanned' }
+
+    it 'does not set file attribute to blank' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload.file).to be_present
+    end
+
+    it 'does not remove the underlying file' do
+      worker.perform(asset.id.to_s)
+
+      expect(File).to exist(path)
+    end
+  end
+
+  context 'when asset is uploaded' do
+    let(:state) { 'uploaded' }
+
+    it 'sets file attribute to blank' do
+      worker.perform(asset.id.to_s)
+
+      expect(asset.reload.file).to be_blank
+    end
+
+    it 'removes the underlying file' do
+      worker.perform(asset.id.to_s)
+
+      expect(File).not_to exist(path)
+    end
+  end
+end


### PR DESCRIPTION
Since #328 the app hasn't been capable of instructing Nginx to serve assets directly from the NFS mount and since alphagov/govuk-puppet#6971 Nginx hasn't been configured to allow assets to be served directly from the NFS mount.

This means that the only reason we need to store files on NFS is currently so that the Sidekiq workers (which may be running on different machines to that which handled the upload request) have access to the files.

This in turn means that it is safe to remove the underlying file once the asset has been scanned for viruses and uploaded to S3.

In order to achieve this I've introduced a new state transition callback which calls `Asset#remove_file!`. The latter seems to be the recommended way to remove the underlying file via the Carrierwave API and results in `Asset#file` becoming blank which seems to make sense to me.

I've had to restrict the validation which checks for the presence of the file attribute in order to ensure that an uploaded asset remains valid. I've also had to prevent the `store_metadata` callback from running when the asset is in the uploaded state, because it relies on the underlying file in order to e.g. compute the `ETag` from the file metadata. I think disabling the latter should be OK, because it should only need to be run on Asset creation or update, i.e. when a new file is specified.

Once this commit has been deployed, the underlying files for assets should only exist on NFS temporarily, i.e. until they have been scanned for viruses and uploaded to S3. This means we should then be in a position to delete all the underlying files for existing assets in the uploaded state and free up a significant amount of space on NFS. I've included a new Rake task (`govuk_assets:delete_file_from_nfs_for_assets_uploaded_to_s3`) to make this possible.
