### PR TITLE
Revert "Remove empty CarrierWave directories when new asset is created and file is removed after upload to S3" (#390)

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -58,9 +58,7 @@ class Asset
     end
 
     after_transition to: :uploaded do |asset, _|
-      path = asset.file.path
       asset.remove_file!
-      FileUtils.rmdir(File.dirname(path), parents: true)
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -525,10 +525,6 @@ RSpec.describe Asset, type: :model do
     context 'when asset is clean' do
       let(:asset) { FactoryBot.create(:clean_asset) }
       let(:path) { asset.file.path }
-      let(:pathname) { Pathname.new(path) }
-      let(:dir) { pathname.parent }
-      let(:parent_dir) { pathname.parent.parent }
-      let(:grandparent_dir) { pathname.parent.parent.parent }
 
       it 'changes asset state to uploaded' do
         asset.upload_success!
@@ -546,72 +542,6 @@ RSpec.describe Asset, type: :model do
         asset.upload_success!
 
         expect(File.exist?(path)).to be_falsey
-      end
-
-      it 'removes the empty directory' do
-        asset.upload_success!
-
-        expect(Dir).not_to exist(dir), "#{dir} exists"
-      end
-
-      context 'when directory is not empty' do
-        before do
-          FileUtils.touch(dir.join('do-not-delete-me'))
-        end
-
-        after do
-          FileUtils.rm(dir.join('do-not-delete-me'), force: true)
-        end
-
-        it 'does not remove directory' do
-          asset.upload_success!
-
-          expect(Dir).to exist(dir), "#{dir} exists"
-        end
-      end
-
-      it 'removes the empty parent directory' do
-        asset.upload_success!
-
-        expect(Dir).not_to exist(parent_dir), "#{parent_dir} exists"
-      end
-
-      context 'when parent directory is not empty' do
-        before do
-          FileUtils.touch(parent_dir.join('do-not-delete-me'))
-        end
-
-        after do
-          FileUtils.rm(parent_dir.join('do-not-delete-me'), force: true)
-        end
-
-        it 'does not remove the parent directory' do
-          asset.upload_success!
-
-          expect(Dir).to exist(parent_dir), "#{parent_dir} exists"
-        end
-      end
-
-      it 'removes the empty grandparent directory' do
-        asset.upload_success!
-
-        expect(Dir).not_to exist(grandparent_dir), "#{grandparent_dir} exists"
-      end
-
-      context 'when grandparent directory is not empty' do
-        before do
-          FileUtils.touch(grandparent_dir.join('do-not-delete-me'))
-        end
-
-        after do
-          FileUtils.rm(grandparent_dir.join('do-not-delete-me'), force: true)
-        end
-
-        it 'does not remove the grandparent directory if not empty' do
-          asset.upload_success!
-
-          expect(Dir).to exist(grandparent_dir), "#{grandparent_dir} exists"
-        end
       end
     end
 

--- a/spec/support/carrier_wave.rb
+++ b/spec/support/carrier_wave.rb
@@ -2,6 +2,6 @@ def clean_upload_directory!
   FileUtils.rm_rf(Dir["#{AssetManager.carrier_wave_store_base_dir}/[^.]*"])
 end
 
-RSpec.configuration.after do
+RSpec.configuration.after(:suite) do
   clean_upload_directory!
 end


### PR DESCRIPTION
This reverts commit 53fe16b04a24a4244f7cc03e07a0da34110d6028, reversing changes made to 1cb2caed8d0c340d2908865e1b30dbf8ee2fecdc.

I'm reverting #390, because we've been seeing the following exceptions:

* [`VirusScanner::Error` in `Sidekiq/VirusScanWorker`][1]
* [`Errno::ENOENT` in `Sidekiq/SaveToCloudStorageWorker`][2]

Which both look as if they are likely to be related to the removal of directories supposedly after a file has been uploaded to S3.

[1]: https://sentry.io/govuk/app-asset-manager/issues/432945964/
[2]: https://sentry.io/govuk/app-asset-manager/issues/433068645/