### PR TITLE
Require authentication for requests from draft-assets host

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
-    plek (2.0.0)
+    plek (2.1.0)
     powerpack (0.1.1)
     public_suffix (3.0.1)
     rack (2.0.3)

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -1,7 +1,11 @@
 class BaseMediaController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, unless: :requested_from_draft_assets_host?
 
 protected
+
+  def requested_from_draft_assets_host?
+    request.host == AssetManager.govuk.draft_assets_host
+  end
 
   def proxy_to_s3_via_nginx(asset)
     headers['ETag'] = %{"#{asset.etag}"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module AssetManager
 
   mattr_accessor :app_host
 
+  mattr_accessor :govuk
+
   mattr_accessor :s3
 
   mattr_accessor :carrier_wave_store_base_dir

--- a/config/initializers/govuk.rb
+++ b/config/initializers/govuk.rb
@@ -1,0 +1,3 @@
+require 'govuk_configuration'
+
+AssetManager.govuk = GovukConfiguration.new

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -1,6 +1,7 @@
 class GovukConfiguration
-  def initialize(env = ENV)
+  def initialize(env = ENV, plek = Plek.new)
     @env = env
+    @plek = plek
   end
 
   def app_host
@@ -9,5 +10,10 @@ class GovukConfiguration
     "http://#{app_name}.#{app_domain}"
   rescue KeyError
     nil
+  end
+
+  def draft_assets_host
+    draft_assets_base_uri = @plek.external_url_for('draft-assets')
+    URI.parse(draft_assets_base_uri).host
   end
 end

--- a/spec/controllers/base_media_controller_spec.rb
+++ b/spec/controllers/base_media_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe BaseMediaController, type: :controller do
+  let(:draft_assets_host) { AssetManager.govuk.draft_assets_host }
+
   controller do
     def anything
       head :ok
@@ -19,10 +21,34 @@ RSpec.describe BaseMediaController, type: :controller do
     end
   end
 
-  it 'does not require sign-in permission' do
+  it 'does not require sign-in permission by default' do
     expect(controller).not_to receive(:authenticate_user!)
 
     get :anything
+  end
+
+  context 'when requested from draft-assets host' do
+    before do
+      request.headers['X-Forwarded-Host'] = draft_assets_host
+    end
+
+    it 'does require sign-in permission' do
+      expect(controller).to receive(:authenticate_user!)
+
+      get :anything
+    end
+  end
+
+  context 'when requested from host other than draft-assets' do
+    before do
+      request.headers['X-Forwarded-Host'] = "not-#{draft_assets_host}"
+    end
+
+    it 'does not require sign-in permission' do
+      expect(controller).not_to receive(:authenticate_user!)
+
+      get :anything
+    end
   end
 
   describe '#proxy_to_s3_via_nginx' do

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -50,4 +50,20 @@ RSpec.describe GovukConfiguration do
       end
     end
   end
+
+  describe '#draft_assets_host' do
+    subject(:config) { described_class.new(env, plek) }
+
+    let(:env) { {} }
+    let(:plek) { instance_double('Plek') }
+
+    before do
+      allow(plek).to receive(:external_url_for).with('draft-assets')
+        .and_return('https://draft-assets.publishing.service.gov.uk')
+    end
+
+    it 'returns externally facing draft-assets host' do
+      expect(config.draft_assets_host).to eq('draft-assets.publishing.service.gov.uk')
+    end
+  end
 end


### PR DESCRIPTION
The main change in this PR is in the last commit which means that any request from the `draft-assets` host requires SSO authentication.

In a future PR we plan to redirect requests from the
`assets-origin` host for assets marked as draft to the `draft-assets` host.

Note that this change applies to both Mainstream & Whitehall assets.

Note also that we're using the new `Plek#external_url_for` method to obtain the external version of the `draft-assets` host which should mean the functionality works in AWS environments (currently only integration).

Supersedes #432.