### PR TITLE
Add MongoDB index for Asset#legacy_url_path

### DIFF
--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -1,5 +1,6 @@
 class WhitehallAsset < Asset
   field :legacy_url_path, type: String
+  index legacy_url_path: 1
   attr_readonly :legacy_url_path
 
   field :legacy_etag, type: String


### PR DESCRIPTION
We've seen a marked slow-down in creating Whitehall assets since a large number of them have been migrated from Whitehall to Asset Manager and we think this slow-down may be causing [`GdsApi::TimedOutException` exceptions][1] in Whitehall.

The following controller actions lookup Whitehall assets using `legacy_url_path`:

* WhitehallAssetsController#create
* WhitehallAssetsController#show
* WhitehallMediacontroller#download

In adding this index, I can see that the `totalDocsExamined` number in the explanation of the query comes down from 65660 (the total number of assets) to 1 on my local machine. I believe there are now more than 600K assets in Asset Manager in production and so the speed up should be considerable.

My only hesitation is how long it will take to apply the index in production, but it seems to run very fast ~1 sec on my local machine, so I'm hopeful it shouldn't take too long and I plan to test it on integration before merging.

### Without index

    irb> path = "/government/uploads/system/uploads/organisation/logo/301/Parole_Board_logo2.txt"
    => "/government/uploads/system/uploads/organisation/logo/301/Parole_Board_logo2.txt"
    irb> WhitehallAsset.where(legacy_url_path: path).explain['executionStats']['totalDocsExamined']
    => 65660
    irb> Asset.unscoped.count
    => 65660
    > WhitehallAsset.unscoped.count
    => 841

### Add index

    $ rake db:mongoid:create_indexes

### With index

    irb> path = "/government/uploads/system/uploads/organisation/logo/301/Parole_Board_logo2.txt"
    => "/government/uploads/system/uploads/organisation/logo/301/Parole_Board_logo2.txt"
    irb> WhitehallAsset.where(legacy_url_path: path).explain['executionStats']['totalDocsExamined']
    => 1

[1]: https://sentry.io/govuk/app-whitehall/issues/401840961/