### PR TITLE
Configure GDS::SSO caching

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -3,4 +3,5 @@ GDS::SSO.config do |config|
   config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndassetmanager"
   config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
+  config.cache = Rails.cache
 end


### PR DESCRIPTION
The default is not to cache, and this means that large numbers of
requests are being made to Signon. Hopefully caching will reduce this.