### PR TITLE
Avoid redirecting to non-accessible assets

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -25,7 +25,7 @@ class MediaController < BaseMediaController
       return
     end
 
-    if asset.replacement.present?
+    if asset.replacement.present? && (!asset.replacement.draft? || requested_from_draft_assets_host?)
       set_expiry(cache_control)
       redirect_to_replacement_for(asset)
       return

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -20,7 +20,7 @@ class WhitehallMediaController < BaseMediaController
       return
     end
 
-    if asset.replacement.present?
+    if asset.replacement.present? && (!asset.replacement.draft? || requested_from_draft_assets_host?)
       set_expiry(cache_control)
       redirect_to_replacement_for(asset)
       return

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe MediaController, type: :controller do
           replacement.update_attribute(:draft, true)
         end
 
-        it 'serves the asset when requested via something other than the draft-assets host' do
+        it 'serves the original asset when requested via something other than the draft-assets host' do
           request.headers['X-Forwarded-Host'] = "not-#{AssetManager.govuk.draft_assets_host}"
 
           expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
@@ -218,7 +218,7 @@ RSpec.describe MediaController, type: :controller do
           get :download, params
         end
 
-        it 'redirects to the replacement when requested via the draft-assets host' do
+        it 'redirects to the replacement asset when requested via the draft-assets host by a signed-in user' do
           request.headers['X-Forwarded-Host'] = AssetManager.govuk.draft_assets_host
           allow(controller).to receive(:authenticate_user!)
 

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -204,6 +204,29 @@ RSpec.describe MediaController, type: :controller do
 
         expect(response.headers['Cache-Control']).to eq('max-age=86400, public')
       end
+
+      context 'and the replacement is draft' do
+        before do
+          replacement.update_attribute(:draft, true)
+        end
+
+        it 'serves the asset when requested via something other than the draft-assets host' do
+          request.headers['X-Forwarded-Host'] = "not-#{AssetManager.govuk.draft_assets_host}"
+
+          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+          get :download, params
+        end
+
+        it 'redirects to the replacement when requested via the draft-assets host' do
+          request.headers['X-Forwarded-Host'] = AssetManager.govuk.draft_assets_host
+          allow(controller).to receive(:authenticate_user!)
+
+          get :download, params
+
+          expect(response).to redirect_to(replacement.public_url_path)
+        end
+      end
     end
 
     context "when the asset doesn't contain a parent_document_url" do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
           replacement.update_attribute(:draft, true)
         end
 
-        it 'serves the asset when requested via something other than the draft-assets host' do
+        it 'serves the original asset when requested via something other than the draft-assets host' do
           request.headers['X-Forwarded-Host'] = "not-#{AssetManager.govuk.draft_assets_host}"
 
           expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
@@ -161,7 +161,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
           get :download, params: { path: path, format: format }
         end
 
-        it 'redirects to the replacement when requested via the draft-assets host' do
+        it 'redirects to the replacement asset when requested via the draft-assets host by a signed-in user' do
           request.headers['X-Forwarded-Host'] = AssetManager.govuk.draft_assets_host
           allow(controller).to receive(:authenticate_user!)
 


### PR DESCRIPTION
It's possible to replace a public asset with a draft asset. Normal replacement behaviour is to redirect from the old to the new asset; but we shouldn't redirect requests for the public asset in this instance as it'll mean we send the user to an asset they don't have permission to view. Note that we do redirect if the user requested the public asset from the draft-assets host as it means they're authenticated and therefore authorised (barring any additional access-limiting) to view draft assets.

This change follows a similar problem in Whitehall where we were inadvertently redirecting a subset of Attachments to a non-accessible draft version. See https://github.com/alphagov/whitehall/pull/3894 for some more information.