### PR TITLE
Remove unused sdoc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ gem 'rails-controller-testing'
 gem 'state_machines-mongoid', '~> 0.2.0'
 gem 'unicorn', '5.4.0'
 
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
-
 group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdoc (4.3.0)
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -269,9 +268,6 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.0.5)
@@ -348,7 +344,6 @@ DEPENDENCIES
   rails (= 5.1.5)
   rails-controller-testing
   rspec-rails
-  sdoc (~> 0.4.0)
   simplecov-rcov
   state_machines-mongoid (~> 0.2.0)
   unicorn (= 5.4.0)


### PR DESCRIPTION
This was originally added in the [upgrade of Rails from v3.2.22 to v4.2.4][1] as one of the [standard gems][2]. It should have been removed in the [upgrade of Rails from v4.2.10 to v5.1.4][3] in which it was removed from the [standard set of gems][4].

The Rake task mentioned in the comment no longer works and as far as I can see we've never made use of it.

This PR makes 476 redundant.

[1]:
https://github.com/alphagov/asset-manager/commit/993e89469cddfa347b734cfa65503d0ca7c4562e
[2]: http://railsdiff.org/3.2.22/4.2.4
[3]:
https://github.com/alphagov/asset-manager/commit/ea6dc082ee9940c1e10bb695de7353ff3ca661f1
[4]: http://railsdiff.org/4.2.10/5.1.4