### PR TITLE
Save asset before removing file

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -74,6 +74,7 @@ class Asset
     end
 
     after_transition to: :uploaded do |asset, _|
+      asset.save!
       asset.remove_file!
     end
   end


### PR DESCRIPTION
Transitioning to a state doesn't save asset, so we think there's a problem with transitioning to the `uploaded` state:

1. Transition happens
2. `after_transition to: :uploaded` triggers, deleting the file.
3. Save happens
4. `before_save : store_metadata` triggers, raising an exception when it can't read the file.