### PR TITLE
Allow unsetting redirect URLs

### DIFF
--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -19,7 +19,10 @@ class BaseAssetsController < ApplicationController
 protected
 
   def normalize_redirect_url(params)
-    params.reject { |k, v| (k.to_sym == :redirect_url) && v.blank? }
+    if params.has_key?(:redirect_url) && params[:redirect_url].blank?
+      params[:redirect_url] = nil
+    end
+    params
   end
 
   def normalize_access_limited(params)

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -222,6 +222,17 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).redirect_url).to be_nil
       end
 
+      it 'removes existing redirect_url from existing asset if empty one is sent' do
+        redirect_url = 'https://example.com/path/file.ext'
+        attributes = valid_attributes.merge(redirect_url: redirect_url)
+        put :update, params: { id: asset.id, asset: attributes }
+        expect(assigns(:asset).redirect_url).to eq(redirect_url)
+
+        attributes = valid_attributes.merge(redirect_url: '')
+        put :update, params: { id: asset.id, asset: attributes }
+        expect(assigns(:asset).redirect_url).to be_nil
+      end
+
       it 'stores replacement on existing asset' do
         replacement = FactoryBot.create(:asset)
         replacement_id = replacement.id.to_s


### PR DESCRIPTION
b9e3a6a3cae336069913959a67d928bcb3889beb strips out blank redirect URLs from updates because `nil` redirect URLs manifest in the app as empty strings, in part justifying the change by pointing out that the default redirect URL is `nil`, so we never want to set it to an empty string.

However, there's a perfectly legitimate use-case for setting a non-`nil` redirect URL to `nil`: if someone unpublishes a document with an attachment, and then republishes it.  Unpublishing will set the redirect URL, but republishing will not remove the redirect URL currently because of this logic.

This PR changes the logic to normalise empty strings to `nil` redirect URLs.

---

This change is safe **if** all publishing apps which send `{ redirect_url: nil }` only do so when they actually want to unset the redirect URL.  That is - no apps are relying on the behaviour of *not* being able to unset the redirect.  That's the case in whitehall, I assume it is in others too.

---

[Trello card](https://trello.com/c/hoC9DL84/290-investigate-asset-manager-redirecturl-weirdness)