### PR TITLE
Delete directory after uploading an asset to S3

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -80,6 +80,7 @@ class Asset
     after_transition to: :uploaded do |asset, _|
       asset.save!
       asset.remove_file!
+      FileUtils.rmdir(File.dirname(asset.file.path))
     end
   end
 

--- a/app/workers/delete_asset_file_from_nfs_worker.rb
+++ b/app/workers/delete_asset_file_from_nfs_worker.rb
@@ -6,6 +6,7 @@ class DeleteAssetFileFromNfsWorker
     asset = Asset.find(asset_id)
     if asset.uploaded?
       asset.remove_file!
+      FileUtils.rmdir(File.dirname(asset.file.path))
     end
   end
 end


### PR DESCRIPTION
When an asset is uploaded, it is stored on disk in a directory named by a hash, like so: `/aa/bb/cccccccccccccccccccccccc`.  The files themselves are deleted after being uploaded to the cloud storage, but the directory is not.

There are lots of things with hashes which start with `aa`.  Fewer but still lots with hashes which start with `aabb`.  Very very few things have the same hash (which is kind of the point!).  So we're creating a lot of directories, which don't get cleaned up.

This wouldn't be so bad if there were more hash collisions, as files are referenced by the full path anyway (not just the hash), so collisions in directory names would be fine.  But because everything (just about) gets a new hash, we're creating a huge number of directories, and directories are not free: I just deleted 11GB of empty directories.

This brings the Asset Manager behaviour in line with Whitehall:
https://github.com/alphagov/whitehall/blob/f65a2f354a717032cf1009ff951335513ca0b222/app/workers/asset_manager_create_whitehall_asset_worker.rb#L35

---

[Trello card](https://trello.com/c/M3Dfrj8S/443-remove-attachments-from-nfs)