### PR TITLE
Add Whitehall Attachment Content-Type headers

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,13 +3,10 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 
-Mime::Type.register "text/rtf", :rtf
-
-Mime::Type.register "application/vnd.ms-excel", :xls
 Mime::Type.register "application/msword", :doc
-
-Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
-Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
-
+Mime::Type.register "application/vnd.ms-excel", :xls
 Mime::Type.register "application/vnd.oasis.opendocument.spreadsheet", :ods
 Mime::Type.register "application/vnd.oasis.opendocument.text", :odt
+Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
+Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
+Mime::Type.register "text/rtf", :rtf

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,6 +3,8 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 
+Mime::Type.register "application/dxf", :dxf
+Mime::Type.register "application/gml+xml", :gml
 Mime::Type.register "application/msword", :doc
 Mime::Type.register "application/msword", :dot
 Mime::Type.register "application/rdf+xml", :rdf

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -15,4 +15,5 @@ Mime::Type.register "application/vnd.oasis.opendocument.text", :odt
 Mime::Type.register "application/vnd.openxmlformats-officedocument.presentationml.presentation", :pptx
 Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
 Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
+Mime::Type.register "text/plain; charset=utf-8", :txt
 Mime::Type.register "text/rtf", :rtf

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,9 +4,15 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register "application/msword", :doc
+Mime::Type.register "application/msword", :dot
+Mime::Type.register "application/rdf+xml", :rdf
 Mime::Type.register "application/vnd.ms-excel", :xls
+Mime::Type.register "application/vnd.ms-excel", :xlt
+Mime::Type.register "application/vnd.ms-excel.sheet.macroEnabled.12", :xlsm
+Mime::Type.register "application/vnd.ms-powerpoint", :ppt
 Mime::Type.register "application/vnd.oasis.opendocument.spreadsheet", :ods
 Mime::Type.register "application/vnd.oasis.opendocument.text", :odt
+Mime::Type.register "application/vnd.openxmlformats-officedocument.presentationml.presentation", :pptx
 Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
 Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
 Mime::Type.register "text/rtf", :rtf

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -495,6 +495,11 @@ RSpec.describe Asset, type: :model do
       expect(asset.content_type).to eq('application/vnd.ms-excel')
     end
 
+    it 'handles .txt file extensions and adds the charset parameter' do
+      file = Tempfile.new(['file', '.txt'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('text/plain; charset=utf-8')
+    end
   end
 
   describe '#image?' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -500,6 +500,18 @@ RSpec.describe Asset, type: :model do
       asset = Asset.new(file: file)
       expect(asset.content_type).to eq('text/plain; charset=utf-8')
     end
+
+    it 'handles .gml file extensions' do
+      file = Tempfile.new(['file', '.gml'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/gml+xml')
+    end
+
+    it 'handles .dxf file extensions' do
+      file = Tempfile.new(['file', '.dxf'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/dxf')
+    end
   end
 
   describe '#image?' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -458,6 +458,43 @@ RSpec.describe Asset, type: :model do
       asset = Asset.new(file: file)
       expect(asset.content_type).to eq('image/svg+xml')
     end
+
+    it 'handles .dot file extensions' do
+      file = Tempfile.new(['file', '.dot'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/msword')
+    end
+
+    it 'handles .ppt file extensions' do
+      file = Tempfile.new(['file', '.ppt'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.ms-powerpoint')
+    end
+
+    it 'handles .pptx file extensions' do
+      file = Tempfile.new(['file', '.pptx'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.openxmlformats-officedocument.presentationml.presentation')
+    end
+
+    it 'handles .rdf file extensions' do
+      file = Tempfile.new(['file', '.rdf'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/rdf+xml')
+    end
+
+    it 'handles .xlsm file extensions' do
+      file = Tempfile.new(['file', '.xlsm'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.ms-excel.sheet.macroEnabled.12')
+    end
+
+    it 'handles .xlt file extensions' do
+      file = Tempfile.new(['file', '.xlt'])
+      asset = Asset.new(file: file)
+      expect(asset.content_type).to eq('application/vnd.ms-excel')
+    end
+
   end
 
   describe '#image?' do


### PR DESCRIPTION
See: https://github.com/alphagov/asset-manager/issues/419

We are planning to change nginx so that requests for Whitehall attachments are served from Asset Manager instead of Whitehall. We've looked at all the existing attachments under `attachment_data` and requested examples of them to see what Content-Type header they are served with (#419). This PR registers the missing types so that the assets are served with the correct header.