### PR TITLE
Percent encode public_url_path in asset JSON

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'addressable'
 gem 'aws-sdk', '~> 2.10.10'
 gem 'carrierwave', '~> 0.11.2'
 gem 'carrierwave-mongoid', '~> 0.10.0', require: 'carrierwave/mongoid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
     aws-sdk (2.10.105)
@@ -179,6 +181,7 @@ GEM
       ast (~> 2.3)
     plek (2.0.0)
     powerpack (0.1.1)
+    public_suffix (3.0.1)
     rack (2.0.3)
     rack-cache (1.7.1)
       rack (>= 0.4)
@@ -327,6 +330,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   aws-sdk (~> 2.10.10)
   carrierwave (~> 0.11.2)
   carrierwave-mongoid (~> 0.10.0)

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -12,7 +12,7 @@ class AssetPresenter
       id: @view_context.asset_url(@asset.id),
       name: @asset.filename,
       content_type: @asset.content_type,
-      file_url: URI.join(Plek.new.asset_root, @asset.public_url_path).to_s,
+      file_url: URI.join(Plek.new.asset_root, Addressable::URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,
     }
   end

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -54,5 +54,14 @@ RSpec.describe AssetPresenter do
     it 'returns hash including asset state' do
       expect(json).to include(state: 'unscanned')
     end
+
+    context 'when public url path contains non-ascii characters' do
+      let(:public_url_path) { '/public-ürl-path' }
+
+      it 'URI encodes the public asset URL' do
+        uri = URI.parse(json[:file_url])
+        expect(uri.path).to eq('/public-%C3%BCrl-path')
+      end
+    end
   end
 end


### PR DESCRIPTION
This supersedes PR #393.

We've found a number of Whitehall assets whose filenames (and therefore
their `legacy_url_path`s) contain non-ascii characters. We can safely
store these non-ascii characters in the database but need to escape them
when constructing the `file_url` in the JSON representation of an asset.
This addresses the bug described in issue #395.

I initially used Ruby's `URI.escape` method but Rubocop doesn't like
that as it's been marked as obsolete.

After this change we can upload and request a Whitehall asset whose
legacy_url_path contains a non-ascii character:

```
$ echo `date` > whitehall-assét.txt

$ curl http://asset-manager.dev.gov.uk/whitehall_assets \
  --form "asset[file]=@whitehall-assét.txt" \
  --form "asset[legacy_url_path]=/government/uploads/path/to/whitehall-assét.txt"
{
  "_response_info":{"status":"created"},
  "id":"http://asset-manager.dev.gov.uk/assets/5a562f05759b745bcb180de6",
  "name":"whitehall-ass_t.txt",
  "content_type":"text/plain",
  "file_url":"http://assets-origin.dev.gov.uk/government/uploads/path/to/whitehall-ass%C3%A9t.txt",
  "state":"unscanned"
}

$ curl
http://asset-manager.dev.gov.uk/government/uploads/path/to/whitehall-ass%C3%A9t.txt
Wed Jan 10 15:18:02 UTC 2018
```

Note that the version of CarrierWave we're using (0.11.x) doesn't
support non-ascii characters in uploaded filenames which is why the
`name` in the example JSON above has replaced the 'é' with an
underscore.