### PR TITLE
Remove empty CarrierWave directories when new asset is created and file is removed after upload to S3

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -58,7 +58,9 @@ class Asset
     end
 
     after_transition to: :uploaded do |asset, _|
+      path = asset.file.path
       asset.remove_file!
+      FileUtils.rmdir(File.dirname(path), parents: true)
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -525,6 +525,10 @@ RSpec.describe Asset, type: :model do
     context 'when asset is clean' do
       let(:asset) { FactoryBot.create(:clean_asset) }
       let(:path) { asset.file.path }
+      let(:pathname) { Pathname.new(path) }
+      let(:dir) { pathname.parent }
+      let(:parent_dir) { pathname.parent.parent }
+      let(:grandparent_dir) { pathname.parent.parent.parent }
 
       it 'changes asset state to uploaded' do
         asset.upload_success!
@@ -542,6 +546,72 @@ RSpec.describe Asset, type: :model do
         asset.upload_success!
 
         expect(File.exist?(path)).to be_falsey
+      end
+
+      it 'removes the empty directory' do
+        asset.upload_success!
+
+        expect(Dir).not_to exist(dir), "#{dir} exists"
+      end
+
+      context 'when directory is not empty' do
+        before do
+          FileUtils.touch(dir.join('do-not-delete-me'))
+        end
+
+        after do
+          FileUtils.rm(dir.join('do-not-delete-me'), force: true)
+        end
+
+        it 'does not remove directory' do
+          asset.upload_success!
+
+          expect(Dir).to exist(dir), "#{dir} exists"
+        end
+      end
+
+      it 'removes the empty parent directory' do
+        asset.upload_success!
+
+        expect(Dir).not_to exist(parent_dir), "#{parent_dir} exists"
+      end
+
+      context 'when parent directory is not empty' do
+        before do
+          FileUtils.touch(parent_dir.join('do-not-delete-me'))
+        end
+
+        after do
+          FileUtils.rm(parent_dir.join('do-not-delete-me'), force: true)
+        end
+
+        it 'does not remove the parent directory' do
+          asset.upload_success!
+
+          expect(Dir).to exist(parent_dir), "#{parent_dir} exists"
+        end
+      end
+
+      it 'removes the empty grandparent directory' do
+        asset.upload_success!
+
+        expect(Dir).not_to exist(grandparent_dir), "#{grandparent_dir} exists"
+      end
+
+      context 'when grandparent directory is not empty' do
+        before do
+          FileUtils.touch(grandparent_dir.join('do-not-delete-me'))
+        end
+
+        after do
+          FileUtils.rm(grandparent_dir.join('do-not-delete-me'), force: true)
+        end
+
+        it 'does not remove the grandparent directory if not empty' do
+          asset.upload_success!
+
+          expect(Dir).to exist(grandparent_dir), "#{grandparent_dir} exists"
+        end
       end
     end
 

--- a/spec/support/carrier_wave.rb
+++ b/spec/support/carrier_wave.rb
@@ -2,6 +2,6 @@ def clean_upload_directory!
   FileUtils.rm_rf(Dir["#{AssetManager.carrier_wave_store_base_dir}/[^.]*"])
 end
 
-RSpec.configuration.after(:suite) do
+RSpec.configuration.after do
   clean_upload_directory!
 end


### PR DESCRIPTION
Since #373 we've been deleting an asset's underlying file from the filesystem once the file has been uploaded to S3. However, this was leaving behind a bunch of empty directories. This change means that the app now removes all empty parent directories when the file is removed.

The immediate motivation behind this change is that once alphagov/govuk-puppet#7016 is applied in production, the Asset Manager CarrierWave directory will no longer be sync-ed from the Asset Master to the Asset Slaves and there will therefore be a danger that the [`asset_master_and_slave_disk_space_similar_from_xxx` Icinga alert][1] might eventually be triggered by the non-zero disk space taken up by the empty directories.

The implementation makes use of `FileUtils.rmdir` with the `parents` option which is equivalent to the [`rmdir -p` unix command][2] and which recursively removes empty directories from the supplied path upwards.

Note that I think this means that in some circumstances top-level directories (e.g. `tmp/test_uploads/assets` in the test environment) might be removed, but I'm pretty confident CarrierWave creates directories using the equivalent of `mkdir -p` and so any missing intermediate directories will be created and whatever happens it will stop when it gets to the Rails project root which will never be empty.

As far as I can tell, the files and empty directories under the CarrierWave "cache" directory are automatically deleted by CarrierWave, so I don't think we need to worry about disk usage for that directory.

Note also that I've changed the specs so that the CarrierWave directory is cleaned out after *every* example, not just after all the specs have run. This was in order to make testing this change easier.

[1]: https://github.com/alphagov/govuk-puppet/blob/19837b4b351d97d84570bd8a7d01ef3420fbef94/modules/govuk/manifests/node/s_asset_slave.pp#L50-L63
[2]: http://www.linfo.org/rmdir.html
  