### PR TITLE
Add index to uuid field

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -13,6 +13,7 @@ class Asset
   protected :filename_history=
 
   field :uuid, type: String, default: -> { SecureRandom.uuid }
+  index uuid: 1
   attr_readonly :uuid
 
   field :draft, type: Boolean, default: false


### PR DESCRIPTION
There are queries on this field a lot and we noticed a query that was taking 3 seconds to run. We've already added this index in production so we should also include it in the model.