### PR TITLE
Do not make assumptions about files in HMRC PAYE task

### DIFF
--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -31,10 +31,22 @@ namespace :govuk_assets do
     puts "Uploaded '#{file_path}' to '#{legacy_url_path}'"
   end
 
+  def create_or_replace_hmrc_asset(file_path, basename)
+    hmrc_url_base = '/government/uploads/uploaded/hmrc'
+    create_or_replace_whitehall_asset(file_path, "#{hmrc_url_base}/#{basename}")
+  end
+
+  desc 'Upload all *.zip files in the given directory to /government/uploads/uploaded/hmrc'
+  task :create_hmrc_paye_zips, %i[directory] => :environment do |_, args|
+    directory = args[:directory]
+
+    Dir.glob(File.join(directory, "*.zip")).each do |file_path|
+      create_or_replace_hmrc_asset(file_path, File.basename(file_path))
+    end
+  end
+
   desc 'Upload a file to /government/uploads/uploaded/hmrc.  The optional second argument is the filename to use.'
   task :create_hmrc_paye_asset, %i[file_path] => :environment do |_, args|
-    hmrc_url_base = '/government/uploads/uploaded/hmrc'
-
     file_path = args[:file_path]
 
     basename = File.basename(file_path)
@@ -42,7 +54,7 @@ namespace :govuk_assets do
       basename = args.extras[0]
     end
 
-    create_or_replace_whitehall_asset(file_path, "#{hmrc_url_base}/#{basename}")
+    create_or_replace_hmrc_asset(file_path, basename)
   end
 
   desc 'Create a whitehall asset with the given legacy URL path'

--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -31,34 +31,18 @@ namespace :govuk_assets do
     puts "Uploaded '#{file_path}' to '#{legacy_url_path}'"
   end
 
-  desc 'Store HMRC PAYE files, from the given directory'
-  task :create_hmrc_paye_assets, %i[directory version] => :environment do |_, args|
-    directory = args[:directory]
-    version_full = args[:version]
-    version_short = version_full.split('.')[0]
-
+  desc 'Upload a file to /government/uploads/uploaded/hmrc.  The optional second argument is the filename to use.'
+  task :create_hmrc_paye_asset, %i[file_path] => :environment do |_, args|
     hmrc_url_base = '/government/uploads/uploaded/hmrc'
 
-    manifest_basename = "realtimepayetools-update-v#{version_short}.xml"
-    manifest_path = File.join(directory, manifest_basename)
-    test_manifest_legacy_url_path = "#{hmrc_url_base}/test-#{manifest_basename}"
+    file_path = args[:file_path]
 
-    [
-      'payetools-linux.zip',
-      'payetools-osx.zip',
-      'payetools-windows.zip',
-      "payetools-rti-#{version_full}-linux.zip",
-      "payetools-rti-#{version_full}-osx.zip",
-      "payetools-rti-#{version_full}-windows.zip",
-    ].each do |basename|
-      create_or_replace_whitehall_asset(File.join(directory, basename), "#{hmrc_url_base}/#{basename}")
+    basename = File.basename(file_path)
+    if args.extras.count.positive?
+      basename = args.extras[0]
     end
 
-    create_or_replace_whitehall_asset(manifest_path, test_manifest_legacy_url_path)
-
-    puts ''
-    puts "If there are any other files to upload, use 'rake govuk_assets:create_whitehall_asset[/path/to/file.ext,#{hmrc_url_base}/file.ext]'."
-    puts "Run 'rake govuk_assets:create_whitehall_asset[#{manifest_path},#{hmrc_url_base}/#{manifest_basename}]' to store the file to the real URL after it is confirmed to work."
+    create_or_replace_whitehall_asset(file_path, "#{hmrc_url_base}/#{basename}")
   end
 
   desc 'Create a whitehall asset with the given legacy URL path'


### PR DESCRIPTION
The documented list of files does not match the reality.

This also makes it much easier to load all the current files into the asset manager:

```bash
for file in *; do
    sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_asset[$file]
done
```

---

[Trello card](https://trello.com/c/SFeIQ9Dp/371-serve-hmrc-assets-from-the-asset-manager)