### PR TITLE
Fix success? predicate deprecation warning

### DIFF
--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe AssetsController, type: :controller do
       it 'responds with success status' do
         get :show, params: { id: asset.id }
 
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'makes the asset available to the view template' do
@@ -389,7 +389,7 @@ RSpec.describe AssetsController, type: :controller do
       it 'responds with success status' do
         get :show, params: { id: asset.id }
 
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -418,7 +418,7 @@ RSpec.describe AssetsController, type: :controller do
       end
 
       it 'responds with success status' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'marks the asset as not deleted' do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe MediaController, type: :controller do
 
         get :download, params
 
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'denies access to a user who is not authorised to view the asset' do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
         get :download, params: { path: path, format: format }
 
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'denies access to a user who is not authorised to view the asset' do

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Access limited assets", type: :request do
 
     get "/media/#{asset.id}/#{asset.filename}"
 
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it 'are not accessible to users who are not authorised to view them' do

--- a/spec/requests/access_limited_whitehall_assets_spec.rb
+++ b/spec/requests/access_limited_whitehall_assets_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Access limited Whitehall assets", type: :request do
 
     get asset.legacy_url_path
 
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it 'are not accessible to users who are not authorised to view them' do

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Asset requests", type: :request do
 
       get "/assets/#{asset.id}"
 
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Media requests", type: :request do
     end
 
     it "sets the X-Accel-Redirect header" do
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.headers["X-Accel-Redirect"]).to eq("/cloud-storage-proxy/#{presigned_url}")
     end
 


### PR DESCRIPTION
This stops the test suite outputting various warnings like:

```
DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers.
```