### PR TITLE
Set X-Frame-Options: DENY for whitehall assets

### DIFF
--- a/app/controllers/base_media_controller.rb
+++ b/app/controllers/base_media_controller.rb
@@ -37,4 +37,8 @@ protected
       headers['Link'] = %(<#{asset.parent_document_url}>; rel="up")
     end
   end
+
+  def add_frame_header
+    headers['X-Frame-Options'] = 'DENY'
+  end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -39,7 +39,7 @@ class MediaController < BaseMediaController
           set_default_expiry
         end
         add_link_header(asset)
-        headers['X-Frame-Options'] = AssetManager.frame_options
+        add_frame_header
         proxy_to_s3_via_nginx(asset)
       end
     end

--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -42,7 +42,7 @@ class WhitehallMediaController < BaseMediaController
       set_default_expiry
     end
     add_link_header(asset)
-    headers['X-Frame-Options'] = AssetManager.whitehall_frame_options
+    add_frame_header
     proxy_to_s3_via_nginx(asset)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,8 +43,6 @@ module AssetManager
 
   mattr_accessor :content_disposition
   mattr_accessor :default_content_type
-  mattr_accessor :frame_options
-  mattr_accessor :whitehall_frame_options
 
   mattr_accessor :fake_s3
 end

--- a/config/initializers/frame_options.rb
+++ b/config/initializers/frame_options.rb
@@ -1,2 +1,0 @@
-AssetManager.frame_options = 'DENY'
-AssetManager.whitehall_frame_options = 'SAMEORIGIN'

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Media requests", type: :request do
       expect(response.headers["Content-Disposition"]).to eq('inline; filename="asset.png"')
     end
 
-    it "sets the X-Frame-Options header to SAMEORIGIN" do
+    it "sets the X-Frame-Options header to DENY" do
       expect(response.headers["X-Frame-Options"]).to eq('DENY')
     end
   end

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe 'Whitehall media requests', type: :request do
       expect(response.headers['Cache-Control']).to eq('max-age=86400, public')
     end
 
-    it 'sets the X-Frame-Options response header to SAMEORIGIN' do
-      expect(response.headers['X-Frame-Options']).to eq('SAMEORIGIN')
+    it 'sets the X-Frame-Options response header to DENY' do
+      expect(response.headers['X-Frame-Options']).to eq('DENY')
     end
   end
 end


### PR DESCRIPTION
This breaks anything which embeds whitehall assets in an iframe,
however:

- whitehall only uses iframes for external videos
- government-frontend doesn't use iframes at all

So this more conservative header should be safe.

OWASP recommends DENY unless there is a specific reason to use
something else, which is why I didn't change everything to use
SAMEORIGIN instead.

---

Closes #249 

[Trello card](https://trello.com/c/Rx2IiQPR/156-standardise-use-of-x-frame-options-response-header-for-whitehall-vs-mainstream-assets-2)