### PR TITLE
Allow location of clamscan to be configured by environment variable

### DIFF
--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -16,4 +16,8 @@ class GovukConfiguration
     draft_assets_base_uri = @plek.external_url_for('draft-assets')
     URI.parse(draft_assets_base_uri).host
   end
+
+  def clamscan_path
+    @env.fetch('ASSET_MANAGER_CLAMSCAN_PATH', 'govuk_clamscan')
+  end
 end

--- a/lib/virus_scanner.rb
+++ b/lib/virus_scanner.rb
@@ -9,7 +9,8 @@ class VirusScanner
   class InfectedFile < StandardError; end
 
   def scan(file_path)
-    out_str, status = Open3.capture2e('govuk_clamscan', '--no-summary', file_path)
+    clamscan_path = AssetManager.govuk.clamscan_path
+    out_str, status = Open3.capture2e(clamscan_path, '--no-summary', file_path)
     case status.exitstatus
     when 0
       return true

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -51,6 +51,28 @@ RSpec.describe GovukConfiguration do
     end
   end
 
+  describe '#clamscan_path' do
+    context 'when environment includes an ASSET_MANAGER_CLAMSCAN_PATH value' do
+      let(:env) {
+        {
+          'ASSET_MANAGER_CLAMSCAN_PATH' => 'alternative-path',
+        }
+      }
+
+      it 'returns environment variable' do
+        expect(config.clamscan_path).to eq('alternative-path')
+      end
+    end
+
+    context 'when environment does not include an ASSET_MANAGER_CLAMSCAN_PATH value' do
+      let(:env) { {} }
+
+      it 'returns govuk_clamscan' do
+        expect(config.clamscan_path).to eq('govuk_clamscan')
+      end
+    end
+  end
+
   describe '#draft_assets_host' do
     subject(:config) { described_class.new(env, plek) }
 

--- a/spec/lib/virus_scanner_spec.rb
+++ b/spec/lib/virus_scanner_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'virus_scanner'
 
 RSpec.describe VirusScanner do


### PR DESCRIPTION
In the end to end tests environment, we want to be able to disable the virus scan easily as it can take more than 60 seconds to complete a scan when several requests are made to it at once.

By allowing the path to be passed in we can give it /bin/true when wanting to disable the scan.