### PR TITLE
Allow assets to be marked as draft

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -55,6 +55,6 @@ private
   end
 
   def asset_params
-    params.require(:asset).permit(:file)
+    params.require(:asset).permit(:file, :draft)
   end
 end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -27,7 +27,7 @@ private
   def asset_params
     params
       .require(:asset)
-      .permit(:file, :legacy_url_path, :legacy_etag, :legacy_last_modified)
+      .permit(:file, :draft, :legacy_url_path, :legacy_etag, :legacy_last_modified)
   end
 
   def existing_asset_with_this_legacy_url_path

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -13,6 +13,8 @@ class Asset
   field :uuid, type: String, default: -> { SecureRandom.uuid }
   attr_readonly :uuid
 
+  field :draft, type: Boolean, default: false
+
   field :etag, type: String
   protected :etag=
 

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -14,6 +14,7 @@ class AssetPresenter
       content_type: @asset.content_type,
       file_url: URI.join(Plek.new.asset_root, Addressable::URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,
+      draft: @asset.draft?
     }
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe AssetsController, type: :controller do
         expect(body['id']).to eq("http://test.host/assets/#{asset.id}")
         expect(body['name']).to eq("asset.png")
         expect(body['content_type']).to eq("image/png")
+        expect(body['draft']).to be_falsey
       end
     end
 
@@ -61,6 +62,14 @@ RSpec.describe AssetsController, type: :controller do
         post :create, params: { asset: attributes }
 
         expect(assigns(:asset)).to be_draft
+      end
+
+      it "returns the draft status of the new asset" do
+        post :create, params: { asset: attributes }
+
+        body = JSON.parse(response.body)
+
+        expect(body['draft']).to be_truthy
       end
     end
   end
@@ -93,6 +102,7 @@ RSpec.describe AssetsController, type: :controller do
         expect(body['id']).to eq("http://test.host/assets/#{asset.id}")
         expect(body['name']).to eq("asset2.jpg")
         expect(body['content_type']).to eq("image/jpeg")
+        expect(body['draft']).to be_falsey
       end
     end
 
@@ -121,6 +131,14 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset)).to be_draft
+      end
+
+      it "returns the draft status of the updated asset" do
+        put :update, params: { id: asset.id, asset: attributes }
+
+        body = JSON.parse(response.body)
+
+        expect(body['draft']).to be_truthy
       end
     end
   end
@@ -185,6 +203,14 @@ RSpec.describe AssetsController, type: :controller do
 
         expect(assigns(:asset)).to be_a(Asset)
         expect(assigns(:asset).id).to eq(asset.id)
+      end
+
+      it "returns the draft status of the asset" do
+        get :show, params: { id: asset.id }
+
+        body = JSON.parse(response.body)
+
+        expect(body['draft']).to be_falsey
       end
     end
 

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe AssetsController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context "a draft asset" do
+      let(:attributes) { { draft: true, file: load_fixture_file("asset.png") } }
+
+      it "is persisted" do
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset)).to be_draft
+      end
+    end
   end
 
   describe "PUT update" do
@@ -100,6 +110,17 @@ RSpec.describe AssetsController, type: :controller do
         post :create, params: { asset: attributes }
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "a draft asset" do
+      let(:attributes) { { draft: true, file: load_fixture_file("asset2.jpg") } }
+      let(:asset) { FactoryBot.create(:asset) }
+
+      it "updates attributes" do
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset)).to be_draft
       end
     end
   end

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -104,6 +104,23 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(existing_asset.reload).to be_deleted
       end
     end
+
+    context "a draft asset" do
+      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, :with_legacy_metadata, draft: true) }
+
+      it "stores draft status on asset" do
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset)).to be_draft
+      end
+
+      it "returns JSON response including draft status of new asset" do
+        post :create, params: { asset: attributes }
+
+        body = JSON.parse(response.body)
+        expect(body['draft']).to be_truthy
+      end
+    end
   end
 
   describe 'GET show' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -77,6 +77,30 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe '#draft?' do
+    subject(:asset) { Asset.new }
+
+    it 'returns false-y by default' do
+      expect(asset).not_to be_draft
+    end
+
+    context 'when draft attribute is set to false' do
+      subject(:asset) { Asset.new(draft: false) }
+
+      it 'returns false-y by default' do
+        expect(asset).not_to be_draft
+      end
+    end
+
+    context 'when draft attribute is set to true' do
+      subject(:asset) { Asset.new(draft: true) }
+
+      it 'returns truth-y by default' do
+        expect(asset).to be_draft
+      end
+    end
+  end
+
   describe '#public_url_path' do
     subject(:asset) { Asset.new }
 

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe AssetPresenter do
       expect(json).to include(state: 'unscanned')
     end
 
+    it 'returns hash including asset draft status as false' do
+      expect(json).to include(draft: false)
+    end
+
+    context 'when asset is draft' do
+      before do
+        asset.draft = true
+      end
+
+      it 'returns hash including asset draft status as true' do
+        expect(json).to include(draft: true)
+      end
+    end
+
     context 'when public url path contains non-ascii characters' do
       let(:public_url_path) { '/public-ürl-path' }
 


### PR DESCRIPTION
We want to migrate Whitehall attachments to Asset Manager, but Whitehall currently protects draft attachments behind SSO, so before we can do the migration we need to implement similar functionality in Asset Manager. This PR is the first small step towards doing that - it makes it possible to mark an asset as draft when calling the "create" & "update" API actions. It includes the draft status of an asset in the response to those API calls and the "show" API call.

See #431.

### Notes

* For the moment, public requests for assets marked as draft are treated the same as those for assets not marked as draft. I plan to introduce authentication, etc, as a separate PR when addressing #432.

* I've consciously chosen not to update the documentation for the moment since this is somewhat experimental functionality and I don't want to encourage people to use it yet.

* We may need to add a Whitehall-specific "update" API action to allow the Whitehall app to mark a draft Whitehall asset as draft using the `legacy_url_path` rather than the `id`, but I think that's better addressed in a separate PR if/when we know we definitely need it. This PR should be enough for us to try out the new functionality using tools like `curl`.

