### PR TITLE
Update replaced assets to avoid redirect chains

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -51,6 +51,7 @@ class Asset
 
   before_save :store_metadata, unless: :uploaded?
   after_save :schedule_virus_scan
+  after_save :update_indirect_replacements
 
   state_machine :state, initial: :unscanned do
     event :scanned_clean do
@@ -132,6 +133,15 @@ class Asset
 
   def size_from_file
     file_stat.size
+  end
+
+  def update_indirect_replacements
+    return unless replacement.present?
+
+    Asset.unscoped.where(replacement_id: self.id).each do |asset|
+      asset.replacement = replacement
+      asset.save
+    end
   end
 
 protected

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -23,4 +23,14 @@ namespace :db do
       SetAssetSizeWorker.perform_async(asset_id)
     end
   end
+
+  desc "Transform all redirect chains into one-step redirects"
+  task resolve_redirect_chains: :environment do
+    replaced = Asset.unscoped.where(:replacement_id.ne => nil)
+    replaced.each do |asset|
+      next unless asset.replacement.present?
+      next if asset.replacement.replacement.present?
+      asset.update_indirect_replacements
+    end
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe Asset, type: :model do
       end
     end
 
+    context 'when replacements are replaced' do
+      let(:first_replacement) { FactoryBot.create(:asset) }
+      let(:final_replacement) { FactoryBot.create(:asset) }
+
+      before do
+        asset.replacement = first_replacement
+        asset.save
+        first_replacement.replacement = final_replacement
+        first_replacement.save
+      end
+
+      it 'updates the original asset' do
+        expect(asset.reload.replacement_id).to eq(final_replacement.id)
+      end
+    end
+
     context 'when published asset is marked as draft' do
       let(:replacement) { nil }
       let(:redirect_url) { nil }


### PR DESCRIPTION
Say we have an asset `A`, which gets replaced with an asset `B`.  We have this situation:

```
A    ---[replaced by]--->     B
```

When users request asset `A`, they get a redirect to asset `B`.  So far so good.

But what happens then if asset `B` is replaced with asset `C`, giving us this situation: ?

```
A    ---[replaced by]--->     B    ---[replaced by]--->     C
```

When users request asset `B`, they get redirected to asset `C`.  But when users request asset `A` they first get redirected to asset `B`!  This redirect chaining is bad, we want to redirect to the final asset in the replacement chain in one step.

The simplest way to do this is to (recursively) update assets when their replacement gets replaced.  So when `B` is replaced by `C` we end up with this:

```
A    ---[replaced by]--->     C
B    ---[replaced by]--->     C
```

---

Updating assets is recursive, so current redirect chains will be fixed as the assets are updated.  However, if we want to update all assets in one go, I added a rake task.  It's pretty slow: it's been running for a few hours in my dev VM.

---

Closes #498

[Trello card](https://trello.com/c/DbjbmIvU/152-avoid-multiple-redirects-if-a-replacement-asset-is-itself-replaced-2)