### PR TITLE
Allow draft asset access to be restricted to specific users

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def asset_params
-    params.require(:asset).permit(:file, :draft, :redirect_url)
+    params.require(:asset).permit(:file, :draft, :redirect_url, access_limited: [])
   end
 
   def find_asset(include_deleted: false)

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -5,13 +5,9 @@ class MediaController < BaseMediaController
       return
     end
 
-    if asset.draft?
-      if asset.access_limited.any?
-        unless asset.access_limited.include?(current_user.uid)
-          head :forbidden
-          return
-        end
-      end
+    unless asset.accessible_by?(current_user)
+      head :forbidden
+      return
     end
 
     unless asset_servable?

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -5,6 +5,15 @@ class MediaController < BaseMediaController
       return
     end
 
+    if asset.draft?
+      if asset.access_limited.any?
+        unless asset.access_limited.include?(current_user.uid)
+          head :forbidden
+          return
+        end
+      end
+    end
+
     unless asset_servable?
       error_404
       return

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -14,7 +14,8 @@ private
       .require(:asset)
       .permit(
         :file, :draft, :redirect_url,
-        :legacy_url_path, :legacy_etag, :legacy_last_modified
+        :legacy_url_path, :legacy_etag, :legacy_last_modified,
+        access_limited: []
       )
   end
 

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -5,6 +5,11 @@ class WhitehallMediaController < BaseMediaController
       return
     end
 
+    unless asset.accessible_by?(current_user)
+      head :forbidden
+      return
+    end
+
     if asset.infected?
       error_404
       return

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -28,6 +28,8 @@ class Asset
   field :size, type: Integer
   protected :size=
 
+  field :access_limited, type: Array, default: []
+
   validates :file, presence: true, unless: :uploaded?
 
   validates :uuid, presence: true,

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -66,6 +66,13 @@ class Asset
     end
   end
 
+  def accessible_by?(user)
+    return true unless draft?
+    return true if access_limited.empty?
+
+    access_limited.include?(user.uid)
+  end
+
   def public_url_path
     "/media/#{id}/#{filename}"
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe AssetsController, type: :controller do
         expect(response).to have_http_status(:created)
       end
 
+      it "stores access_limited on asset" do
+        post :create, params: { asset: attributes.merge(access_limited: ['user-id']) }
+
+        expect(assigns(:asset).access_limited).to eq(['user-id'])
+      end
+
       it "returns the location and details of the new asset" do
         post :create, params: { asset: attributes }
 
@@ -101,6 +107,12 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(response).to have_http_status(:success)
+      end
+
+      it "stores access_limited on asset" do
+        put :update, params: { id: asset.id, asset: attributes.merge(access_limited: ['user-id']) }
+
+        expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
       it "returns the location and details of the new asset" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).legacy_last_modified).to eq(attributes[:legacy_last_modified])
       end
 
+      it "stores access_limited on asset" do
+        post :create, params: { asset: attributes.merge(access_limited: ['user-id']) }
+
+        expect(assigns(:asset).access_limited).to eq(['user-id'])
+      end
+
       it "returns a created status" do
         post :create, params: { asset: attributes }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe '#accessible_by?' do
+    it 'returns true if the asset is not draft' do
+      asset = FactoryBot.build(:asset, draft: false)
+      expect(asset).to be_accessible_by(nil)
+    end
+
+    it 'returns true if the asset is draft but not access limited' do
+      asset = FactoryBot.build(:asset, draft: true, access_limited: [])
+      expect(asset).to be_accessible_by(nil)
+    end
+
+    it 'returns true if the asset is draft and access limited and the user is authorised to view it' do
+      user = FactoryBot.build(:user, uid: 'user-id')
+      asset = FactoryBot.build(:asset, draft: true, access_limited: ['user-id'])
+      expect(asset).to be_accessible_by(user)
+    end
+
+    it 'returns false if the asset is draft and access limited and the user is not authorised to view it' do
+      user = FactoryBot.build(:user, uid: 'user-id')
+      asset = FactoryBot.build(:asset, draft: true, access_limited: ['another-user-id'])
+      expect(asset).not_to be_accessible_by(user)
+    end
+  end
+
   describe '#uuid' do
     it 'is generated on instantiation' do
       allow(SecureRandom).to receive(:uuid).and_return('uuid')

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Access limited assets", type: :request do
+  let(:user_1) { FactoryBot.create(:user, uid: 'user-1-id') }
+  let(:user_2) { FactoryBot.create(:user, uid: 'user-2-id') }
+  let(:asset) { FactoryBot.create(:uploaded_asset, draft: true, access_limited: ['user-1-id']) }
+
+  before do
+    host! AssetManager.govuk.draft_assets_host
+  end
+
+  it 'are accessible to users who are authorised to view them' do
+    login_as user_1
+
+    get "/media/#{asset.id}/#{asset.filename}"
+
+    expect(response).to be_success
+  end
+
+  it 'are not accessible to users who are not authorised to view them' do
+    login_as user_2
+
+    get "/media/#{asset.id}/#{asset.filename}"
+
+    expect(response).to be_forbidden
+  end
+end

--- a/spec/requests/access_limited_whitehall_assets_spec.rb
+++ b/spec/requests/access_limited_whitehall_assets_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Access limited Whitehall assets", type: :request do
+  let(:user_1) { FactoryBot.create(:user, uid: 'user-1-id') }
+  let(:user_2) { FactoryBot.create(:user, uid: 'user-2-id') }
+  let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, draft: true, access_limited: ['user-1-id']) }
+
+  before do
+    host! AssetManager.govuk.draft_assets_host
+  end
+
+  it 'are accessible to users who are authorised to view them' do
+    login_as user_1
+
+    get asset.legacy_url_path
+
+    expect(response).to be_success
+  end
+
+  it 'are not accessible to users who are not authorised to view them' do
+    login_as user_2
+
+    get asset.legacy_url_path
+
+    expect(response).to be_forbidden
+  end
+end


### PR DESCRIPTION
Certain documents in Whitehall can be marked as access limited; which means that they're only accessible to users within the same organisation(s) that the document belongs to. Any attachments belonging to those documents should be subject to the same restrictions. This branch adds functionality to allow access to draft assets to be restricted to a subset of users. Setting the `access_limited` attribute to an array of users' UIDs will allow _only_ those users to access the asset when its in draft.

This implementation is based on a cut-down version of the equivalent functionality in the Content Store; notably I'm not storing the `auth_bypass_ids` that it's possible to set on a `ContentItem` in the Content Store.

Note the additional duplication in the two media controllers. I imagine we'll DRY this up in future.

Note that I'm not emitting the access_limited data from the AssetPresenter. It doesn't feel quite right to emit this sensitive information.
