### PR TITLE
Run e2e tests via foreman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav && apt-get clean
 RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
-RUN gem install bundler -v1.14.5
 
 ENV GOVUK_APP_NAME asset-manager
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav && apt-get clean
 RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME asset-manager
 ENV GOVUK_ASSET_ROOT http://assets-origin.dev.gov.uk
@@ -20,4 +21,4 @@ ADD . $APP_HOME
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
 
-CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3037}
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This PR adds foreman as a gem dependency of docker (as per [foreman instructions](https://github.com/ddollar/foreman#installation)) as the means to run the processes for this app.

It also adds the web process to the Profile to boot the web server.