### PR TITLE
Use external signon URL for OAuth exchange

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,6 +2,6 @@ GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndassetmanager"
   config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.current.external_url_for("signon")
+  config.oauth_root_url = Plek.new.external_url_for("signon")
   config.cache = Rails.cache
 end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -2,6 +2,6 @@ GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndassetmanager"
   config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.current.find("signon")
+  config.oauth_root_url = Plek.current.external_url_for("signon")
   config.cache = Rails.cache
 end


### PR DESCRIPTION
I noticed that visiting the draft-assets host was resulting in a redirect to the internal signon URL (e.g. https://signon.integration.govuk-internal.digital). It should be redirecting to the external URL (e.g. https://signon.integration.publishing.service.gov.uk) as we need to be able to follow it in a browser.

Note that We're not yet sending any traffic to draft-assets so this incorrect behaviour wasn't actually causing us a problem.

I've [added a test to Smokey][1] to help avoid this problem in future.

[1]: https://github.com/alphagov/smokey/pull/341