### PR TITLE
Add test coverage for scripts

### DIFF
--- a/bin/create_asset
+++ b/bin/create_asset
@@ -2,22 +2,6 @@
 
 require File.expand_path("../../config/environment", __FILE__)
 
-filename = ARGV.any? ? ARGV.fetch(0) : nil
+require 'cli'
 
-unless filename
-  puts "You need to provide a filename as first argument when running this script"
-  abort
-end
-
-file = File.new(filename)
-asset = Asset.new(file: file)
-
-if asset.save
-  puts "Saved!"
-  puts "Asset id: #{asset.id}"
-  puts "Asset name: #{asset.file.filename}"
-  puts "Asset basepath: /media/#{asset.id}/#{asset.file.filename}"
-else
-  puts "Not saved, error messages:"
-  puts asset.errors.full_messages
-end
+CLI.new.create_asset(*ARGV)

--- a/bin/update_asset
+++ b/bin/update_asset
@@ -2,28 +2,6 @@
 
 require File.expand_path("../../config/environment", __FILE__)
 
-old_asset_id = ARGV.any? ? ARGV.fetch(0) : nil
-filename = ARGV.any? ? ARGV.fetch(1) : nil
+require 'cli'
 
-unless old_asset_id
-  puts "You need to provide the asset ID as first argument when running this script"
-  abort
-end
-
-unless filename
-  puts "You need to provide a filename as second argument when running this script"
-  abort
-end
-
-file = File.new(filename)
-old_asset = Asset.find(old_asset_id)
-
-if old_asset.update_attributes(file: file)
-  puts "Updated!"
-  puts "Asset id: #{old_asset.id}"
-  puts "Asset name: #{old_asset.file.filename}"
-  puts "Asset basepath: /media/#{old_asset.id}/#{old_asset.file.filename}"
-else
-  puts "not updated, something went wrong"
-  puts "errors: #{old_asset.errors.full_messages}"
-end
+CLI.new.update_asset(*ARGV)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -25,4 +25,32 @@ class CLI
       @output.puts asset.errors.full_messages
     end
   end
+
+  def update_asset(*argv)
+    old_asset_id = argv[0]
+    filename = argv[1]
+
+    unless old_asset_id
+      @output.puts "You need to provide the asset ID as first argument when running this script"
+      @kernel.abort
+    end
+
+    unless filename
+      @output.puts "You need to provide a filename as second argument when running this script"
+      @kernel.abort
+    end
+
+    file = File.new(filename)
+    old_asset = Asset.find(old_asset_id)
+
+    if old_asset.update_attributes(file: file)
+      @output.puts "Updated!"
+      @output.puts "Asset id: #{old_asset.id}"
+      @output.puts "Asset name: #{old_asset.file.filename}"
+      @output.puts "Asset basepath: /media/#{old_asset.id}/#{old_asset.file.filename}"
+    else
+      @output.puts "not updated, something went wrong"
+      @output.puts "errors: #{old_asset.errors.full_messages}"
+    end
+  end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -5,7 +5,7 @@ class CLI
   end
 
   def create_asset(*argv)
-    filename = argv.any? ? argv.fetch(0) : nil
+    filename = argv[0]
 
     unless filename
       @output.puts "You need to provide a filename as first argument when running this script"

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,0 +1,28 @@
+class CLI
+  def initialize(output = STDOUT, kernel = Kernel)
+    @output = output
+    @kernel = kernel
+  end
+
+  def create_asset(*argv)
+    filename = argv.any? ? argv.fetch(0) : nil
+
+    unless filename
+      @output.puts "You need to provide a filename as first argument when running this script"
+      @kernel.abort
+    end
+
+    file = File.new(filename)
+    asset = Asset.new(file: file)
+
+    if asset.save
+      @output.puts "Saved!"
+      @output.puts "Asset id: #{asset.id}"
+      @output.puts "Asset name: #{asset.file.filename}"
+      @output.puts "Asset basepath: /media/#{asset.id}/#{asset.file.filename}"
+    else
+      @output.puts "Not saved, error messages:"
+      @output.puts asset.errors.full_messages
+    end
+  end
+end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -9,7 +9,7 @@ class CLI
 
     unless filename
       puts "You need to provide a filename as first argument when running this script"
-      @kernel.abort
+      abort
     end
 
     file = File.new(filename)
@@ -32,12 +32,12 @@ class CLI
 
     unless old_asset_id
       puts "You need to provide the asset ID as first argument when running this script"
-      @kernel.abort
+      abort
     end
 
     unless filename
       puts "You need to provide a filename as second argument when running this script"
-      @kernel.abort
+      abort
     end
 
     file = File.new(filename)
@@ -58,5 +58,9 @@ private
 
   def puts(*messages)
     @output.puts(*messages)
+  end
+
+  def abort(message = nil)
+    @kernel.abort(message)
   end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -8,7 +8,7 @@ class CLI
     filename = argv[0]
 
     unless filename
-      @output.puts "You need to provide a filename as first argument when running this script"
+      puts "You need to provide a filename as first argument when running this script"
       @kernel.abort
     end
 
@@ -16,13 +16,13 @@ class CLI
     asset = Asset.new(file: file)
 
     if asset.save
-      @output.puts "Saved!"
-      @output.puts "Asset id: #{asset.id}"
-      @output.puts "Asset name: #{asset.file.filename}"
-      @output.puts "Asset basepath: /media/#{asset.id}/#{asset.file.filename}"
+      puts "Saved!"
+      puts "Asset id: #{asset.id}"
+      puts "Asset name: #{asset.file.filename}"
+      puts "Asset basepath: /media/#{asset.id}/#{asset.file.filename}"
     else
-      @output.puts "Not saved, error messages:"
-      @output.puts asset.errors.full_messages
+      puts "Not saved, error messages:"
+      puts asset.errors.full_messages
     end
   end
 
@@ -31,12 +31,12 @@ class CLI
     filename = argv[1]
 
     unless old_asset_id
-      @output.puts "You need to provide the asset ID as first argument when running this script"
+      puts "You need to provide the asset ID as first argument when running this script"
       @kernel.abort
     end
 
     unless filename
-      @output.puts "You need to provide a filename as second argument when running this script"
+      puts "You need to provide a filename as second argument when running this script"
       @kernel.abort
     end
 
@@ -44,13 +44,19 @@ class CLI
     old_asset = Asset.find(old_asset_id)
 
     if old_asset.update_attributes(file: file)
-      @output.puts "Updated!"
-      @output.puts "Asset id: #{old_asset.id}"
-      @output.puts "Asset name: #{old_asset.file.filename}"
-      @output.puts "Asset basepath: /media/#{old_asset.id}/#{old_asset.file.filename}"
+      puts "Updated!"
+      puts "Asset id: #{old_asset.id}"
+      puts "Asset name: #{old_asset.file.filename}"
+      puts "Asset basepath: /media/#{old_asset.id}/#{old_asset.file.filename}"
     else
-      @output.puts "not updated, something went wrong"
-      @output.puts "errors: #{old_asset.errors.full_messages}"
+      puts "not updated, something went wrong"
+      puts "errors: #{old_asset.errors.full_messages}"
     end
+  end
+
+private
+
+  def puts(*messages)
+    @output.puts(*messages)
   end
 end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+require 'cli'
+
+RSpec.describe CLI, type: :model do
+  subject(:cli) { described_class.new(output, kernel) }
+
+  let(:output) { StringIO.new }
+  let(:kernel) { class_double('Kernel') }
+  let(:path) { fixture_file_path('asset.png') }
+
+  describe '#create_asset' do
+    context 'when called with path to file' do
+      let(:args) { [path] }
+
+      it 'creates an asset' do
+        expect { cli.create_asset(*args) }.to change { Asset.count }.by 1
+      end
+
+      it 'reports that asset was saved' do
+        cli.create_asset(*args)
+
+        output.rewind
+        expect(output.read).to match(/^saved/i)
+      end
+
+      context 'when saving asset fails due to validation errors' do
+        let(:invalid_asset) { Asset.new }
+
+        before do
+          allow(Asset).to receive(:new).and_return(invalid_asset)
+        end
+
+        it 'does not create an asset' do
+          expect { cli.create_asset(*args) }.to change { Asset.count }.by 0
+        end
+
+        it 'reports that asset was not saved' do
+          cli.create_asset(*args)
+
+          output.rewind
+          expect(output.read).to match(/^not saved/i)
+        end
+      end
+    end
+
+    context 'when called with no arguments' do
+      let(:args) { [] }
+
+      before do
+        allow(kernel).to receive(:abort).and_raise('abort-error')
+      end
+
+      it 'aborts execution' do
+        expect(kernel).to receive(:abort)
+
+        cli.create_asset(*args) rescue nil
+      end
+
+      it 'prints usage instructions' do
+        cli.create_asset(*args) rescue nil
+
+        output.rewind
+        expect(output.read).to match(/provide a filename/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've extracted the two custom scripts (`bin/create_asset` & `bin/update_asset`) into methods on a new class (`CLI`) and added a spec for that class.

In doing this I identified a slight flaw in the argument parsing of `bin/update_asset` which I have fixed. Other than that I've attempted to keep the code as unchanged as possible, albeit with some changes to make testing easier. This is not because I think the code is especially good, but because I wanted to minimise the chance of introducing bugs.

I did contemplate turning them into Rake tasks as we did in Manuals Publisher, but I realised that would mean updating [the corresponding documentation](https://github.com/alphagov/govuk-developer-docs/blob/8757e2bcc61469b8d94f3d09a552c1608b17a90c/source/manual/howto-upload-an-asset-to-asset-manager.html.md).