### PR TITLE
Improvements to Sidekiq workers

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -40,7 +40,7 @@ class Asset
 
   state_machine :state, initial: :unscanned do
     event :scanned_clean do
-      transition any => :clean
+      transition unscanned: :clean
     end
 
     after_transition to: :clean do |asset, _|
@@ -48,7 +48,7 @@ class Asset
     end
 
     event :scanned_infected do
-      transition any => :infected
+      transition unscanned: :infected
     end
 
     event :upload_success do

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -5,7 +5,9 @@ class SaveToCloudStorageWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    Services.cloud_storage.save(asset)
-    asset.upload_success!
+    unless asset.uploaded?
+      Services.cloud_storage.save(asset)
+      asset.upload_success!
+    end
   end
 end

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -5,12 +5,14 @@ class VirusScanWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    begin
-      Services.virus_scanner.scan(asset.file.path)
-      asset.scanned_clean!
-    rescue VirusScanner::InfectedFile => e
-      GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
-      asset.scanned_infected!
+    if asset.unscanned?
+      begin
+        Services.virus_scanner.scan(asset.file.path)
+        asset.scanned_clean!
+      rescue VirusScanner::InfectedFile => e
+        GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+        asset.scanned_infected!
+      end
     end
   end
 end

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -6,9 +6,9 @@ class VirusScanWorker
   def perform(asset_id)
     asset = Asset.find(asset_id)
     Services.virus_scanner.scan(asset.file.path)
-    asset.scanned_clean
+    asset.scanned_clean!
   rescue VirusScanner::InfectedFile => e
     GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
-    asset.scanned_infected
+    asset.scanned_infected!
   end
 end

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -5,10 +5,12 @@ class VirusScanWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    Services.virus_scanner.scan(asset.file.path)
-    asset.scanned_clean!
-  rescue VirusScanner::InfectedFile => e
-    GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
-    asset.scanned_infected!
+    begin
+      Services.virus_scanner.scan(asset.file.path)
+      asset.scanned_clean!
+    rescue VirusScanner::InfectedFile => e
+      GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+      asset.scanned_infected!
+    end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "when an asset is marked as clean" do
-    let!(:asset) { FactoryBot.create(:asset) }
+    let(:asset) { FactoryBot.create(:asset) }
 
     before do
       allow(SaveToCloudStorageWorker).to receive(:perform_async)
@@ -383,13 +383,14 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#etag_from_file" do
-    let!(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+    let(:asset) { Asset.new }
 
     let(:size) { 1024 }
     let(:mtime) { Time.zone.parse('2017-01-01') }
     let(:stat) { instance_double(File::Stat, size: size, mtime: mtime) }
 
     before do
+      asset.file = load_fixture_file("asset.png")
       allow(File).to receive(:stat).and_return(stat)
     end
 
@@ -453,12 +454,13 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#last_modified_from_file" do
-    let!(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+    let(:asset) { Asset.new }
 
     let(:mtime) { Time.zone.parse('2017-01-01') }
     let(:stat) { instance_double(File::Stat, mtime: mtime) }
 
     before do
+      asset.file = load_fixture_file("asset.png")
       allow(File).to receive(:stat).and_return(stat)
     end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Asset, type: :model do
     it 'schedules saving the asset to cloud storage' do
       expect(SaveToCloudStorageWorker).to receive(:perform_async).with(asset.id)
 
-      asset.scanned_clean
+      asset.scanned_clean!
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "when an asset is marked as clean" do
-    let(:asset) { FactoryBot.create(:asset) }
+    let(:asset) { FactoryBot.build(:asset) }
 
     before do
       allow(SaveToCloudStorageWorker).to receive(:perform_async)

--- a/spec/workers/save_to_cloud_storage_worker_spec.rb
+++ b/spec/workers/save_to_cloud_storage_worker_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe SaveToCloudStorageWorker, type: :worker do
       expect(asset.reload).to be_uploaded
     end
 
+    context 'when asset is already uploaded' do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      it 'does not save the asset to cloud storage' do
+        expect(cloud_storage).not_to receive(:save).with(asset)
+
+        worker.perform(asset)
+      end
+
+      it 'does not change the state of the asset' do
+        worker.perform(asset)
+
+        expect(asset.reload).to be_uploaded
+      end
+    end
+
     context 'when S3Storage::ObjectUploadFailedError is raised' do
       before do
         allow(cloud_storage).to receive(:save)

--- a/spec/workers/virus_scan_worker_spec.rb
+++ b/spec/workers/virus_scan_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe VirusScanWorker do
       worker.perform(asset.id)
 
       asset.reload
-      expect(asset.state).to eq('clean')
+      expect(asset).to be_clean
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe VirusScanWorker do
       worker.perform(asset.id)
 
       asset.reload
-      expect(asset.state).to eq('infected')
+      expect(asset).to be_infected
     end
 
     it "sends an exception notification" do

--- a/spec/workers/virus_scan_worker_spec.rb
+++ b/spec/workers/virus_scan_worker_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe VirusScanWorker do
     end
   end
 
+  context 'when the asset is already marked as clean' do
+    let(:asset) { FactoryBot.create(:clean_asset) }
+
+    it 'does not virus scan file' do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context 'when the asset is already marked as infected' do
+    let(:asset) { FactoryBot.create(:infected_asset) }
+
+    it 'does not virus scan file' do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context 'when the asset is already marked as uploaded' do
+    let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+    it 'does not virus scan file' do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
   context "when a virus is found" do
     let(:exception_message) { "/path/to/file: Eicar-Test-Signature FOUND" }
     let(:exception) { VirusScanner::InfectedFile.new(exception_message) }


### PR DESCRIPTION
The main purpose of this PR is to make the `SaveToCloudStorageWorker` & `VirusScanWorker` jobs idempotent. These are the only two jobs used in standard operation, the only other one, `DeleteAssetFileFromNfsWorker`, has served its purpose and will soon be removed.

My motivation for making this change is that on a couple of occasions I've seen these jobs apparently fail, because the underlying file no longer exists. And on at least one occasion the state of the asset has still been changed to 'uploaded' and the asset appears to have been saved to the cloud. This suggests that the job may have executed more than once. If that is indeed what happened, these changes should avoid that happening again.

Also [the Sidekiq documentation recommends ensuring jobs are idempotent][1].

As part of this PR, I've also further constrained the asset state machine transitions. Hopefully this should make the code easier to reason about. I've also done some incidental tidying up in order to make my changes easier to apply.

[1]:
https://github.com/mperham/sidekiq/wiki/Best-Practices#2-make-your-job-idempotent-and-transactional
