### PR TITLE
Ensure we support content types of whitehall assets

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,14 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "text/rtf", :rtf
+
+Mime::Type.register "application/vnd.ms-excel", :xls
+Mime::Type.register "application/msword", :doc
+
+Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
+Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
+
+Mime::Type.register "application/vnd.oasis.opendocument.spreadsheet", :ods
+Mime::Type.register "application/vnd.oasis.opendocument.text", :odt

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Asset, type: :model do
       end
 
       context 'and the extension is not a recognised mime type' do
-        let(:asset) { Asset.new(file: load_fixture_file("asset-with-unregistered-mimetype-extension.doc")) }
+        let(:asset) { Asset.new(file: Tempfile.new(['file', '.unknown-extension'])) }
 
         it "returns default content type" do
           expect(asset.content_type).to eq('application/octet-stream')
@@ -321,6 +321,60 @@ RSpec.describe Asset, type: :model do
       file = Tempfile.new(['file', '.png'])
       asset = Asset.new(file: file)
       expect(asset.content_type).to eq('image/png')
+    end
+
+    it 'handles .pdf file extensions' do
+      file = Tempfile.new(['file', '.pdf'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/pdf')
+    end
+
+    it 'handles .csv file extensions' do
+      file = Tempfile.new(['file', '.csv'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('text/csv')
+    end
+
+    it 'handles .rtf file extensions' do
+      file = Tempfile.new(['file', '.rtf'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('text/rtf')
+    end
+
+    it 'handles .doc file extensions' do
+      file = Tempfile.new(['file', '.doc'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/msword')
+    end
+
+    it 'handles .docx file extensions' do
+      file = Tempfile.new(['file', '.docx'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+    end
+
+    it 'handles .xls file extensions' do
+      file = Tempfile.new(['file', '.xls'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.ms-excel')
+    end
+
+    it 'handles .xlsx file extensions' do
+      file = Tempfile.new(['file', '.xlsx'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    end
+
+    it 'handles .odt file extensions' do
+      file = Tempfile.new(['file', '.odt'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.oasis.opendocument.text')
+    end
+
+    it 'handles .ods file extensions' do
+      file = Tempfile.new(['file', '.ods'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.oasis.opendocument.spreadsheet')
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -298,6 +298,30 @@ RSpec.describe Asset, type: :model do
         expect(asset.content_type).to eq('application/octet-stream')
       end
     end
+
+    it 'handles .jpg file extensions' do
+      file = Tempfile.new(['file', '.jpg'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('image/jpeg')
+    end
+
+    it 'handles .jpeg file extensions' do
+      file = Tempfile.new(['file', '.jpeg'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('image/jpeg')
+    end
+
+    it 'handles .gif file extensions' do
+      file = Tempfile.new(['file', '.gif'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('image/gif')
+    end
+
+    it 'handles .png file extensions' do
+      file = Tempfile.new(['file', '.png'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('image/png')
+    end
   end
 
   describe '#image?' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -376,6 +376,12 @@ RSpec.describe Asset, type: :model do
       asset = Asset.new(file: file)
       expect(asset.content_type).to eq('application/vnd.oasis.opendocument.spreadsheet')
     end
+
+    it 'handles .svg file extensions' do
+      file = Tempfile.new(['file', '.svg'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('image/svg+xml')
+    end
   end
 
   describe '#image?' do


### PR DESCRIPTION
This addresses https://github.com/alphagov/asset-manager/issues/417 and https://github.com/alphagov/asset-manager/issues/408.

I've ensured we're setting the correct `Content-Type` header for assets allowed by Whitehall's non-attachments assets that we're in the process of migrating to Asset Manager.