### PR TITLE
Add index to replacement_id field

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -6,7 +6,7 @@ class Asset
   include Mongoid::Paranoia
   include Mongoid::Timestamps
 
-  belongs_to :replacement, class_name: 'Asset', optional: true
+  belongs_to :replacement, class_name: 'Asset', optional: true, index: true
 
   field :state, type: String, default: 'unscanned'
   field :filename_history, type: Array, default: -> { [] }


### PR DESCRIPTION
We've found some queries are running slow without this index and we've already added the index in production.

[Trello Card](https://trello.com/c/uSPO7Sc9/185-investigate-potential-problem-with-whitehall-assets-blocking-publishing-to-the-publishing-api-3)