### PR TITLE
Allow access_limited to be reset on update

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -39,7 +39,7 @@ private
 
   def asset_params
     normalize_redirect_url(
-      handle_empty_access_limited_param(params)
+      normalize_access_limited(params)
         .require(:asset)
         .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])
     )

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,8 +38,9 @@ private
   end
 
   def asset_params
+    asset_params = handle_empty_access_limited_param(params)
     exclude_blank_redirect_url(
-      params
+      asset_params
         .require(:asset)
         .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])
     )

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,9 +38,8 @@ private
   end
 
   def asset_params
-    asset_params = handle_empty_access_limited_param(params)
     exclude_blank_redirect_url(
-      asset_params
+      handle_empty_access_limited_param(params)
         .require(:asset)
         .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])
     )

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def asset_params
-    exclude_blank_redirect_url(
+    normalize_redirect_url(
       handle_empty_access_limited_param(params)
         .require(:asset)
         .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -22,7 +22,7 @@ protected
     params.reject { |k, v| (k.to_sym == :redirect_url) && v.blank? }
   end
 
-  def handle_empty_access_limited_param(params)
+  def normalize_access_limited(params)
     if params.has_key?(:asset) && params[:asset].has_key?(:access_limited) && params[:asset][:access_limited].empty?
       params[:asset][:access_limited] = []
     end

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -22,6 +22,13 @@ protected
     params.reject { |k, v| (k.to_sym == :redirect_url) && v.blank? }
   end
 
+  def handle_empty_access_limited_param(params)
+    if params.has_key?(:asset) && params[:asset].has_key?(:access_limited) && params[:asset][:access_limited].empty?
+      params[:asset][:access_limited] = []
+    end
+    params
+  end
+
   def cache_control
     AssetManager.cache_control
   end

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -18,7 +18,7 @@ class BaseAssetsController < ApplicationController
 
 protected
 
-  def exclude_blank_redirect_url(params)
+  def normalize_redirect_url(params)
     params.reject { |k, v| (k.to_sym == :redirect_url) && v.blank? }
   end
 

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -10,7 +10,7 @@ class WhitehallAssetsController < BaseAssetsController
 private
 
   def asset_params
-    exclude_blank_redirect_url(
+    normalize_redirect_url(
       params
         .require(:asset)
         .permit(

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -195,6 +195,17 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it 'resets access_limited to an empty array for an existing asset with an access_limited array' do
+        asset.update_attributes!(access_limited: ['user-uid'])
+
+        # We have to use an empty string as that is what gds-api-adapters/rest-client
+        # will generate instead of an empty array
+        attributes = valid_attributes.merge(access_limited: '')
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).access_limited).to eq([])
+      end
+
       it 'stores redirect_url on existing asset' do
         redirect_url = 'https://example.com/path/file.ext'
         attributes = valid_attributes.merge(redirect_url: redirect_url)


### PR DESCRIPTION
While investigating issue #450, I noticed that resetting/removing the access_limited status of an asset wasn't working as expected.

This is because when we pass an empty `access_limited` array to gds-api-adapters/rest-client it's turned into an empty string in Asset Manager. This results in an `UnpermittedParameter` exception for the `access_limited` parameter in Asset Manager as it's expecting an Array but receives a String. The fix is to detect the empty string in the controller and convert it back into the empty array that's intended. I don't think this is particularly nice but I think it's good enough for now.

Note that I haven't had to use `handle_empty_access_limited_param` in `WhitehallAssetsController#asset_params` as the problem only occurs when _updating_ an access-limited asset, and the `WhitehallAssetsController` is only responsible for _creating_ assets.

I also considered using two fields to implement the access-limiting functionality: a boolean to control whether access-limiting was enabled in conjunction with an array of user UIDs who are authorised to view the asset. I decided against that approach because it's more work and because it means the implementation in Asset Manager diverges from the access-limiting functionality in the Content Store.
