### PR TITLE
Refactor assets controllers

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,16 +1,6 @@
 class AssetsController < BaseAssetsController
   before_action :restrict_request_format
 
-  def create
-    @asset = build_asset
-
-    if @asset.save
-      render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
-    else
-      error 422, @asset.errors.full_messages
-    end
-  end
-
   def update
     @asset = find_asset
 

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -19,7 +19,7 @@ class AssetsController < ApplicationController
   end
 
   def update
-    @asset = Asset.find(params.fetch(:id))
+    @asset = Asset.find(params[:id])
 
     if @asset.update_attributes(asset_params)
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
@@ -29,7 +29,7 @@ class AssetsController < ApplicationController
   end
 
   def destroy
-    @asset = Asset.find(params.fetch(:id))
+    @asset = Asset.find(params[:id])
 
     if @asset.destroy
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
@@ -39,7 +39,7 @@ class AssetsController < ApplicationController
   end
 
   def restore
-    @asset = Asset.unscoped.find(params.fetch(:id))
+    @asset = Asset.unscoped.find(params[:id])
 
     if @asset.restore
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,12 +1,5 @@
-class AssetsController < ApplicationController
+class AssetsController < BaseAssetsController
   before_action :restrict_request_format
-
-  def show
-    @asset = find_asset
-
-    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
-    render json: AssetPresenter.new(@asset, view_context)
-  end
 
   def create
     @asset = build_asset

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -2,14 +2,14 @@ class AssetsController < ApplicationController
   before_action :restrict_request_format
 
   def show
-    @asset = Asset.find(params[:id])
+    @asset = find_asset
 
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render json: AssetPresenter.new(@asset, view_context)
   end
 
   def create
-    @asset = Asset.new(asset_params)
+    @asset = build_asset
 
     if @asset.save
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
@@ -19,7 +19,7 @@ class AssetsController < ApplicationController
   end
 
   def update
-    @asset = Asset.find(params[:id])
+    @asset = find_asset
 
     if @asset.update_attributes(asset_params)
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
@@ -29,7 +29,7 @@ class AssetsController < ApplicationController
   end
 
   def destroy
-    @asset = Asset.find(params[:id])
+    @asset = find_asset
 
     if @asset.destroy
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
@@ -39,7 +39,7 @@ class AssetsController < ApplicationController
   end
 
   def restore
-    @asset = Asset.unscoped.find(params[:id])
+    @asset = find_asset(include_deleted: true)
 
     if @asset.restore
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
@@ -56,5 +56,14 @@ private
 
   def asset_params
     params.require(:asset).permit(:file, :draft)
+  end
+
+  def find_asset(include_deleted: false)
+    scope = include_deleted ? Asset.unscoped : Asset
+    scope.find(params[:id])
+  end
+
+  def build_asset
+    Asset.new(asset_params)
   end
 end

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -1,0 +1,8 @@
+class BaseAssetsController < ApplicationController
+  def show
+    @asset = find_asset
+
+    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
+    render json: AssetPresenter.new(@asset, view_context)
+  end
+end

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -5,4 +5,14 @@ class BaseAssetsController < ApplicationController
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render json: AssetPresenter.new(@asset, view_context)
   end
+
+  def create
+    @asset = build_asset
+
+    if @asset.save
+      render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
+    else
+      error 422, @asset.errors.full_messages
+    end
+  end
 end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -7,8 +7,7 @@ class WhitehallAssetsController < BaseAssetsController
     @asset = build_asset
 
     if @asset.save
-      presenter = AssetPresenter.new(@asset, view_context)
-      render json: presenter.as_json(status: :created), status: :created
+      render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
     else
       error 422, @asset.errors.full_messages
     end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -1,8 +1,6 @@
 class WhitehallAssetsController < ApplicationController
   def show
-    @asset = WhitehallAsset.from_params(
-      path: params[:path], format: params[:format]
-    )
+    @asset = find_asset
 
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render json: AssetPresenter.new(@asset, view_context)
@@ -13,7 +11,7 @@ class WhitehallAssetsController < ApplicationController
       existing_asset_with_this_legacy_url_path.destroy
     end
 
-    @asset = WhitehallAsset.new(asset_params)
+    @asset = build_asset
 
     if @asset.save
       presenter = AssetPresenter.new(@asset, view_context)
@@ -33,5 +31,15 @@ private
 
   def existing_asset_with_this_legacy_url_path
     WhitehallAsset.where(legacy_url_path: asset_params[:legacy_url_path])
+  end
+
+  def find_asset
+    WhitehallAsset.from_params(
+      path: params[:path], format: params[:format]
+    )
+  end
+
+  def build_asset
+    WhitehallAsset.new(asset_params)
   end
 end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -1,11 +1,4 @@
-class WhitehallAssetsController < ApplicationController
-  def show
-    @asset = find_asset
-
-    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
-    render json: AssetPresenter.new(@asset, view_context)
-  end
-
+class WhitehallAssetsController < BaseAssetsController
   def create
     if existing_asset_with_this_legacy_url_path.exists?
       existing_asset_with_this_legacy_url_path.destroy

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -15,9 +15,9 @@ class WhitehallAssetsController < ApplicationController
   end
 
   def show
-    path = "/#{params[:path]}"
-    path += ".#{params[:format]}" if params[:format].present?
-    @asset = WhitehallAsset.find_by(legacy_url_path: path)
+    @asset = WhitehallAsset.from_params(
+      path: params[:path], format: params[:format]
+    )
 
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
     render json: AssetPresenter.new(@asset, view_context)

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -1,4 +1,13 @@
 class WhitehallAssetsController < ApplicationController
+  def show
+    @asset = WhitehallAsset.from_params(
+      path: params[:path], format: params[:format]
+    )
+
+    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
+    render json: AssetPresenter.new(@asset, view_context)
+  end
+
   def create
     if existing_asset_with_this_legacy_url_path.exists?
       existing_asset_with_this_legacy_url_path.destroy
@@ -12,15 +21,6 @@ class WhitehallAssetsController < ApplicationController
     else
       error 422, @asset.errors.full_messages
     end
-  end
-
-  def show
-    @asset = WhitehallAsset.from_params(
-      path: params[:path], format: params[:format]
-    )
-
-    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
-    render json: AssetPresenter.new(@asset, view_context)
   end
 
 private

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -4,13 +4,7 @@ class WhitehallAssetsController < BaseAssetsController
       existing_asset_with_this_legacy_url_path.destroy
     end
 
-    @asset = build_asset
-
-    if @asset.save
-      render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
-    else
-      error 422, @asset.errors.full_messages
-    end
+    super
   end
 
 private

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -15,7 +15,8 @@ class WhitehallAssetsController < ApplicationController
   end
 
   def show
-    path = "/#{params[:path]}.#{params[:format]}"
+    path = "/#{params[:path]}"
+    path += ".#{params[:format]}" if params[:format].present?
     @asset = WhitehallAsset.find_by(legacy_url_path: path)
 
     @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -28,10 +28,8 @@ class WhitehallMediaController < BaseMediaController
 protected
 
   def asset
-    @asset ||= begin
-      path = "/government/uploads/#{params[:path]}"
-      path += ".#{params[:format]}" if params[:format].present?
-      WhitehallAsset.find_by(legacy_url_path: path)
-    end
+    @asset ||= WhitehallAsset.from_params(
+      path: params[:path], format: params[:format], path_prefix: 'government/uploads/'
+    )
   end
 end

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -16,6 +16,12 @@ class WhitehallAsset < Asset
       message: 'must start with /government/uploads'
     }
 
+  def self.from_params(path:, format: nil, path_prefix: nil)
+    legacy_url_path = "/#{path_prefix}#{path}"
+    legacy_url_path += ".#{format}" if format.present?
+    find_by(legacy_url_path: legacy_url_path)
+  end
+
   def etag
     legacy_etag || super
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -106,23 +106,6 @@ RSpec.describe AssetsController, type: :controller do
       end
     end
 
-    context "an invalid asset" do
-      let(:attributes) { { file: nil } }
-
-      it "is not persisted" do
-        post :create, params: { asset: attributes }
-
-        expect(assigns(:asset)).not_to be_persisted
-        expect(assigns(:asset).file.path).to be_nil
-      end
-
-      it "returns an unprocessable entity status" do
-        post :create, params: { asset: attributes }
-
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-    end
-
     context "a draft asset" do
       let(:attributes) { { draft: true, file: load_fixture_file("asset2.jpg") } }
       let(:asset) { FactoryBot.create(:asset) }

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -104,24 +104,24 @@ RSpec.describe AssetsController, type: :controller do
         expect(body['content_type']).to eq("image/jpeg")
         expect(body['draft']).to be_falsey
       end
-    end
 
-    context "a draft asset" do
-      let(:attributes) { { draft: true, file: load_fixture_file("asset2.jpg") } }
-      let(:asset) { FactoryBot.create(:asset) }
+      context "a draft asset" do
+        let(:attributes) { { draft: true, file: load_fixture_file("asset2.jpg") } }
+        let(:asset) { FactoryBot.create(:asset) }
 
-      it "updates attributes" do
-        put :update, params: { id: asset.id, asset: attributes }
+        it "updates attributes" do
+          put :update, params: { id: asset.id, asset: attributes }
 
-        expect(assigns(:asset)).to be_draft
-      end
+          expect(assigns(:asset)).to be_draft
+        end
 
-      it "returns the draft status of the updated asset" do
-        put :update, params: { id: asset.id, asset: attributes }
+        it "returns the draft status of the updated asset" do
+          put :update, params: { id: asset.id, asset: attributes }
 
-        body = JSON.parse(response.body)
+          body = JSON.parse(response.body)
 
-        expect(body['draft']).to be_truthy
+          expect(body['draft']).to be_truthy
+        end
       end
     end
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe AssetsController, type: :controller do
       it "deletes the asset" do
         delete :destroy, params: { id: asset.id }
 
-        expect((get :show, params: { id: asset.id }).status).to eq(404)
+        expect(Asset.where(id: asset.id).first).to be_nil
       end
 
       it "returns a success status" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe WhitehallAssetsController, type: :controller do
   end
 
   describe 'GET show' do
-    let(:asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: '/government/uploads/image.png') }
+    let(:legacy_url_path) { '/government/uploads/image.png' }
+    let(:asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: legacy_url_path) }
     let(:presenter) { instance_double(AssetPresenter) }
 
     before do
@@ -162,6 +163,16 @@ RSpec.describe WhitehallAssetsController, type: :controller do
       get :show, params: { path: 'government/uploads/image', format: 'png' }
 
       expect(response.headers['Cache-Control']).to match("max-age=#{30.minutes}")
+    end
+
+    context 'and legacy_url_path has no format' do
+      let(:legacy_url_path) { '/government/uploads/file' }
+
+      it 'returns a 200 response' do
+        get :show, params: { path: 'government/uploads/file' }
+
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -137,4 +137,37 @@ RSpec.describe WhitehallAsset, type: :model do
       expect(asset).not_to be_mainstream
     end
   end
+
+  describe '.from_params' do
+    let(:format_from_params) { 'png' }
+    let(:path_from_params) { 'government/uploads/path/to/asset' }
+    let(:legacy_url_path) { "/#{path_from_params}.#{format_from_params}" }
+    let!(:asset) { FactoryBot.create(:whitehall_asset, legacy_url_path: legacy_url_path) }
+
+    it 'finds Whitehall asset by legacy_url_path' do
+      found_asset = described_class.from_params(
+        path: path_from_params, format: format_from_params
+      )
+      expect(found_asset).to eq(asset)
+    end
+
+    context 'when format is not specified' do
+      let(:legacy_url_path) { "/#{path_from_params}" }
+
+      it 'finds Whitehall asset by legacy_url_path not including format' do
+        found_asset = described_class.from_params(path: path_from_params)
+        expect(found_asset).to eq(asset)
+      end
+    end
+
+    context 'when path_prefix is specified' do
+      it 'finds Whitehall asset by legacy_url_path including path_prefix' do
+        found_asset = described_class.from_params(
+          path: 'path/to/asset', format: format_from_params,
+          path_prefix: 'government/uploads/'
+        )
+        expect(found_asset).to eq(asset)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I started work on this, because I wanted to add an `update` action to the `WhitehallAssetsController`, but I was painfully aware that we already had a bunch of duplication. However, having chatted to @chrisroos I've now convinced myself that we don't need this `update` action - we can just use a combination of `WhitehallAssetsController#show` & `AssetsController#update`.

I think some or all of the following work is still useful, because I fixed a couple of things and removed a bunch of duplication. However, I'm happy if people think it's not useful.

The fixes are in these commits:

* "Fix asset lookup in WhitehallAssetsController#show with no format"
* "Remove duplicate examples from AssetsController spec"
* "Move context into describe block in AssetsController spec"

The other commits are mostly about removing duplication or improving consistency.

Aside: I did start looking at adding a `WhitehallAssetsController#update` action and one thing I wondered was whether it might be worth making the `path` used in the `WhitehallAssetsController` routes into a proper `id` parameter, i.e. having `gds-api-adapters` encode the path so that it can cope with the forward-slashes. I think this would mean we could make `whitehall_assets` into a standard Rails resource, i.e. use resource-ful routes for all actions. However, since I decided not to add this action (see above), I didn't end up making this change.
