### PR TITLE
Use `/bin/true` over `govuk_clamscan`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.4.2
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav && apt-get clean
-RUN freshclam
-RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
+RUN apt-get update -qq && apt-get upgrade -y && apt-get clean
+RUN ln -sf /bin/true /usr/bin/govuk_clamscan
 RUN gem install bundler -v1.14.5
 
 ENV GOVUK_APP_NAME asset-manager


### PR DESCRIPTION
We've found that during e2e testing we can effectively DDOS the asset
manager by providing several assets to scan at once. This results in all
the attachments returning 404s for over 60 seconds. By using `/bin/true`
we can always return exit status 0 satisfying the requirements of the
Virus Scanner.