### PR TITLE
[Do not merge] Require SSO authentication for requests from draft-assets host

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -1,7 +1,12 @@
 class BaseMediaController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, unless: :requested_from_draft_assets_host?
 
 protected
+
+  def requested_from_draft_assets_host?
+    original_host = URI(request.original_url).host
+    original_host.split('.').first == 'draft-assets'
+  end
 
   def proxy_to_s3_via_nginx(asset)
     headers['ETag'] = %{"#{asset.etag}"}

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -19,10 +19,34 @@ RSpec.describe BaseMediaController, type: :controller do
     end
   end
 
-  it 'does not require sign-in permission' do
+  it 'does not require sign-in permission by default' do
     expect(controller).not_to receive(:authenticate_user!)
 
     get :anything
+  end
+
+  context 'when requested from draft-assets host' do
+    before do
+      request.headers['X-Forwarded-Host'] = 'draft-assets.example.gov.uk'
+    end
+
+    it 'does require sign-in permission' do
+      expect(controller).to receive(:authenticate_user!)
+
+      get :anything
+    end
+  end
+
+  context 'when requested from host other than draft-assets' do
+    before do
+      request.headers['X-Forwarded-Host'] = 'assets-origin.example.gov.uk'
+    end
+
+    it 'does not require sign-in permission' do
+      expect(controller).not_to receive(:authenticate_user!)
+
+      get :anything
+    end
   end
 
   describe '#proxy_to_s3_via_nginx' do


### PR DESCRIPTION
This makes draft assets available to authenticated users via the new `draft-assets` host. Requests from non-authenticated users will be rejected. Requests from the existing `assets-origin` host will continue not to require authentication.

Note that by authenticating *before* we've made any queries to the database we can reduce the chances of a DOS attack causing problems.

Note also that this change applies to both Mainstream & Whitehall assets although we're only really interested in Whitehall assets at the moment.
