### PR TITLE
Use worker for asset size migration

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -117,10 +117,6 @@ class Asset
     file_stat.size
   end
 
-  def set_size_from_etag
-    set(size: size_from_etag)
-  end
-
 protected
 
   def store_metadata
@@ -146,9 +142,5 @@ protected
 
   def file_stat
     File.stat(file.path)
-  end
-
-  def size_from_etag
-    etag.split('-').last.to_i(16)
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -118,8 +118,7 @@ class Asset
   end
 
   def set_size_from_etag
-    self.size = size_from_etag
-    save
+    set(size: size_from_etag)
   end
 
 protected

--- a/app/workers/set_asset_size_worker.rb
+++ b/app/workers/set_asset_size_worker.rb
@@ -1,0 +1,8 @@
+class SetAssetSizeWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'low_priority'
+
+  def perform(asset_id)
+    Asset.unscoped.find(asset_id).set_size_from_etag
+  end
+end

--- a/app/workers/set_asset_size_worker.rb
+++ b/app/workers/set_asset_size_worker.rb
@@ -3,6 +3,8 @@ class SetAssetSizeWorker
   sidekiq_options queue: 'low_priority'
 
   def perform(asset_id)
-    Asset.unscoped.find(asset_id).set_size_from_etag
+    asset = Asset.unscoped.find(asset_id)
+    size_from_etag = asset.etag.split('-').last.to_i(16)
+    asset.set(size: size_from_etag)
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -20,7 +20,7 @@ namespace :db do
     scope = Asset.unscoped.where(size: nil)
     processor = AssetProcessor.new(scope: scope)
     processor.process_all_assets_with do |asset_id|
-      scope.find(asset_id).set_size_from_etag
+      SetAssetSizeWorker.perform_async(asset_id)
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -636,16 +636,6 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "#set_size_from_etag" do
-    let(:asset) { FactoryBot.create(:uploaded_asset_without_size) }
-
-    it 'sets the size from the calculated etag' do
-      expect(asset.size).to be_nil
-      asset.set_size_from_etag
-      expect(asset.reload.size).to eq(57705)
-    end
-  end
-
   describe "#size=" do
     let(:asset) { Asset.new }
 

--- a/spec/workers/set_asset_size_worker_spec.rb
+++ b/spec/workers/set_asset_size_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe SetAssetSizeWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:asset) { FactoryBot.create(:uploaded_asset_without_size) }
+
+  it 'sets the size of the asset' do
+    expect(asset.size).to be_nil
+    worker.perform(asset.id)
+    expect(asset.reload.size).to eq(57705)
+  end
+end


### PR DESCRIPTION
In 16e323e we added a rake task to set the `size` field for all
existing assets. When we ran the task in integration however, we
estimated that it would take around 12 hours to complete. This runs
the risk of the rake task being killed and leaving the database in a
somewhat inconsistent state.

This PR moves the work of the rake task into a worker. Hopefully
this will improve the run time as the workers run with concurrency,
and the rake task that queues up the jobs will complete more quickly.