### PR TITLE
Upgrade aws-sdk from v2.10.105 -> v2.11.3, i.e. latest 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'addressable'
-gem 'aws-sdk', '~> 2.10.10'
+gem 'aws-sdk', '~> 2.0'
 gem 'carrierwave', '~> 0.11.2'
 gem 'carrierwave-mongoid', '~> 0.10.0', require: 'carrierwave/mongoid'
 gem 'gds-sso', '~> 13.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,13 +43,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    aws-sdk (2.10.105)
-      aws-sdk-resources (= 2.10.105)
-    aws-sdk-core (2.10.105)
+    aws-sdk (2.11.3)
+      aws-sdk-resources (= 2.11.3)
+    aws-sdk-core (2.11.3)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.105)
-      aws-sdk-core (= 2.10.105)
+    aws-sdk-resources (2.11.3)
+      aws-sdk-core (= 2.11.3)
     aws-sigv4 (1.0.2)
     bson (4.2.2)
     builder (3.2.3)
@@ -331,7 +331,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
-  aws-sdk (~> 2.10.10)
+  aws-sdk (~> 2.0)
   carrierwave (~> 0.11.2)
   carrierwave-mongoid (~> 0.10.0)
   database_cleaner


### PR DESCRIPTION
I loosened the constraint on the aws-sdk gem in the Gemfile to allow any 2.x version and then ran the following command:

    bundle update --conservative aws-sdk

This has upgraded to the latest 2.x version. I've looked through [the changelog][1] and it looks as if all the changes are new features, so this should be a safe upgrade, although it would be sensible to test the app in integration, i.e. with a real S3 connection.

As per the review on [this PR][2], I don't want to upgrade to v3.x, because it includes breaking changes.

I plan to close #478 in favour of this PR.

[1]: https://github.com/aws/aws-sdk-ruby/blob/version-2/CHANGELOG.md
[2]: https://github.com/alphagov/asset-manager/pull/352