### PR TITLE
Redirect requests for assets marked as draft to draft-assets host

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -19,4 +19,10 @@ protected
 
     head :ok, content_type: asset.content_type
   end
+
+  def redirected_to_draft_assets_host_for?(asset)
+    if asset.draft? && !requested_from_draft_assets_host?
+      redirect_to host: AssetManager.govuk.draft_assets_host, format: params[:format]
+    end
+  end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,5 +1,9 @@
 class MediaController < BaseMediaController
   def download
+    if redirected_to_draft_assets_host_for?(asset)
+      return
+    end
+
     unless asset_servable?
       error_404
       return

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -8,7 +8,9 @@ class WhitehallMediaController < BaseMediaController
         redirect_to '/government/placeholder'
       end
       return
-    elsif asset.infected?
+    end
+
+    if asset.infected?
       error_404
       return
     end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,9 +1,5 @@
 class WhitehallMediaController < BaseMediaController
   def download
-    path = "/government/uploads/#{params[:path]}"
-    path += ".#{params[:format]}" if params[:format].present?
-    asset = WhitehallAsset.find_by(legacy_url_path: path)
-
     if asset.unscanned? || asset.clean?
       set_expiry(1.minute)
       if asset.image?
@@ -20,5 +16,15 @@ class WhitehallMediaController < BaseMediaController
     set_expiry(AssetManager.whitehall_cache_control.max_age)
     headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
     proxy_to_s3_via_nginx(asset)
+  end
+
+protected
+
+  def asset
+    @asset ||= begin
+      path = "/government/uploads/#{params[:path]}"
+      path += ".#{params[:format]}" if params[:format].present?
+      WhitehallAsset.find_by(legacy_url_path: path)
+    end
   end
 end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,5 +1,10 @@
 class WhitehallMediaController < BaseMediaController
   def download
+    if asset.infected?
+      error_404
+      return
+    end
+
     if asset.unscanned? || asset.clean?
       set_expiry(1.minute)
       if asset.image?
@@ -7,11 +12,6 @@ class WhitehallMediaController < BaseMediaController
       else
         redirect_to '/government/placeholder'
       end
-      return
-    end
-
-    if asset.infected?
-      error_404
       return
     end
 

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,5 +1,9 @@
 class WhitehallMediaController < BaseMediaController
   def download
+    if redirected_to_draft_assets_host_for?(asset)
+      return
+    end
+
     if asset.infected?
       error_404
       return

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe WhitehallMediaController, type: :controller do
     let(:path) { 'path/to/asset' }
     let(:format) { 'png' }
     let(:legacy_url_path) { "/government/uploads/#{path}.#{format}" }
-    let(:asset) { FactoryBot.build(:whitehall_asset, legacy_url_path: legacy_url_path, state: state) }
+    let(:draft) { false }
+    let(:attributes) { { legacy_url_path: legacy_url_path, state: state, draft: draft } }
+    let(:asset) { FactoryBot.build(:whitehall_asset, attributes) }
 
     before do
       allow(WhitehallAsset).to receive(:find_by).with(legacy_url_path: legacy_url_path).and_return(asset)
@@ -53,6 +55,44 @@ RSpec.describe WhitehallMediaController, type: :controller do
           expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
 
           get :download, params: { path: path, format: nil }
+        end
+      end
+    end
+
+    context 'when asset is draft and uploaded' do
+      let(:draft) { true }
+      let(:state) { 'uploaded' }
+      let(:draft_assets_host) { AssetManager.govuk.draft_assets_host }
+
+      context 'when requested from host other than draft-assets' do
+        before do
+          request.headers['X-Forwarded-Host'] = "not-#{draft_assets_host}"
+        end
+
+        it 'redirects to draft assets host' do
+          get :download, params: { path: path, format: format }
+
+          expect(controller).to redirect_to(host: draft_assets_host, path: path, format: format)
+        end
+      end
+
+      context 'when requested from draft-assets host' do
+        before do
+          request.headers['X-Forwarded-Host'] = draft_assets_host
+          allow(controller).to receive(:authenticate_user!)
+          allow(controller).to receive(:proxy_to_s3_via_nginx)
+        end
+
+        it 'requires authentication' do
+          expect(controller).to receive(:authenticate_user!)
+
+          get :download, params: { path: path, format: format }
+        end
+
+        it 'proxies asset to S3 via Nginx as usual' do
+          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+          get :download, params: { path: path, format: format }
         end
       end
     end


### PR DESCRIPTION
The significant changes are in the final commit of this PR which redirects requests for assets marked as draft to the `draft-assets` host if they have come from another host, typically `assets-origin`.

Assets marked as draft should only be accessed via the draft-assets host which requires authentication as of #444.

Note that these changes apply to both Mainstream & Whitehall assets.

Although I've managed to extract the common functionality into `BaseMediaController#redirected_to_draft_assets_host_for?`, I've ended up adding examples to the specs for both `MediaController` & `WhitehallMediaController`, because I found it awkward to add them to `BaseMediaController` spec.

I'm not entirely happy with the resulting code, but it's the best compromise I could come up with. Hopefully as we bring the two media controllers into line with each other all this code can be simplified.

In preparation for this PR, I've done some work to bring the two media controller a bit more into line with each other. While this wasn't strictly necessary, I found it made it easier to see where to make the changes.