### PR TITLE
WIP: Handle URI encoded legacy url paths

### DIFF
--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -16,7 +16,7 @@ class WhitehallAssetsController < ApplicationController
 
   def show
     path = "/#{params[:path]}.#{params[:format]}"
-    @asset = WhitehallAsset.find_by(legacy_url_path: path)
+    @asset = WhitehallAsset.find_by(legacy_url_path: URI.decode(path))
 
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render json: AssetPresenter.new(@asset, view_context)

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -12,7 +12,7 @@ class AssetPresenter
       id: @view_context.asset_url(@asset.id),
       name: @asset.filename,
       content_type: @asset.content_type,
-      file_url: URI.join(Plek.new.asset_root, @asset.public_url_path).to_s,
+      file_url: URI.join(Plek.new.asset_root, URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,
     }
   end

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -146,5 +146,15 @@ RSpec.describe WhitehallAssetsController, type: :controller do
 
       expect(response.headers['Cache-Control']).to match("max-age=#{30.minutes}")
     end
+
+    context "an asset with a legacy_url_path containing URI encoded characters" do
+      let(:asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: '/government/uploads/îmage.png') }
+
+      it "renders the asset using the AssetPresenter" do
+        get :show, params: { path: URI.encode('government/uploads/îmage'), format: 'png' }
+
+        expect(response.body).to eq('"asset-as-json"')
+      end
+    end
   end
 end

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -54,5 +54,14 @@ RSpec.describe AssetPresenter do
     it 'returns hash including asset state' do
       expect(json).to include(state: 'unscanned')
     end
+
+    context 'when public url path contains non-ascii characters' do
+      let(:public_url_path) { '/public-ürl-path' }
+
+      it 'URI encodes the public asset URL' do
+        uri = URI.parse(json[:file_url])
+        expect(uri.path).to eq(URI.encode(public_url_path))
+      end
+    end
   end
 end


### PR DESCRIPTION
We've found a number of Whitehall assets whose filenames (and therefore their `legacy_url_path`s) contain non-ascii characters. These non-ascii characters cause problems when used in URLs to request Whitehall assets because the resulting URL is invalid.

I've updated the `AssetPresenter` to encode the asset URI so that we're presenting valid URLs to the world.

I've updated `WhitehallAssetsController#show` to decode the `legacy_url_path`. This is in preparation for updating the gds-api-adapters to URI encode the legacy_url_path when making a request for a Whitehall asset.
