### PR TITLE
Delete files uploaded to s3 from disk

### DIFF
--- a/app/workers/save_to_cloud_storage_worker.rb
+++ b/app/workers/save_to_cloud_storage_worker.rb
@@ -8,6 +8,12 @@ class SaveToCloudStorageWorker
     unless asset.uploaded?
       Services.cloud_storage.save(asset)
       asset.upload_success!
+
+      # if we're using real s3, the uploaded file is no longer
+      # required
+      unless AssetManager.s3.fake?
+        DeleteAssetFileFromNfsWorker.perform_async(asset_id)
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow us to shrink the asset NFS share with confidence, as the disk space used by assets will no longer grow continuously.

---

[Trello card](https://trello.com/c/M3Dfrj8S/443-remove-attachments-from-nfs)