### PR TITLE
Add asset file size to API

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -122,6 +122,7 @@ protected
     self.etag = etag_from_file
     self.last_modified = last_modified_from_file
     self.md5_hexdigest = md5_hexdigest_from_file
+    self.size = size_from_file
   end
 
   def valid_filenames

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -24,6 +24,9 @@ class Asset
   field :md5_hexdigest, type: String
   protected :md5_hexdigest=
 
+  field :size, type: Integer
+  protected :size=
+
   validates :file, presence: true, unless: :uploaded?
 
   validates :uuid, presence: true,

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -109,6 +109,10 @@ class Asset
     @md5_hexdigest ||= Digest::MD5.hexdigest(file.file.read)
   end
 
+  def size_from_file
+    file_stat.size
+  end
+
 protected
 
   def store_metadata

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -116,6 +116,11 @@ class Asset
     file_stat.size
   end
 
+  def set_size_from_etag
+    self.size = size_from_etag
+    save
+  end
+
 protected
 
   def store_metadata
@@ -141,5 +146,9 @@ protected
 
   def file_stat
     File.stat(file.path)
+  end
+
+  def size_from_etag
+    etag.split('-').last.to_i(16)
   end
 end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -12,6 +12,7 @@ class AssetPresenter
       id: @view_context.asset_url(@asset.id),
       name: @asset.filename,
       content_type: @asset.content_type,
+      size: @asset.size,
       file_url: URI.join(Plek.new.asset_root, Addressable::URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,
       draft: @asset.draft?

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -14,4 +14,13 @@ namespace :db do
       puts 'Error: Unable to remove Asset#organisation_slug'
     end
   end
+
+  desc "Set the size field for all assets from the etag"
+  task set_size_for_all_uploaded_assets: :environment do
+    scope = Asset.unscoped.where(size: nil)
+    processor = AssetProcessor.new(scope: scope)
+    processor.process_all_assets_with do |asset_id|
+      scope.find(asset_id).set_size_from_etag
+    end
+  end
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -16,6 +16,13 @@ FactoryBot.define do
     deleted_at { Time.now }
   end
 
+  factory :uploaded_asset_without_size, parent: :uploaded_asset do
+    after(:create) do |asset, _|
+      asset.send(:size=, nil)
+      asset.save
+    end
+  end
+
   factory :whitehall_asset, parent: :asset, class: WhitehallAsset do
     sequence(:legacy_url_path) { |n| "/government/uploads/asset-#{n}.png" }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -636,6 +636,16 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#set_size_from_etag" do
+    let(:asset) { FactoryBot.create(:uploaded_asset_without_size) }
+
+    it 'sets the size from the calculated etag' do
+      expect(asset.size).to be_nil
+      asset.set_size_from_etag
+      expect(asset.reload.size).to eq(57705)
+    end
+  end
+
   describe "#size=" do
     let(:asset) { Asset.new }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -592,6 +592,15 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#size_from_file" do
+    let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
+    let(:size) { 57705 }
+
+    it "returns the size of the file" do
+      expect(asset.size_from_file).to eq(size)
+    end
+  end
+
   describe "#md5_hexdigest_from_file" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
     let(:md5_hexdigest) { 'a0d8aa55f6db670e38a14962c0652776' }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -601,6 +601,40 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#size" do
+    let(:asset) { Asset.new(file: load_fixture_file("asset.png"), size: size) }
+    let(:asset_size) { 100 }
+
+    before do
+      allow(asset).to receive(:size).and_return(asset_size)
+    end
+
+    context "when asset is created" do
+      let(:size) { nil }
+
+      before do
+        asset.save!
+      end
+
+      it "stores the value generated from the file in the database" do
+        expect(asset.reload.size).to eq(asset_size)
+      end
+
+      context "when asset is updated with new file" do
+        let(:new_file) { load_fixture_file("asset2.jpg") }
+        let(:new_asset_size) { 200 }
+
+        before do
+          allow(asset).to receive(:size).and_return(new_asset_size)
+          asset.update_attributes!(file: new_file)
+        end
+
+        it "stores the value generated from the new file in the database" do
+          expect(asset.reload.size).to eq(new_asset_size)
+        end
+      end
+    end
+  end
 
   describe "#size=" do
     let(:asset) { Asset.new }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -601,6 +601,15 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+
+  describe "#size=" do
+    let(:asset) { Asset.new }
+
+    it "cannot be called from outside the Asset class" do
+      expect { asset.size = 100 }.to raise_error(NoMethodError)
+    end
+  end
+
   describe "#md5_hexdigest_from_file" do
     let(:asset) { Asset.new(file: load_fixture_file("asset.png")) }
     let(:md5_hexdigest) { 'a0d8aa55f6db670e38a14962c0652776' }

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe AssetPresenter do
       expect(json).to include(content_type: 'image/png')
     end
 
+    it 'returns hash with a size key' do
+      expect(json).to have_key(:size)
+    end
+
+    context 'when the asset has been saved' do
+      before do
+        asset.save
+      end
+
+      it 'returns hash including asset size' do
+        expect(json).to include(size: 57705)
+      end
+    end
+
     it 'returns hash including public asset URL as file_url' do
       uri = URI.parse(json[:file_url])
       expect("#{uri.scheme}://#{uri.host}").to eq(Plek.new.asset_root)


### PR DESCRIPTION
See: https://github.com/alphagov/asset-manager/issues/482

This PR adds an integer `size` attribtute to the JSON returned from a call to `GET http://asset-manager.<host>/assets/<id>`.  The JSON returned now looks like

```
{
  "_response_info": {
    "status": "ok"
  },
  "id": "http://asset-manager.dev.gov.uk/assets/5a689582759b744e3518efd8",
  "name": "minister-of-funk.960x640.jpg",
  "content_type": "image/jpeg",
  "size": 108106,
  "file_url": "http://assets-origin.dev.gov.uk/government/uploads/system/uploads/image_data/file/41/minister-of-funk.960x640.jpg",
  "state": "uploaded",
  "draft": false
}
```

The first 3 commits add the methods required to save the size to the database from the result of `stat`ing the file on disk before it is uploaded. These methods are very similar to the ones for setting `last_modified` and `md5_hexdigest` for example. 

2e5b016 adds the size to the JSON response. 

In 13d35c4 there is a migration rake task (which reuses `AssetProcessor` for progress indication) to set the `size` on all existing uploaded assets based on the size encoded in the `etag`. I've checked on the integration clone of the production data and as far as I can see the `etag` is set for all existing assets. I think this task should run in a reasonable time, but I intend to run it on integration to verify. Once migrated, this commit can be reverted. 
