### PR TITLE
Remove unused AssetManager.app_host accessor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,8 +35,6 @@ module AssetManager
     config.assets.prefix = '/asset-manager'
   end
 
-  mattr_accessor :app_host
-
   mattr_accessor :govuk
 
   mattr_accessor :s3


### PR DESCRIPTION
This was made redundant in [this commit][1] and should have been removed at that point.

[1]:https://github.com/alphagov/asset-manager/commit/e6f630f0e335b0a1bb6db9366a6bd8c4da31a943