### PR TITLE
Allow deleted assets to be retrieved using the API

### DIFF
--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -1,6 +1,6 @@
 class BaseAssetsController < ApplicationController
   def show
-    @asset = find_asset
+    @asset = find_asset(include_deleted: true)
 
     expires_now
     render json: AssetPresenter.new(@asset, view_context)

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -25,8 +25,9 @@ private
     WhitehallAsset.where(legacy_url_path: asset_params[:legacy_url_path])
   end
 
-  def find_asset
-    WhitehallAsset.from_params(
+  def find_asset(include_deleted: false)
+    scope = include_deleted ? WhitehallAsset.unscoped : WhitehallAsset
+    scope.from_params(
       path: params[:path], format: params[:format]
     )
   end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -15,7 +15,8 @@ class AssetPresenter
       size: @asset.size,
       file_url: URI.join(Plek.new.asset_root, Addressable::URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,
-      draft: @asset.draft?
+      draft: @asset.draft?,
+      deleted: @asset.deleted?
     }
     if @asset.redirect_url.present?
       json[:redirect_url] = @asset.redirect_url

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -372,6 +372,16 @@ RSpec.describe AssetsController, type: :controller do
       end
     end
 
+    context 'an asset that has been deleted' do
+      let(:asset) { FactoryBot.create(:deleted_asset) }
+
+      it 'responds with success status' do
+        get :show, params: { id: asset.id }
+
+        expect(response).to be_success
+      end
+    end
+
     context 'no existing asset' do
       it 'responds with not found status' do
         get :show, params: { id: 'some-gif-or-other' }

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -208,5 +208,17 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context 'when the asset has been deleted' do
+      before do
+        asset.destroy
+      end
+
+      it 'returns a 200 response' do
+        get :show, params: { path: 'government/uploads/image', format: 'png' }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe AssetPresenter do
       expect(json).to have_key(:size)
     end
 
+    it 'return hash including deleted state' do
+      expect(json).to include(deleted: false)
+    end
+
     context 'when the asset has been saved' do
       before do
         asset.save
@@ -56,6 +60,17 @@ RSpec.describe AssetPresenter do
 
       it 'returns hash including asset size' do
         expect(json).to include(size: 57705)
+      end
+    end
+
+    context 'when the asset has been saved and then destroyed' do
+      before do
+        asset.save!
+        asset.destroy
+      end
+
+      it 'return hash including deleted state' do
+        expect(json).to include(deleted: true)
       end
     end
 

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -116,8 +116,10 @@ RSpec.describe "Asset requests", type: :request do
       expect(body["state"]).to eq("uploaded")
 
       get "/assets/#{asset.id}"
+      body = JSON.parse(response.body)
 
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:ok)
+      expect(body['deleted']).to eq(true)
     end
   end
 


### PR DESCRIPTION
We're seeing a number of problems in Whitehall when it's trying to update attachments in Asset Manager. A large number of these are being caused by us not being able to retrieve information about assets that have been deleted. This change should help improve the situation.

More generally, I think this is a reasonable change to make given that there's an API restore endpoint that undeletes a previously deleted asset. I think it's probably useful to be able to query the API to determine the state of the asset before attempting to delete it.

Note that it's not possible to update a previously deleted asset, nor is it possible to request the content of a deleted asset.