### PR TITLE
Prevent certain published assets from being marked as draft

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -165,8 +165,13 @@ protected
   end
 
   def prevent_transition_from_published_to_draft_if_replaced
-    if (changes[:draft] == [false, true]) && replacement.present?
-      errors.add(:draft, 'cannot be true, because already replaced')
+    if changes[:draft] == [false, true]
+      if replacement.present?
+        errors.add(:draft, 'cannot be true, because already replaced')
+      end
+      if redirect_url.present?
+        errors.add(:draft, 'cannot be true, because already redirected')
+      end
     end
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -42,6 +42,7 @@ class Asset
                    }
 
   validate :check_specified_replacement_exists
+  validate :prevent_transition_from_published_to_draft_if_replaced
 
   mount_uploader :file, AssetUploader
 
@@ -160,6 +161,12 @@ protected
   def check_specified_replacement_exists
     if replacement_id.present? && replacement.blank?
       errors.add(:replacement, 'not found')
+    end
+  end
+
+  def prevent_transition_from_published_to_draft_if_replaced
+    if (changes[:draft] == [false, true]) && replacement.present?
+      errors.add(:draft, 'cannot be true, because already replaced')
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -64,7 +64,14 @@ RSpec.describe Asset, type: :model do
 
     context 'when published asset is marked as draft' do
       let(:replacement) { nil }
-      let(:attributes) { { draft: false, replacement: replacement } }
+      let(:redirect_url) { nil }
+      let(:attributes) {
+        {
+          draft: false,
+          replacement: replacement,
+          redirect_url: redirect_url
+        }
+      }
 
       before do
         asset.save!
@@ -85,6 +92,20 @@ RSpec.describe Asset, type: :model do
         it 'includes error for forbidden draft state change' do
           asset.valid?
           message = 'cannot be true, because already replaced'
+          expect(asset.errors[:draft]).to include(message)
+        end
+      end
+
+      context 'and asset is redirected' do
+        let(:redirect_url) { 'https://example.com/path/file.ext' }
+
+        it 'is not valid' do
+          expect(asset).not_to be_valid
+        end
+
+        it 'includes error for forbidden draft state change' do
+          asset.valid?
+          message = 'cannot be true, because already redirected'
           expect(asset.errors[:draft]).to include(message)
         end
       end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -61,6 +61,34 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
+
+    context 'when published asset is marked as draft' do
+      let(:replacement) { nil }
+      let(:attributes) { { draft: false, replacement: replacement } }
+
+      before do
+        asset.save!
+        asset.draft = true
+      end
+
+      it 'is valid' do
+        expect(asset).to be_valid
+      end
+
+      context 'and asset is replaced' do
+        let(:replacement) { Asset.new }
+
+        it 'is not valid' do
+          expect(asset).not_to be_valid
+        end
+
+        it 'includes error for forbidden draft state change' do
+          asset.valid?
+          message = 'cannot be true, because already replaced'
+          expect(asset.errors[:draft]).to include(message)
+        end
+      end
+    end
   end
 
   describe 'creation' do


### PR DESCRIPTION
This PR prevents assets being changed from published to draft if they have been replaced by another asset or have had a `redirect_url` set on them (which happens when they are associated with an unpublished/withdrawn Whitehall edition).

We probably don't ever want to make a published asset draft, because it's URL will be out in the wild. However, this is _definitely_ the case when the asset has been replaced or redirected, because we'll always want the redirect to be publicly accessible.

This commit adds validation on Asset to prevent such a draft status transition for replaced or redirected assets.

My motivation for making this change was the uncertainty I've expressed in https://github.com/alphagov/whitehall/pull/3827 about whether the logic in Whitehall might mean that it inadvertently attempts to mark a published redirected asset as draft. The changes in this PR will mean we fail fast if it does happen and we can decide what to do about it then.

I feel as if we should probably add more validation like this to further constrain the combinations of allowed asset attributes and states, but that can wait for now. Another way to achieve this might be to have dedicated API endpoints for e.g. replacing an asset, rather than re-using the existing generic update endpoint.