### PR TITLE
Use undeleted scope and remove unscoped queries

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -100,7 +100,7 @@ protected
   end
 
   def asset
-    @asset ||= Asset.find(params[:id])
+    @asset ||= Asset.undeleted.find(params[:id])
   end
 
   def redirect_to_current_filename

--- a/app/models/healthcheck/database_healthcheck.rb
+++ b/app/models/healthcheck/database_healthcheck.rb
@@ -5,7 +5,7 @@ class Healthcheck
     end
 
     def status
-      Asset.unscoped.count
+      Asset.count
       :ok
     rescue Mongo::Error::NoServerAvailable
       :critical

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -19,7 +19,7 @@ class WhitehallAsset < Asset
   def self.from_params(path:, format: nil, path_prefix: nil)
     legacy_url_path = "/#{path_prefix}#{path}"
     legacy_url_path += ".#{format}" if format.present?
-    order(updated_at: :desc).find_by(legacy_url_path: legacy_url_path)
+    undeleted.order(updated_at: :desc).find_by(legacy_url_path: legacy_url_path)
   end
 
   def etag

--- a/app/workers/delete_asset_file_from_nfs_worker.rb
+++ b/app/workers/delete_asset_file_from_nfs_worker.rb
@@ -3,7 +3,7 @@ class DeleteAssetFileFromNfsWorker
   sidekiq_options queue: 'low_priority'
 
   def perform(asset_id)
-    asset = Asset.unscoped.find(asset_id)
+    asset = Asset.find(asset_id)
     if asset.uploaded?
       asset.remove_file!
     end

--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -4,7 +4,7 @@ class SaveToCloudStorageWorker
   include Sidekiq::Worker
 
   def perform(asset_id)
-    asset = Asset.find(asset_id)
+    asset = Asset.undeleted.find(asset_id)
     unless asset.uploaded?
       Services.cloud_storage.save(asset)
       asset.upload_success!

--- a/app/workers/set_asset_size_worker.rb
+++ b/app/workers/set_asset_size_worker.rb
@@ -3,7 +3,7 @@ class SetAssetSizeWorker
   sidekiq_options queue: 'low_priority'
 
   def perform(asset_id)
-    asset = Asset.unscoped.find(asset_id)
+    asset = Asset.find(asset_id)
     size_from_etag = asset.etag.split('-').last.to_i(16)
     asset.set(size: size_from_etag)
   end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,13 +1,13 @@
 namespace :db do
   task remove_unused_fields_from_assets: :environment do
-    if Asset.unscoped.where(access_limited: true).none?
+    if Asset.where(access_limited: true).none?
       Asset.update_all('$unset' => { 'access_limited' => true })
       puts 'Asset#access_limited field removed successfully'
     else
       puts 'Error: Unable to remove Asset#access_limited'
     end
 
-    if Asset.unscoped.where(:organisation_slug.ne => nil).none?
+    if Asset.where(:organisation_slug.ne => nil).none?
       Asset.update_all('$unset' => { 'organisation_slug' => true })
       puts 'Asset#organisation_slug field removed successfully'
     else
@@ -17,7 +17,7 @@ namespace :db do
 
   desc "Set the size field for all assets from the etag"
   task set_size_for_all_uploaded_assets: :environment do
-    scope = Asset.unscoped.where(size: nil)
+    scope = Asset.where(size: nil)
     processor = AssetProcessor.new(scope: scope)
     processor.process_all_assets_with do |asset_id|
       SetAssetSizeWorker.perform_async(asset_id)
@@ -26,7 +26,7 @@ namespace :db do
 
   desc "Transform all redirect chains into one-step redirects"
   task resolve_redirect_chains: :environment do
-    replaced = Asset.unscoped.where(:replacement_id.ne => nil)
+    replaced = Asset.where(:replacement_id.ne => nil)
     replaced.each do |asset|
       next unless asset.replacement.present?
       next if asset.replacement.replacement.present?

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -3,7 +3,7 @@ require 'asset_processor'
 namespace :govuk_assets do
   desc 'Delete file from NFS for assets uploaded to S3'
   task delete_file_from_nfs_for_assets_uploaded_to_s3: :environment do
-    processor = AssetProcessor.new(scope: Asset.unscoped.where(state: 'uploaded'))
+    processor = AssetProcessor.new(scope: Asset.where(state: 'uploaded'))
     processor.process_all_assets_with do |asset_id|
       DeleteAssetFileFromNfsWorker.perform_async(asset_id)
     end
@@ -11,7 +11,7 @@ namespace :govuk_assets do
 
   desc 'Normalize blank Asset#redirect_url values'
   task normalize_blank_asset_redirect_url_values: :environment do
-    scope = Asset.unscoped.where(redirect_url: '')
+    scope = Asset.where(redirect_url: '')
     result = scope.update_all('$unset' => { redirect_url: true })
     status = result.successful? ? 'OK' : 'Error'
     puts "#{status}: #{result.written_count} documents updated"

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -223,9 +223,11 @@ RSpec.describe MediaController, type: :controller do
 
       context "when the file name in the URL represents an old version" do
         let(:old_file_name) { "an_old_filename.pdf" }
+        let(:scope) { double(:undeleted_scope) }
 
         before do
-          allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+          allow(Asset).to receive(:undeleted).and_return(scope)
+          allow(scope).to receive(:find).with(asset.id).and_return(asset)
           allow(asset).to receive(:filename_valid?).and_return(true)
         end
 
@@ -294,9 +296,11 @@ RSpec.describe MediaController, type: :controller do
     context 'with an access limited draft asset' do
       let(:user) { FactoryBot.build(:user) }
       let(:asset) { FactoryBot.create(:uploaded_asset, draft: true) }
+      let(:scope) { double(:undeleted_scope) }
 
       before do
-        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(Asset).to receive(:undeleted).and_return(scope)
+        allow(scope).to receive(:find).with(asset.id).and_return(asset)
         request.headers['X-Forwarded-Host'] = AssetManager.govuk.draft_assets_host
         login_as user
       end

--- a/spec/models/healthcheck/database_healthcheck_spec.rb
+++ b/spec/models/healthcheck/database_healthcheck_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Healthcheck::DatabaseHealthcheck do
   context "when the database is not available" do
     before do
       allow(Asset)
-        .to receive_message_chain(:unscoped, :count) # rubocop:disable RSpec/MessageChain
+        .to receive(:count)
         .and_raise(Mongo::Error::NoServerAvailable.allocate)
     end
 

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WhitehallAsset, type: :model do
 
           it 'can find the most recent (undeleted) asset' do
             path = asset.legacy_url_path[1..-1]
-            expect(WhitehallAsset.unscoped.from_params(path: path).deleted?).to eq(false)
+            expect(WhitehallAsset.from_params(path: path).deleted?).to eq(false)
           end
         end
       end


### PR DESCRIPTION
https://trello.com/c/VubcGtSx/343-investigate-asset-manager-default-scopes

Missed in https://github.com/alphagov/asset-manager/pull/578
This PR tidies up redundant calls to `.unscoped` and uses the correct `.undeleted` scope where appropriate.