### PR TITLE
Allow asset to be replaced with another asset

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -41,7 +41,7 @@ private
     exclude_blank_redirect_url(
       params
         .require(:asset)
-        .permit(:file, :draft, :redirect_url, access_limited: [])
+        .permit(:file, :draft, :redirect_url, :replacement_id, access_limited: [])
     )
   end
 

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -27,4 +27,8 @@ protected
   def redirect_to_draft_assets_host
     redirect_to host: AssetManager.govuk.draft_assets_host, format: params[:format]
   end
+
+  def redirect_to_replacement_for(asset)
+    redirect_to asset.replacement.public_url_path, status: :moved_permanently
+  end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -25,6 +25,11 @@ class MediaController < BaseMediaController
       return
     end
 
+    if asset.replacement.present?
+      redirect_to_replacement_for(asset)
+      return
+    end
+
     respond_to do |format|
       format.any do
         set_expiry(cache_control)

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -26,6 +26,7 @@ class MediaController < BaseMediaController
     end
 
     if asset.replacement.present?
+      set_expiry(cache_control)
       redirect_to_replacement_for(asset)
       return
     end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -14,7 +14,7 @@ private
       params
         .require(:asset)
         .permit(
-          :file, :draft, :redirect_url,
+          :file, :draft, :redirect_url, :replacement_id,
           :legacy_url_path, :legacy_etag, :legacy_last_modified,
           access_limited: []
         )

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -20,6 +20,11 @@ class WhitehallMediaController < BaseMediaController
       return
     end
 
+    if asset.replacement.present?
+      redirect_to_replacement_for(asset)
+      return
+    end
+
     if asset.unscanned? || asset.clean?
       set_expiry(cache_control.expires_in(1.minute))
       if asset.image?

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -21,6 +21,7 @@ class WhitehallMediaController < BaseMediaController
     end
 
     if asset.replacement.present?
+      set_expiry(cache_control)
       redirect_to_replacement_for(asset)
       return
     end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -6,6 +6,8 @@ class Asset
   include Mongoid::Paranoia
   include Mongoid::Timestamps
 
+  belongs_to :replacement, class_name: 'Asset', optional: true
+
   field :state, type: String, default: 'unscanned'
   field :filename_history, type: Array, default: -> { [] }
   protected :filename_history=

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -41,6 +41,8 @@ class Asset
                      message: 'must match the format defined in rfc4122'
                    }
 
+  validate :check_specified_replacement_exists
+
   mount_uploader :file, AssetUploader
 
   before_save :store_metadata, unless: :uploaded?
@@ -153,5 +155,11 @@ protected
 
   def file_stat
     File.stat(file.path)
+  end
+
+  def check_specified_replacement_exists
+    if replacement_id.present? && replacement.blank?
+      errors.add(:replacement, 'not found')
+    end
   end
 end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -20,6 +20,9 @@ class AssetPresenter
     if @asset.redirect_url.present?
       json[:redirect_url] = @asset.redirect_url
     end
+    if @asset.replacement.present?
+      json[:replacement_id] = @asset.replacement_id.to_s
+    end
     json
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -135,6 +135,24 @@ RSpec.describe AssetsController, type: :controller do
         end
       end
 
+      context 'and replacement_id does not match an existing asset' do
+        let(:replacement_id) { 'non-existent-asset-id' }
+
+        it 'responds with unprocessable entity status' do
+          post :create, params: { asset: attributes }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'includes error message in response' do
+          post :create, params: { asset: attributes }
+
+          body = JSON.parse(response.body)
+          status = body['_response_info']['status']
+          expect(status).to include('Replacement not found')
+        end
+      end
+
       it 'includes the replacement_id in the response' do
         post :create, params: { asset: attributes }
 
@@ -201,6 +219,24 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset).replacement_id).to be_nil
+      end
+
+      it 'responds with unprocessable entity status if replacement is not found' do
+        replacement_id = 'non-existent-asset-id'
+        attributes = valid_attributes.merge(replacement_id: replacement_id)
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'includes error message in response if replacement is not found' do
+        replacement_id = 'non-existent-asset-id'
+        attributes = valid_attributes.merge(replacement_id: replacement_id)
+        put :update, params: { id: asset.id, asset: attributes }
+
+        body = JSON.parse(response.body)
+        status = body['_response_info']['status']
+        expect(status).to include('Replacement not found')
       end
 
       it 'responds with success status' do

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -107,6 +107,42 @@ RSpec.describe AssetsController, type: :controller do
         end
       end
     end
+
+    context 'when attributes include a replacement_id' do
+      let(:replacement) { FactoryBot.create(:asset) }
+      let(:replacement_id) { replacement.id.to_s }
+      let(:attributes) { valid_attributes.merge(replacement_id: replacement_id) }
+
+      it 'stores replacement asset' do
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).replacement).to eq(replacement)
+      end
+
+      context 'and replacement_id is blank' do
+        let(:replacement_id) { '' }
+
+        it 'stores no replacement' do
+          post :create, params: { asset: attributes }
+
+          expect(assigns(:asset).replacement).to be_blank
+        end
+
+        it 'stores replacement_id as nil' do
+          post :create, params: { asset: attributes }
+
+          expect(assigns(:asset).replacement_id).to be_nil
+        end
+      end
+
+      it 'includes the replacement_id in the response' do
+        post :create, params: { asset: attributes }
+
+        body = JSON.parse(response.body)
+
+        expect(body['replacement_id']).to eq(replacement_id)
+      end
+    end
   end
 
   describe 'PUT update' do
@@ -148,6 +184,23 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset).redirect_url).to be_nil
+      end
+
+      it 'stores replacement on existing asset' do
+        replacement = FactoryBot.create(:asset)
+        replacement_id = replacement.id.to_s
+        attributes = valid_attributes.merge(replacement_id: replacement_id)
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).replacement).to eq(replacement)
+      end
+
+      it 'stores replacement_id as nil if replacement_id is blank' do
+        replacement_id = ''
+        attributes = valid_attributes.merge(replacement_id: replacement_id)
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).replacement_id).to be_nil
       end
 
       it 'responds with success status' do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -192,6 +192,12 @@ RSpec.describe MediaController, type: :controller do
 
         expect(response).to have_http_status(:moved_permanently)
       end
+
+      it 'sets the Cache-Control response header to 24 hours' do
+        get :download, params
+
+        expect(response.headers['Cache-Control']).to eq('max-age=86400, public')
+      end
     end
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -176,5 +176,22 @@ RSpec.describe MediaController, type: :controller do
         expect(response).to redirect_to(redirect_url)
       end
     end
+
+    context 'when asset has a replacement' do
+      let(:replacement) { FactoryBot.create(:uploaded_asset) }
+      let(:asset) { FactoryBot.create(:uploaded_asset, replacement: replacement) }
+
+      it 'redirects to replacement for asset' do
+        get :download, params
+
+        expect(response).to redirect_to(replacement.public_url_path)
+      end
+
+      it 'responds with 301 moved permanently status' do
+        get :download, params
+
+        expect(response).to have_http_status(:moved_permanently)
+      end
+    end
   end
 end

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it "stores replacement on asset" do
+        replacement = FactoryBot.create(:asset)
+        replacement_id = replacement.id.to_s
+        post :create, params: { asset: { replacement_id: replacement_id } }
+
+        expect(assigns(:asset).replacement).to eq(replacement)
+      end
+
       it "returns a created status" do
         post :create, params: { asset: attributes }
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -116,6 +116,27 @@ RSpec.describe WhitehallMediaController, type: :controller do
       end
     end
 
+    context 'when asset has a replacement' do
+      let(:state) { 'uploaded' }
+      let(:replacement) { FactoryBot.create(:uploaded_asset) }
+
+      before do
+        asset.replacement = replacement
+      end
+
+      it 'redirects to replacement for asset' do
+        get :download, params: { path: path, format: format }
+
+        expect(response).to redirect_to(replacement.public_url_path)
+      end
+
+      it 'responds with 301 moved permanently status' do
+        get :download, params: { path: path, format: format }
+
+        expect(response).to have_http_status(:moved_permanently)
+      end
+    end
+
     context 'when asset is draft and access limited' do
       let(:user) { FactoryBot.build(:user) }
       let(:state) { 'uploaded' }

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
         expect(response).to have_http_status(:moved_permanently)
       end
+
+      it 'sets the Cache-Control response header to 4 hours' do
+        get :download, params: { path: path, format: format }
+
+        expect(response.headers['Cache-Control']).to eq('max-age=14400, public')
+      end
     end
 
     context 'when asset is draft and access limited' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -27,6 +27,40 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
+
+    context 'when replacement_id is not specified' do
+      let(:attributes) { { replacement_id: nil } }
+
+      it 'is valid' do
+        expect(asset).to be_valid
+      end
+    end
+
+    context 'when replacement_id is specified' do
+      let(:attributes) { { replacement_id: replacement_id } }
+
+      context 'and replacement asset exists' do
+        let(:replacement) { FactoryBot.create(:asset) }
+        let(:replacement_id) { replacement.id.to_s }
+
+        it 'is valid' do
+          expect(asset).to be_valid
+        end
+      end
+
+      context 'and replacement asset does not exist' do
+        let(:replacement_id) { 'non-existent-asset-id' }
+
+        it 'is not valid' do
+          expect(asset).not_to be_valid
+        end
+
+        it 'includes error for replacement not found' do
+          asset.valid?
+          expect(asset.errors[:replacement]).to include('not found')
+        end
+      end
+    end
   end
 
   describe 'creation' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -845,4 +845,40 @@ RSpec.describe Asset, type: :model do
       end
     end
   end
+
+  describe '#replacement' do
+    let(:asset) { FactoryBot.build(:asset, replacement: replacement) }
+
+    context 'when replacement is nil' do
+      let(:replacement) { nil }
+
+      it 'is valid' do
+        expect(asset).to be_valid
+      end
+
+      it 'has no replacement_id' do
+        expect(asset.replacement_id).to be_nil
+      end
+    end
+
+    context 'when replacement is set' do
+      let(:replacement) { FactoryBot.create(:asset) }
+
+      it 'is valid' do
+        expect(asset).to be_valid
+      end
+
+      it 'persists replacement when saved' do
+        asset.save!
+
+        expect(asset.reload.replacement).to eq(replacement)
+      end
+
+      it 'persists replacement_id when saved' do
+        asset.save!
+
+        expect(asset.reload.replacement_id).to eq(replacement.id)
+      end
+    end
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -2,14 +2,16 @@ require "rails_helper"
 
 RSpec.describe Asset, type: :model do
   describe 'validation' do
-    subject(:asset) { FactoryBot.build(:asset) }
+    subject(:asset) { FactoryBot.build(:asset, attributes) }
+
+    let(:attributes) { {} }
 
     it 'is valid when built from factory' do
       expect(asset).to be_valid
     end
 
     context 'when file is not specified' do
-      subject(:asset) { FactoryBot.build(:asset, file: nil) }
+      let(:attributes) { { file: nil } }
 
       it 'is not valid' do
         expect(asset).not_to be_valid

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -113,5 +113,28 @@ RSpec.describe AssetPresenter do
         expect(json).to have_key(:redirect_url)
       end
     end
+
+    context 'when asset has no replacement' do
+      before do
+        asset.replacement = nil
+      end
+
+      it 'returns hash without replacement_id' do
+        expect(json).not_to have_key(:replacement_id)
+      end
+    end
+
+    context 'when asset has replacement' do
+      let(:replacement) { FactoryBot.create(:asset) }
+      let(:replacement_id) { replacement.id.to_s }
+
+      before do
+        asset.replacement = replacement
+      end
+
+      it 'returns hash including replacement_id' do
+        expect(json).to include(replacement_id: replacement_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
When a Whitehall attachment is "replaced", requests for its URL result in a redirect to the attachment which replaced it. This PR implements this functionality in Asset Manager so that we'll be able to serve Whitehall attachments from Asset Manager without changing the externally visible behaviour.

This PR introduces the `Asset#replacement` association. If an asset has such a replacement then requests for it are redirected to the path for the replacement. This is equivalent to [the behaviour implemented in Whitehall's `AttachmentsController#fail` method][1].

This PR also allows a `replacement_id` to be specified when creating or updating an asset via the API. I plan to call this [when an attachment is replaced in Whitehall][2].

Notes:

* I have not addressed the issue of setting a different value for the `Cache-Control` response header when the user is not signed in, because I think this is a wider concern which has been captured in [this GitHub issue][3].

* I have not implemented the optimisation which avoids multiple redirects where a replacement asset is itself replaced. For the moment, we can retain this behaviour by leaving it in Whitehall, but it would probably make sense to move it into Asset Manager at some point so we don't need to implement it in other publisher apps. See [this GitHub issue][4] for more details.

* This work is based on the work in #497. The first commit is a squashed version of that PR and should be removed/rebased-out before merging this PR.

[1]: https://github.com/alphagov/whitehall/blob/446e60b80fee198540e5abe3a7077a5a7f5f63e5/app/controllers/attachments_controller.rb#L45-L47
[2]: https://github.com/alphagov/whitehall/blob/446e60b80fee198540e5abe3a7077a5a7f5f63e5/app/models/attachment_data.rb#L100
[3]: https://github.com/alphagov/asset-manager/issues/494
[4]: https://github.com/alphagov/asset-manager/issues/498
