### PR TITLE
Add redirect_url to assets & redirect requests for Whitehall assets with redirect_url

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def asset_params
-    params.require(:asset).permit(:file, :draft)
+    params.require(:asset).permit(:file, :draft, :redirect_url)
   end
 
   def find_asset(include_deleted: false)

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -12,7 +12,10 @@ private
   def asset_params
     params
       .require(:asset)
-      .permit(:file, :draft, :legacy_url_path, :legacy_etag, :legacy_last_modified)
+      .permit(
+        :file, :draft, :redirect_url,
+        :legacy_url_path, :legacy_etag, :legacy_last_modified
+      )
   end
 
   def existing_asset_with_this_legacy_url_path

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -10,6 +10,11 @@ class WhitehallMediaController < BaseMediaController
       return
     end
 
+    if asset.redirect_url.present?
+      redirect_to asset.redirect_url
+      return
+    end
+
     if asset.unscanned? || asset.clean?
       set_expiry(1.minute)
       if asset.image?

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -14,6 +14,7 @@ class Asset
   attr_readonly :uuid
 
   field :draft, type: Boolean, default: false
+  field :redirect_url, type: String
 
   field :etag, type: String
   protected :etag=

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -5,7 +5,7 @@ class AssetPresenter
   end
 
   def as_json(options = {})
-    {
+    json = {
       _response_info: {
         status: options[:status] || "ok",
       },
@@ -16,5 +16,9 @@ class AssetPresenter
       state: @asset.state,
       draft: @asset.draft?
     }
+    if @asset.redirect_url.present?
+      json[:redirect_url] = @asset.redirect_url
+    end
+    json
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -72,6 +72,17 @@ RSpec.describe AssetsController, type: :controller do
         expect(body['draft']).to be_truthy
       end
     end
+
+    context 'an asset with a redirect URL' do
+      let(:redirect_url) { 'https://example.com/path/file.ext' }
+      let(:attributes) { { redirect_url: redirect_url, file: load_fixture_file("asset.png") } }
+
+      it 'stores redirect URL' do
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).redirect_url).to eq(redirect_url)
+      end
+    end
   end
 
   describe "PUT update" do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(body['draft']).to be_truthy
       end
     end
+
+    context 'an asset with a redirect URL' do
+      let(:redirect_url) { 'https://example.com/path/file.ext' }
+      let(:attributes) { FactoryBot.attributes_for(:whitehall_asset, redirect_url: redirect_url) }
+
+      it 'returns JSON response including redirect URL of new asset' do
+        post :create, params: { asset: attributes }
+
+        body = JSON.parse(response.body)
+        expect(body['redirect_url']).to eq(redirect_url)
+      end
+    end
   end
 
   describe 'GET show' do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -32,7 +32,15 @@ RSpec.describe WhitehallMediaController, type: :controller do
     let(:format) { 'png' }
     let(:legacy_url_path) { "/government/uploads/#{path}.#{format}" }
     let(:draft) { false }
-    let(:attributes) { { legacy_url_path: legacy_url_path, state: state, draft: draft } }
+    let(:redirect_url) { nil }
+    let(:attributes) {
+      {
+        legacy_url_path: legacy_url_path,
+        state: state,
+        draft: draft,
+        redirect_url: redirect_url
+      }
+    }
     let(:asset) { FactoryBot.build(:whitehall_asset, attributes) }
 
     before do
@@ -94,6 +102,17 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           get :download, params: { path: path, format: format }
         end
+      end
+    end
+
+    context 'when asset has a redirect URL' do
+      let(:state) { 'uploaded' }
+      let(:redirect_url) { 'https://example.com/path/file.ext' }
+
+      it 'redirects to redirect URL' do
+        get :download, params: { path: path, format: format }
+
+        expect(response).to redirect_to(redirect_url)
       end
     end
 

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -77,5 +77,27 @@ RSpec.describe AssetPresenter do
         expect(uri.path).to eq('/public-%C3%BCrl-path')
       end
     end
+
+    context 'when asset has no redirect URL' do
+      before do
+        asset.redirect_url = nil
+      end
+
+      it 'returns hash without redirect_url' do
+        expect(json).not_to have_key(:redirect_url)
+      end
+    end
+
+    context 'when asset has redirect URL' do
+      let(:redirect_url) { 'https://example.com/path/file.ext' }
+
+      before do
+        asset.redirect_url = redirect_url
+      end
+
+      it 'returns hash including redirect_url' do
+        expect(json).to have_key(:redirect_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
The plan is for Whitehall to set `Asset#redirect_url` for an attachment if its parent document is unpublished. This relates to the logic in [Whitehall's `AttachmentController#fail`](https://github.com/alphagov/whitehall/blob/64bb168edf383fc62a7190f614f6822df9dff4a7/app/controllers/attachments_controller.rb#L43-L44) which determines whether the attachment's parent document has been unpublished.

This PR makes it possible to set a `redirect_url` attribute on any asset via the `update` API endpotin and to see its value via the `show` API endpoint. It also does the redirect if the attribute is set, but only for Whitehall assets.

In Asset Manager the concept of a "draft" asset means that requests for it must come via the `draft-assets` host and be associated with an authenticated user. Thus to avoid a double redirect and (more significantly) unnecessary authentication, Whitehall should not mark an asset with a redirect URL as draft.

Note that this redirect is intended to be used for non-asset URLs. More specifically in the case of an unpublished document, the user should be redirected to the original public URL of the relevant attachment's parent document. This will be set by the Whitehall app via the Asset Manager API.
