### PR TITLE
Remove unused access-limiting functionality

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -28,7 +28,6 @@ protected
   def asset_servable?
     asset.filename_valid?(params[:filename]) &&
       asset.uploaded? &&
-      asset.accessible_by?(current_user) &&
       asset.mainstream?
   end
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,4 @@
 class MediaController < BaseMediaController
-  before_action :authenticate_if_private
-
   def download
     unless asset_servable?
       error_404
@@ -34,16 +32,8 @@ protected
       asset.mainstream?
   end
 
-  def authenticate_if_private
-    authenticate_user! if requested_via_private_vhost?
-  end
-
   def asset
     @asset ||= Asset.find(params[:id])
-  end
-
-  def requested_via_private_vhost?
-    request.host == ENV['PRIVATE_ASSET_MANAGER_HOST']
   end
 
   def redirect_to_current_filename

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -111,12 +111,6 @@ class Asset
     @md5_hexdigest ||= Digest::MD5.hexdigest(file.file.read)
   end
 
-  def accessible_by?(user)
-    return true unless access_limited?
-
-    user && user.organisation_slug == self.organisation_slug
-  end
-
 protected
 
   def store_metadata

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -13,9 +13,6 @@ class Asset
   field :uuid, type: String, default: -> { SecureRandom.uuid }
   attr_readonly :uuid
 
-  field :access_limited, type: Boolean, default: false
-  field :organisation_slug, type: String
-
   field :etag, type: String
   protected :etag=
 
@@ -26,7 +23,6 @@ class Asset
   protected :md5_hexdigest=
 
   validates :file, presence: true, unless: :uploaded?
-  validates :organisation_slug, presence: true, if: :access_limited?
 
   validates :uuid, presence: true,
                    uniqueness: true,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,17 @@
+namespace :db do
+  task remove_unused_fields_from_assets: :environment do
+    if Asset.unscoped.where(access_limited: true).none?
+      Asset.update_all('$unset' => { 'access_limited' => true })
+      puts 'Asset#access_limited field removed successfully'
+    else
+      puts 'Error: Unable to remove Asset#access_limited'
+    end
+
+    if Asset.unscoped.where(:organisation_slug.ne => nil).none?
+      Asset.update_all('$unset' => { 'organisation_slug' => true })
+      puts 'Asset#organisation_slug field removed successfully'
+    else
+      puts 'Error: Unable to remove Asset#organisation_slug'
+    end
+  end
+end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe MediaController, type: :controller do
   describe "GET 'download'" do
     let(:params) { { params: { id: asset, filename: asset.filename } } }
 
-    before do
-      allow(controller).to receive_messages(requested_via_private_vhost?: false)
-    end
-
     context "with a valid uploaded file" do
       let(:asset) { FactoryBot.create(:uploaded_asset) }
 
@@ -104,38 +100,6 @@ RSpec.describe MediaController, type: :controller do
 
       it "responds with 200 OK for unrestricted documents" do
         get :download, params: { id: unrestricted_asset, filename: 'asset.png' }
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "access limiting on the private interface" do
-      let(:asset) { FactoryBot.create(:access_limited_asset, organisation_slug: 'correct-organisation-slug') }
-
-      before do
-        allow(controller).to receive_messages(requested_via_private_vhost?: true)
-      end
-
-      it "bounces anonymous users to sign-on" do
-        expect(controller).to receive(:authenticate_user!)
-
-        get :download, params: { id: asset, filename: 'asset.png' }
-      end
-
-      it "responds with 404 Not Found for access-limited documents if the user has the wrong organisation" do
-        user = FactoryBot.create(:user, organisation_slug: 'incorrect-organisation-slug')
-        login_as(user)
-
-        get :download, params: { id: asset, filename: 'asset.png' }
-
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it "responds with 200 OK for access-limited documents if the user has the right organisation" do
-        user = FactoryBot.create(:user, organisation_slug: 'correct-organisation-slug')
-        login_as(user)
-
-        get :download, params: { id: asset, filename: 'asset.png' }
-
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -89,21 +89,6 @@ RSpec.describe MediaController, type: :controller do
       end
     end
 
-    context "access limiting on the public interface" do
-      let(:restricted_asset) { FactoryBot.create(:access_limited_asset, organisation_slug: 'example-slug') }
-      let(:unrestricted_asset) { FactoryBot.create(:uploaded_asset) }
-
-      it "responds with 404 Not Found for access-limited documents" do
-        get :download, params: { id: restricted_asset, filename: 'asset.png' }
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it "responds with 200 OK for unrestricted documents" do
-        get :download, params: { id: unrestricted_asset, filename: 'asset.png' }
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
     context "with a soft deleted file" do
       let(:asset) { FactoryBot.create(:deleted_asset) }
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -12,11 +12,6 @@ FactoryBot.define do
     after :create, &:upload_success!
   end
 
-  factory :access_limited_asset, parent: :uploaded_asset do
-    access_limited true
-    organisation_slug 'example-organisation'
-  end
-
   factory :deleted_asset, parent: :asset do
     deleted_at { Time.now }
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -194,38 +194,6 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "#accessible_by?(user)" do
-    let(:user) { FactoryBot.build(:user, organisation_slug: 'example-organisation') }
-
-    it "is always true if the asset is not access limited" do
-      expect(Asset.new(access_limited: false)).to be_accessible_by(user)
-      expect(Asset.new(access_limited: false)).to be_accessible_by(nil)
-      asset = Asset.new(access_limited: false, organisation_slug: (user.organisation_slug + "-2"))
-      expect(asset).to be_accessible_by(user)
-    end
-
-    it "is true if the asset is access limited and the user has the correct organisation" do
-      asset = Asset.new(access_limited: true, organisation_slug: user.organisation_slug)
-      expect(asset).to be_accessible_by(user)
-    end
-
-    it "is false if the asset is access limited and the user has an incorrect organisation" do
-      asset = Asset.new(access_limited: true, organisation_slug: (user.organisation_slug + "-2"))
-      expect(asset).not_to be_accessible_by(user)
-    end
-
-    it "is false if the asset is access limited and the user has no organisation" do
-      unassociated_user = FactoryBot.build(:user, organisation_slug: nil)
-      asset = Asset.new(access_limited: true, organisation_slug: user.organisation_slug)
-      expect(asset).not_to be_accessible_by(unassociated_user)
-    end
-
-    it "is false if the asset is access limited and the user is not logged in" do
-      asset = Asset.new(access_limited: true, organisation_slug: user.organisation_slug)
-      expect(asset).not_to be_accessible_by(nil)
-    end
-  end
-
   describe "soft deletion" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -25,24 +25,6 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
-
-    it 'is valid without an organisation slug' do
-      asset.organisation_slug = nil
-      expect(asset).to be_valid
-    end
-
-    context 'when access-limited' do
-      subject(:asset) { FactoryBot.build(:access_limited_asset) }
-
-      it 'is valid when built from factory' do
-        expect(asset).to be_valid
-      end
-
-      it 'is not valid without an organisation slug' do
-        asset.organisation_slug = nil
-        expect(asset).not_to be_valid
-      end
-    end
   end
 
   describe 'creation' do


### PR DESCRIPTION
We're about to add functionality to the Asset Manager to protect draft assets behind SSO and this unused functionality just confuses matters. Note that this PR probably also addresses the concerns detailed in https://github.com/alphagov/asset-manager/issues/156.

### Remove authentication for private virtual host

Although in govuk-puppet [the `PRIVATE_ASSET_MANAGER_HOST` environment variable is set to `private-asset-manager.${app_domain}`][1] and [`private-asset-manager` is added as an alias to the `asset-manager` virtual host][2], the Asset Manager app never supplies URLs using this hostname to publishing apps and I haven't found any evidence that any of the publishing apps manually construct URLs using this hostname. So as far as I can tell this functionality is not currently (and possibly has never been) used.

We're about to add functionality to the Asset Manager to protect draft assets behind SSO and this unused functionality just confused matters.

I plan to remove the related code from govuk-puppet in a PR on that repo.

### Remove access-limited functionality for Mainstream assets

At some point it was possible to mark an asset as access-limited. However, since [the upgrade to Rails v4][3] this will have been prevented by [Rails' Strong Parameter functionality][4]. This won't have been noticed, because there are no specs testing that it's possible to supply the `access_limited` or `organisation_slug` parameters to the API endpoints for creating or updating an asset. If either of these parameters are supplied to these API endpoints, the parameters are stripped from the attributes used in the mass assignment and the a warning like the following is logged:

    Unpermitted parameters: :access_limited, :organisation_slug

I confirmed that there are currently no assets in production with either of these fields set by asking for the following queries to be run in the Asset Manager Rails console:

    irb> Asset.unscoped.where(access_limited: nil).count
    => 0
    irb> Asset.unscoped.where(access_limited: false).count
    => 1100658
    irb> Asset.unscoped.where(access_limited: true).count
    => 0

    irb> Asset.unscoped.where(organisation_slug: nil).count
    => 1100658
    irb> Asset.unscoped.where(:organisation_slug.ne =>
    nil).count
    => 0

### Tidy up

The rest of the PR just removes the now redundant code and database fields. It adds a new Rake task to achieve the latter.

[1]:
https://github.com/alphagov/govuk-puppet/blob/9a4ad116d8b495690415405e6ee3b0663959d06d/modules/govuk/manifests/apps/asset_manager.pp#L69-L74
[2]:
https://github.com/alphagov/govuk-puppet/blob/9a4ad116d8b495690415405e6ee3b0663959d06d/modules/govuk/manifests/apps/asset_manager.pp#L172
[3]: https://github.com/alphagov/asset-manager/pull/42
[4]:
http://guides.rubyonrails.org/v5.1.4/action_controller_overview.html#strong-parameters
