### PR TITLE
Prevent caching of API endpoint for getting asset details

### DIFF
--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -2,7 +2,7 @@ class BaseAssetsController < ApplicationController
   def show
     @asset = find_asset
 
-    @asset.unscanned? ? set_expiry(0) : set_expiry(30.minutes)
+    set_expiry(0)
     render json: AssetPresenter.new(@asset, view_context)
   end
 

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -254,24 +254,10 @@ RSpec.describe AssetsController, type: :controller do
     describe "cache headers" do
       let(:asset) { FactoryBot.create(:asset) }
 
-      it "sets the cache-control headers to 0 for an unscanned asset" do
+      it "sets the cache-control headers to 0" do
         get :show, params: { id: asset.id }
 
         expect(response.headers["Cache-Control"]).to eq("max-age=0, public")
-      end
-
-      it "sets the cache-control headers to 30 minutes for a clean asset" do
-        asset.scanned_clean!
-        get :show, params: { id: asset.id }
-
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
-      end
-
-      it "sets the cache-control headers to 30 minutes for an infected asset" do
-        asset.scanned_infected!
-        get :show, params: { id: asset.id }
-
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
       end
     end
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -195,6 +195,12 @@ RSpec.describe AssetsController, type: :controller do
 
         expect(body['draft']).to be_falsey
       end
+
+      it "sets the cache-control headers to 0" do
+        get :show, params: { id: asset.id }
+
+        expect(response.headers["Cache-Control"]).to eq("max-age=0, public")
+      end
     end
 
     context "an asset which does not exist" do
@@ -248,16 +254,6 @@ RSpec.describe AssetsController, type: :controller do
         it "responds with an error message" do
           expect(response.body).to match(/Something went wrong/)
         end
-      end
-    end
-
-    describe "cache headers" do
-      let(:asset) { FactoryBot.create(:asset) }
-
-      it "sets the cache-control headers to 0" do
-        get :show, params: { id: asset.id }
-
-        expect(response.headers["Cache-Control"]).to eq("max-age=0, public")
       end
     end
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe AssetsController, type: :controller do
         expect(body['draft']).to be_falsey
       end
 
-      it "sets the cache-control headers to 0" do
+      it "sets the Cache-Control header max-age to 0" do
         get :show, params: { id: asset.id }
 
         expect(response.headers["Cache-Control"]).to eq("max-age=0, public")

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -151,18 +151,10 @@ RSpec.describe WhitehallAssetsController, type: :controller do
       expect(response.body).to eq('"asset-as-json"')
     end
 
-    it 'sets the cache expiry to 0 if the asset is unscanned' do
+    it 'sets the cache expiry to 0' do
       get :show, params: { path: 'government/uploads/image', format: 'png' }
 
       expect(response.headers['Cache-Control']).to match('max-age=0')
-    end
-
-    it 'sets the cache expiry to 30 minutes if the asset is scanned' do
-      asset.scanned_clean!
-
-      get :show, params: { path: 'government/uploads/image', format: 'png' }
-
-      expect(response.headers['Cache-Control']).to match("max-age=#{30.minutes}")
     end
 
     context 'and legacy_url_path has no format' do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe WhitehallAssetsController, type: :controller do
       expect(response.body).to eq('"asset-as-json"')
     end
 
-    it 'sets the cache expiry to 0' do
+    it 'sets the Cache-Control header max-age to 0' do
       get :show, params: { path: 'government/uploads/image', format: 'png' }
 
       expect(response.headers['Cache-Control']).to match('max-age=0')


### PR DESCRIPTION
This changes the `AssetsController#show` and `WhitehallAssetsController#show` endpoints so that the `Cache-Control` header is always set to have `max-age=0`, i.e. indicating that the response should not be cached.

This logic became out-of-date when we introduced the uploaded state in [this PR][1]. I considered only updating the logic to fix this, i.e. by setting cache expiry to 0 for 'uploaded' or 'infected' assets (vs 'scanned' or 'infected' assets).

However, I realised that since we introduced the `draft` status of an asset in [this PR][2] and included it in the JSON response, it no longer makes sense to set the cache expiry to 0 for uploaded assets, because their `draft` status may change, even after they have been virus scanned and uploaded cloud storage.

Since very few assets are marked as infected, few (if any) of the publishing apps use this endpoint, and it isn't a very "expensive" request, so I decided it was better to simplify the app by always setting the cache expiry to 0.

Note that the `gds-api-adapters` gem used by the publishing apps [does respect the `Cache-Control` header][3] and so it is important to set the header appropriately.

[1]: https://github.com/alphagov/asset-manager/pull/364
[2]: https://github.com/alphagov/asset-manager/pull/435
[3]:
https://github.com/alphagov/gds-api-adapters/blob/5bdb71743ca94f11cad2756b37ab150a847ed53c/lib/gds_api/json_client.rb#L204-L241
