### PR TITLE
Update Docker Healthcheck to use healthcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
 
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
The existing healthcheck errors out as there is nothing available on the
root route. This resolves that issue by using the provided healthcheck
route.