### PR TITLE
Assets should be valid if their replacement has been deleted

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -162,7 +162,8 @@ protected
   end
 
   def check_specified_replacement_exists
-    if replacement_id.present? && replacement.blank?
+    unscoped_replacement = Asset.unscoped.where(id: replacement_id)
+    if replacement_id.present? && unscoped_replacement.blank?
       errors.add(:replacement, 'not found')
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe Asset, type: :model do
           expect(asset.errors[:replacement]).to include('not found')
         end
       end
+
+      context 'and the replacement exists but has been deleted' do
+        let(:replacement) { FactoryBot.create(:asset) }
+        let(:replacement_id) { replacement.id.to_s }
+
+        before do
+          replacement.destroy
+        end
+
+        it 'is valid' do
+          expect(asset).to be_valid
+        end
+      end
     end
 
     context 'when published asset is marked as draft' do
@@ -83,7 +96,7 @@ RSpec.describe Asset, type: :model do
       end
 
       context 'and asset is replaced' do
-        let(:replacement) { Asset.new }
+        let(:replacement) { FactoryBot.create(:asset) }
 
         it 'is not valid' do
           expect(asset).not_to be_valid


### PR DESCRIPTION
We saw some exceptions when updating the metadata of Whitehall attachments stored in Asset Manager. Some of these attachments had been replaced by assets that had subsequently been deleted. This left the assets in an invalid state and meant that we couldn't update them.

We considered removing the `replacement_id` foreign key when a replacement is deleted but weren't keen on losing that data. Allowing an asset to be valid if it's been replaced by a deleted asset feels slightly safer.

See https://github.com/alphagov/asset-manager/issues/533 for some more information.