### PR TITLE
Standardize code for redirecting to draft-assets host

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -20,9 +20,11 @@ protected
     head :ok, content_type: asset.content_type
   end
 
-  def redirected_to_draft_assets_host_for?(asset)
-    if asset.draft? && !requested_from_draft_assets_host?
-      redirect_to host: AssetManager.govuk.draft_assets_host, format: params[:format]
-    end
+  def redirect_to_draft_assets_host_for?(asset)
+    asset.draft? && !requested_from_draft_assets_host?
+  end
+
+  def redirect_to_draft_assets_host
+    redirect_to host: AssetManager.govuk.draft_assets_host, format: params[:format]
   end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,7 @@
 class MediaController < BaseMediaController
   def download
-    if redirected_to_draft_assets_host_for?(asset)
+    if redirect_to_draft_assets_host_for?(asset)
+      redirect_to_draft_assets_host
       return
     end
 

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,6 +1,7 @@
 class WhitehallMediaController < BaseMediaController
   def download
-    if redirected_to_draft_assets_host_for?(asset)
+    if redirect_to_draft_assets_host_for?(asset)
+      redirect_to_draft_assets_host
       return
     end
 


### PR DESCRIPTION
The previous implementation was non-standard and therefore confusing. In particular, the
`BaseMediaController#redirected_to_draft_assets_host_for?` method looked like a query method, but was actually a command method, i.e. it had side effects which might have been surprising. By splitting this method into a query method and a command method, we can avoid this confusion at the expense of a little duplication.

Addresses [this comment in an earlier PR](https://github.com/alphagov/asset-manager/pull/446#pullrequestreview-92674337).