### PR TITLE
Avoid caching responses made to draft-assets host

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -33,7 +33,11 @@ class MediaController < BaseMediaController
 
     respond_to do |format|
       format.any do
-        set_expiry(cache_control)
+        if requested_from_draft_assets_host?
+          expires_now
+        else
+          set_expiry(cache_control)
+        end
         add_link_header(asset)
         headers['X-Frame-Options'] = AssetManager.frame_options
         proxy_to_s3_via_nginx(asset)

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -36,7 +36,11 @@ class WhitehallMediaController < BaseMediaController
       return
     end
 
-    set_expiry(cache_control)
+    if requested_from_draft_assets_host?
+      expires_now
+    else
+      set_expiry(cache_control)
+    end
     add_link_header(asset)
     headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
     proxy_to_s3_via_nginx(asset)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe MediaController, type: :controller do
 
           get :download, params
         end
+
+        it "sets Cache-Control header to no-cache" do
+          get :download, params
+
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
       end
     end
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           get :download, params: { path: path, format: format }
         end
+
+        it "sets Cache-Control header to no-cache" do
+          get :download, params: { path: path, format: format }
+
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
       end
     end
 


### PR DESCRIPTION
Draft assets can be optionally access-limited to a subset of users.
Caching the response to a request for an access-limited draft asset
might mean that unauthorised users can see things they shouldn't be able
to.

This is similar to the behaviour in Whitehall where [attachment requests
made by signed-in users aren't cached][1].

[1]: https://github.com/alphagov/whitehall/blob/cc57fbae96042952584d90583952d077be1c59a8/app/controllers/base_attachments_controller.rb#L35