### PR TITLE
Add a rake task to upload HMRC PAYE files

### DIFF
--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -17,13 +17,52 @@ namespace :govuk_assets do
     puts "#{status}: #{result.written_count} documents updated"
   end
 
+  def create_or_replace_whitehall_asset(file_path, legacy_url_path)
+    begin
+      prior = WhitehallAsset.find_by(legacy_url_path: legacy_url_path)
+      prior.file = Pathname.new(file_path).open
+      prior.save!
+    rescue Mongoid::Errors::DocumentNotFound
+      WhitehallAsset.create!(
+        file: Pathname.new(file_path).open,
+        legacy_url_path: legacy_url_path,
+      )
+    end
+    puts "Uploaded '#{file_path}' to '#{legacy_url_path}'"
+  end
+
+  desc 'Store HMRC PAYE files, from the given directory'
+  task :create_hmrc_paye_assets, %i[directory version] => :environment do |_, args|
+    directory = args[:directory]
+    version_full = args[:version]
+    version_short = version_full.split('.')[0]
+
+    hmrc_url_base = '/government/uploads/uploaded/hmrc'
+
+    manifest_basename = "realtimepayetools-update-v#{version_short}.xml"
+    manifest_path = File.join(directory, manifest_basename)
+    test_manifest_legacy_url_path = "#{hmrc_url_base}/test-#{manifest_basename}"
+
+    [
+      'payetools-linux.zip',
+      'payetools-osx.zip',
+      'payetools-windows.zip',
+      "payetools-rti-#{version_full}-linux.zip",
+      "payetools-rti-#{version_full}-osx.zip",
+      "payetools-rti-#{version_full}-windows.zip",
+    ].each do |basename|
+      create_or_replace_whitehall_asset(File.join(directory, basename), "#{hmrc_url_base}/#{basename}")
+    end
+
+    create_or_replace_whitehall_asset(manifest_path, test_manifest_legacy_url_path)
+
+    puts ''
+    puts "If there are any other files to upload, use 'rake govuk_assets:create_whitehall_asset[/path/to/file.ext,#{hmrc_url_base}/file.ext]'."
+    puts "Run 'rake govuk_assets:create_whitehall_asset[#{manifest_path},#{hmrc_url_base}/#{manifest_basename}]' to store the file to the real URL after it is confirmed to work."
+  end
+
   desc 'Create a whitehall asset with the given legacy URL path'
   task :create_whitehall_asset, %i[file_path legacy_url_path] => :environment do |_, args|
-    file_path = args[:file_path]
-    legacy_url_path = args[:legacy_url_path]
-    WhitehallAsset.create!(
-      file: Pathname.new(file_path).open,
-      legacy_url_path: legacy_url_path,
-    )
+    create_or_replace_whitehall_asset(args[:file_path], args[:legacy_url_path])
   end
 end


### PR DESCRIPTION
HMRC PAYE files are manually uploaded, because we don't normally allow exe files on GOV.UK.  Infrequently, we will receive a zendesk ticket with a bunch of new files attached.  These files are:

* `payetools-{linux,osx,win}.zip` - the full binary

* `payetools-rti-$version-{linux,osx,win}.zip` - the binary patch updates

* `realtimepayetools-update-vXX.xml` - a manifest file describing the patch update locations and versions

There may be additional files (`payetools-rti-patch-*` and `*-win-assistive.zip` are common), but these 7 are always present, so they are what the rake task uploads.

The `govuk_assets:create_whitehall_asset` task can be used to upload any additional files.

---

[Trello card](https://trello.com/c/SFeIQ9Dp/371-serve-hmrc-assets-from-the-asset-manager)