### PR TITLE
Add support for parent document URL to Asset Manager

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -41,7 +41,7 @@ private
     exclude_blank_redirect_url(
       params
         .require(:asset)
-        .permit(:file, :draft, :redirect_url, :replacement_id, access_limited: [])
+        .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])
     )
   end
 

--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -31,4 +31,10 @@ protected
   def redirect_to_replacement_for(asset)
     redirect_to asset.replacement.public_url_path, status: :moved_permanently
   end
+
+  def add_link_header(asset)
+    if asset.parent_document_url
+      headers['Link'] = %(<#{asset.parent_document_url}>; rel="up")
+    end
+  end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -34,6 +34,7 @@ class MediaController < BaseMediaController
     respond_to do |format|
       format.any do
         set_expiry(cache_control)
+        add_link_header(asset)
         headers['X-Frame-Options'] = AssetManager.frame_options
         proxy_to_s3_via_nginx(asset)
       end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -16,7 +16,7 @@ private
         .permit(
           :file, :draft, :redirect_url, :replacement_id,
           :legacy_url_path, :legacy_etag, :legacy_last_modified,
-          access_limited: []
+          :parent_document_url, access_limited: []
         )
     )
   end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -37,6 +37,7 @@ class WhitehallMediaController < BaseMediaController
     end
 
     set_expiry(cache_control)
+    add_link_header(asset)
     headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
     proxy_to_s3_via_nginx(asset)
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -45,6 +45,7 @@ class Asset
 
   validate :check_specified_replacement_exists
   validate :prevent_transition_from_published_to_draft_if_replaced
+  validate :ensure_parent_document_url_is_valid
 
   mount_uploader :file, AssetUploader
 
@@ -174,6 +175,20 @@ protected
       if redirect_url.present?
         errors.add(:draft, 'cannot be true, because already redirected')
       end
+    end
+  end
+
+  def ensure_parent_document_url_is_valid
+    return unless parent_document_url.present?
+
+    begin
+      uri = Addressable::URI.parse(parent_document_url)
+    rescue Addressable::URI::InvalidURIError
+      uri = nil
+    end
+
+    unless uri && %w(http https).include?(uri.scheme)
+      errors.add(:parent_document_url, 'must be an http(s) URL')
     end
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -32,6 +32,8 @@ class Asset
 
   field :access_limited, type: Array, default: []
 
+  field :parent_document_url, type: String
+
   validates :file, presence: true, unless: :uploaded?
 
   validates :uuid, presence: true,

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -23,6 +23,9 @@ class AssetPresenter
     if @asset.replacement.present?
       json[:replacement_id] = @asset.replacement_id.to_s
     end
+    if @asset.parent_document_url.present?
+      json[:parent_document_url] = @asset.parent_document_url.to_s
+    end
     json
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it 'stores parent_document_url on asset' do
+        attributes = valid_attributes.merge(parent_document_url: 'parent-document-url')
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).parent_document_url).to eq('parent-document-url')
+      end
+
       it 'responds with created status' do
         post :create, params: { asset: valid_attributes }
 

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -199,5 +199,33 @@ RSpec.describe MediaController, type: :controller do
         expect(response.headers['Cache-Control']).to eq('max-age=86400, public')
       end
     end
+
+    context "when the asset doesn't contain a parent_document_url" do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      before do
+        asset.update_attribute(:parent_document_url, nil)
+      end
+
+      it "doesn't send a Link HTTP header" do
+        get :download, params
+
+        expect(response.headers['Link']).to be_nil
+      end
+    end
+
+    context 'when the asset has a parent_document_url' do
+      let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+      before do
+        asset.update_attribute(:parent_document_url, 'parent-document-url')
+      end
+
+      it 'sends the parent_document_url in a Link HTTP header' do
+        get :download, params
+
+        expect(response.headers['Link']).to eql('<parent-document-url>; rel="up"')
+      end
+    end
   end
 end

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).replacement).to eq(replacement)
       end
 
+      it 'stores parent_document_url on asset' do
+        post :create, params: { asset: attributes.merge(parent_document_url: 'parent-document-url') }
+
+        expect(assigns(:asset).parent_document_url).to eq('parent-document-url')
+      end
+
       it "returns a created status" do
         post :create, params: { asset: attributes }
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -171,6 +171,38 @@ RSpec.describe WhitehallMediaController, type: :controller do
       end
     end
 
+    context "when the asset doesn't contain a parent_document_url" do
+      let(:state) { 'uploaded' }
+
+      before do
+        allow(controller).to receive(:proxy_to_s3_via_nginx)
+        allow(WhitehallAsset).to receive(:from_params).and_return(asset)
+        asset.update_attribute(:parent_document_url, nil)
+      end
+
+      it "doesn't send a Link HTTP header" do
+        get :download, params: { path: path, format: format }
+
+        expect(response.headers['Link']).to be_nil
+      end
+    end
+
+    context 'when the asset has a parent_document_url' do
+      let(:state) { 'uploaded' }
+
+      before do
+        allow(controller).to receive(:proxy_to_s3_via_nginx)
+        allow(WhitehallAsset).to receive(:from_params).and_return(asset)
+        asset.update_attribute(:parent_document_url, 'parent-document-url')
+      end
+
+      it 'sends the parent_document_url in a Link HTTP header' do
+        get :download, params: { path: path, format: format }
+
+        expect(response.headers['Link']).to eql('<parent-document-url>; rel="up"')
+      end
+    end
+
     context 'when asset is unscanned' do
       let(:state) { 'unscanned' }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -966,4 +966,17 @@ RSpec.describe Asset, type: :model do
       end
     end
   end
+
+  describe '#parent_document_url' do
+    let(:asset) { Asset.new }
+
+    it 'is nil by default' do
+      expect(asset.parent_document_url).to be_nil
+    end
+
+    it 'can be set' do
+      asset.parent_document_url = 'parent-document-url'
+      expect(asset.parent_document_url).to eql('parent-document-url')
+    end
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -110,6 +110,57 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
+
+    context 'when parent_document_url is not specified' do
+      it 'is valid' do
+        asset.parent_document_url = nil
+        expect(asset).to be_valid
+      end
+    end
+
+    context 'when parent_document_url is specified' do
+      it "is valid when it's an http URL" do
+        asset.parent_document_url = 'http://www.example.com'
+        expect(asset).to be_valid
+      end
+
+      it "is valid when it's an https URL" do
+        asset.parent_document_url = 'https://www.example.com'
+        expect(asset).to be_valid
+      end
+
+      context 'and is not an http(s) URL' do
+        before do
+          asset.parent_document_url = 'ftp://example.com'
+        end
+
+        it "is invalid" do
+          expect(asset).not_to be_valid
+        end
+
+        it "contains error message" do
+          asset.valid?
+          message = 'must be an http(s) URL'
+          expect(asset.errors[:parent_document_url]).to include(message)
+        end
+      end
+
+      context 'and the URL cannot be parsed' do
+        before do
+          asset.parent_document_url = 'http://foo:bar:baz'
+        end
+
+        it "is invalid" do
+          expect(asset).not_to be_valid
+        end
+
+        it "contains error message" do
+          asset.valid?
+          message = 'must be an http(s) URL'
+          expect(asset.errors[:parent_document_url]).to include(message)
+        end
+      end
+    end
   end
 
   describe 'creation' do

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -92,6 +92,28 @@ RSpec.describe AssetPresenter do
       end
     end
 
+    context 'when asset has no parent document URL' do
+      before do
+        asset.parent_document_url = nil
+      end
+
+      it 'returns hash without parent_document_url' do
+        expect(json).not_to have_key(:parent_document_url)
+      end
+    end
+
+    context 'when asset has parent document URL' do
+      let(:parent_document_url) { 'https://example.com/path/file.ext' }
+
+      before do
+        asset.parent_document_url = parent_document_url
+      end
+
+      it 'returns hash including parent_document_url' do
+        expect(json).to include(parent_document_url: parent_document_url)
+      end
+    end
+
     context 'when asset has no redirect URL' do
       before do
         asset.redirect_url = nil


### PR DESCRIPTION
Whitehall attachments can include a `Link` header containing the URL of their parent document (added to Whitehall in alphagov/whitehall#2202). We need to add support for this functionality to Asset Manager so that we can serve Whitehall attachments from this app.

Although this is primarily for Whitehall attachments I felt that it'd be less confusing to add support for it to both non-Whitehall and Whitehall assets.