### PR TITLE
Include mongo & redis checks in healthcheck action

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,13 @@
+class HealthcheckController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def check
+    render json: healthcheck.details.merge(status: healthcheck.status)
+  end
+
+private
+
+  def healthcheck
+    @healthcheck ||= Healthcheck.build
+  end
+end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -1,0 +1,52 @@
+class Healthcheck
+  class Base
+    def name
+      raise NotImplemented
+    end
+
+    def status
+      raise NotImplemented
+    end
+
+    def details
+      raise NotImplemented
+    end
+  end
+
+  def self.build
+    new([
+      DatabaseHealthcheck.new,
+      RedisHealthcheck.new,
+    ])
+  end
+
+  def initialize(healthchecks = [])
+    @healthchecks = healthchecks
+  end
+
+  def status
+    if statuses.include?(:critical)
+      :critical
+    elsif statuses.include?(:warning)
+      :warning
+    else
+      :ok
+    end
+  end
+
+  def details
+    { checks: checks }
+  end
+
+private
+
+  def checks
+    @healthchecks.each.with_object({}) do |check, hash|
+      hash[check.name] = check.details.merge(status: check.status)
+    end
+  end
+
+  def statuses
+    @statuses ||= @healthchecks.map(&:status)
+  end
+end

--- a/app/models/healthcheck/database_healthcheck.rb
+++ b/app/models/healthcheck/database_healthcheck.rb
@@ -1,0 +1,18 @@
+class Healthcheck
+  class DatabaseHealthcheck < Base
+    def name
+      :database
+    end
+
+    def status
+      Asset.count
+      :ok
+    rescue Mongo::Error::NoServerAvailable
+      :critical
+    end
+
+    def details
+      {}
+    end
+  end
+end

--- a/app/models/healthcheck/redis_healthcheck.rb
+++ b/app/models/healthcheck/redis_healthcheck.rb
@@ -1,0 +1,15 @@
+class Healthcheck
+  class RedisHealthcheck < Base
+    def name
+      :redis
+    end
+
+    def status
+      Sidekiq.redis_info ? :ok : :critical
+    end
+
+    def details
+      {}
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,5 @@ Rails.application.routes.draw do
     mount Rack::File.new(AssetManager.fake_s3.root), at: AssetManager.fake_s3.path_prefix, as: 'fake_s3'
   end
 
-  get "/healthcheck" => Proc.new { [200, { "Content-type" => "text/plain" }, ["OK"]] }
+  get "/healthcheck", to: "healthcheck#check"
 end

--- a/spec/models/healthcheck/database_healthcheck_spec.rb
+++ b/spec/models/healthcheck/database_healthcheck_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck::DatabaseHealthcheck do
+  subject(:healthcheck) { described_class.new }
+
+  context "when the database is connected" do
+    specify { expect(healthcheck.status).to eq(:ok) }
+  end
+
+  context "when the database is not available" do
+    before do
+      allow(Asset).to receive(:count).and_raise(Mongo::Error::NoServerAvailable.allocate)
+    end
+
+    specify { expect(healthcheck.status).to eq(:critical) }
+  end
+end

--- a/spec/models/healthcheck/redis_healthcheck_spec.rb
+++ b/spec/models/healthcheck/redis_healthcheck_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck::RedisHealthcheck do
+  subject(:healthcheck) { described_class.new }
+
+  context "when redis is available" do
+    specify { expect(healthcheck.status).to eq(:ok) }
+  end
+
+  context "when redis is not available" do
+    before { allow(Sidekiq).to receive(:redis_info).and_return(false) }
+    specify { expect(healthcheck.status).to eq(:critical) }
+  end
+end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck do
+  subject(:healthcheck) { described_class.new(healthchecks) }
+
+  let(:critical) do
+    instance_double('Healthcheck::Base', name: :foo, status: :critical, details: {})
+  end
+
+  let(:warning) do
+    instance_double('Healthcheck::Base', name: :bar, status: :warning, details: { errors: 7 })
+  end
+
+  let(:ok) do
+    instance_double('Healthcheck::Base', name: :baz, status: :ok, details: { https: true })
+  end
+
+  context "when one of the checks is critical" do
+    let(:healthchecks) { [warning, critical, ok] }
+
+    specify { expect(healthcheck.status).to eq(:critical) }
+  end
+
+  context "when no checks are critical but one is warning" do
+    let(:healthchecks) { [ok, ok, warning] }
+
+    specify { expect(healthcheck.status).to eq(:warning) }
+  end
+
+  context "when all the checks are ok" do
+    let(:healthchecks) { [ok, ok, ok] }
+
+    specify { expect(healthcheck.status).to eq(:ok) }
+  end
+
+  describe "#details" do
+    let(:healthchecks) { [critical, warning, ok] }
+    let(:expected_checks) {
+      {
+        foo: { status: :critical },
+        bar: { status: :warning, errors: 7 },
+        baz: { status: :ok, https: true },
+      }
+    }
+
+    it "returns a hash containing statuses and details for the checks" do
+      expect(healthcheck.details).to eq(
+        checks: expected_checks,
+      )
+    end
+  end
+end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,10 +1,65 @@
 require "rails_helper"
 
 RSpec.describe "Healthcheck", type: :request do
-  it "responds with success on the healthcheck path" do
+  it "responds with json" do
     get "/healthcheck"
-    expect(response).to have_http_status(:success)
-    expect(response.content_type).to eq("text/plain")
-    expect(response.body).to eq("OK")
+
+    expect(response.status).to eq(200)
+    expect(response.content_type).to eq("application/json")
+    expect { data }.not_to raise_error
+  end
+
+  context "when the healthchecks pass" do
+    it "returns a status of 'ok'" do
+      get "/healthcheck"
+      expect(data.fetch(:status)).to eq("ok")
+    end
+  end
+
+  context "when one of the healthchecks is warning" do
+    let(:database_healthcheck) { Healthcheck::DatabaseHealthcheck.new }
+
+    before do
+      allow(Healthcheck::DatabaseHealthcheck)
+        .to receive(:new).and_return(database_healthcheck)
+      allow(database_healthcheck)
+        .to receive(:status).and_return(:warning)
+    end
+
+    it "returns a status of 'warning'" do
+      get "/healthcheck"
+      expect(data.fetch(:status)).to eq("warning")
+    end
+  end
+
+  context "when one of the healthchecks is critical" do
+    let(:database_healthcheck) { Healthcheck::DatabaseHealthcheck.new }
+
+    before do
+      allow(Healthcheck::DatabaseHealthcheck)
+        .to receive(:new).and_return(database_healthcheck)
+      allow(database_healthcheck)
+        .to receive(:status).and_return(:critical)
+    end
+
+    it "returns a status of 'critical'" do
+      get "/healthcheck"
+      expect(data.fetch(:status)).to eq("critical")
+    end
+  end
+
+  it "includes useful information about each check" do
+    get "/healthcheck"
+
+    expect(data.fetch(:checks)).to include(
+      database: { status: "ok" },
+      redis:    { status: "ok" },
+    )
+  end
+
+private
+
+  def data(body = response.body)
+    JSON.parse(body).deep_symbolize_keys
   end
 end


### PR DESCRIPTION
This was motivated by the recent discovery that Asset Manager wasn't properly configured to connect to Redis in the new AWS integration environment. If this healthcheck had been present, we would've been alerted to the problem much sooner.

This is modelled closely on the code in the [email-alert-api repo][1]. For now I've only included checks for mongo & redis connectivity. We can always add further checks later.

* I've included the logic for warnings as well as critical errors even though the checks I've included only report critical errors.
* I've included the logic for reporting details of the warnings/errors even though the checks I've included don't report any details.
* I had to make some changes to the code to fix some Rubocop RSpec violations, e.g. introduce a base class healthcheck, use named subjects & instance doubles in the specs, allow injection of healthchecks into the top-level Healthcheck class, etc.
* I couldn't find an equivalent of ActiveRecord::Base.connected?, so I ended up calling Asset.count and rescuing the relevant exception. Note that this may take some time to timeout if MongoDB isn't available - 30 secs in the development environment.

[1]: https://github.com/alphagov/email-alert-api