### PR TITLE
Show most recent whitehall asset

### DIFF
--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -19,7 +19,7 @@ class WhitehallAsset < Asset
   def self.from_params(path:, format: nil, path_prefix: nil)
     legacy_url_path = "/#{path_prefix}#{path}"
     legacy_url_path += ".#{format}" if format.present?
-    find_by(legacy_url_path: legacy_url_path)
+    order(updated_at: :desc).find_by(legacy_url_path: legacy_url_path)
   end
 
   def etag

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WhitehallAsset, type: :model do
       end
 
       context 'and legacy_url_path is not unique' do
-        let(:existing_asset) { FactoryBot.create(:whitehall_asset) }
+        let!(:existing_asset) { FactoryBot.create(:whitehall_asset) }
 
         before do
           asset.legacy_url_path = existing_asset.legacy_url_path
@@ -49,10 +49,16 @@ RSpec.describe WhitehallAsset, type: :model do
           before do
             asset.legacy_url_path = existing_asset.legacy_url_path
             existing_asset.delete
+            asset.save
           end
 
           it 'is valid because legacy_url_path is unique within the assets not marked as deleted' do
             expect(asset).to be_valid
+          end
+
+          it 'can find the most recent (undeleted) asset' do
+            path = asset.legacy_url_path[1..-1]
+            expect(WhitehallAsset.unscoped.from_params(path: path).deleted?).to eq(false)
           end
         end
       end


### PR DESCRIPTION
Currently, if the whitehall asset legacy_url_path isn't unique, it finds the first one by ID, rather than finding the most recent.

Paired with @barrucadu.

[Trello Card](https://trello.com/c/VybIxQvG/104-fix-assetmanagerupdateassetworkerassetmanagerassetdeleted-error-in-whitehall)