### PR TITLE
View draft assets with token authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'state_machines-mongoid', '~> 0.2.0'
 gem 'unicorn', '5.4.1'
 
 group :development, :test do
+  gem 'climate_control'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'govuk-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'carrierwave-mongoid', '~> 0.10.0', require: 'carrierwave/mongoid'
 gem 'gds-sso', '~> 13.6'
 gem 'govuk_app_config', '~> 1.9'
 gem 'govuk_sidekiq', '~> 3.0'
+gem 'jwt', '~> 1.5'
 gem 'mongoid', '~> 6.2.0'
 gem 'nokogiri', '~> 1.8.5'
 gem 'plek', '~> 2.1'
@@ -22,4 +23,5 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'rspec-rails'
   gem 'simplecov-rcov'
+  gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
       oj (~> 3.0)
     bson (4.2.2)
     builder (3.2.3)
+    byebug (10.0.2)
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -339,6 +340,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   aws-sdk (~> 2.0)
+  byebug
   carrierwave (~> 0.11.2)
   carrierwave-mongoid (~> 0.10.0)
   database_cleaner
@@ -347,6 +349,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 1.9)
   govuk_sidekiq (~> 3.0)
+  jwt (~> 1.5)
   mongoid (~> 6.2.0)
   nokogiri (~> 1.8.5)
   plek (~> 2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       carrierwave (>= 0.8.0, < 0.12.0)
       mongoid (>= 3.0, < 7.0)
       mongoid-grid_fs (>= 1.3, < 3.0)
+    climate_control (0.2.0)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crass (1.0.4)
@@ -343,6 +344,7 @@ DEPENDENCIES
   byebug
   carrierwave (~> 0.11.2)
   carrierwave-mongoid (~> 0.10.0)
+  climate_control
   database_cleaner
   factory_bot_rails
   gds-sso (~> 13.6)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ node ('mongodb-2.4') {
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar('TEST_COVERAGE', 'true')
+      govuk.setEnvar('JWT_AUTH_SECRET', 'secret')
     },
     sassLint: false,
     rubyLintDiff: false,

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -38,11 +38,13 @@ private
   end
 
   def asset_params
-    normalize_redirect_url(
-      normalize_access_limited(params)
-        .require(:asset)
-        .permit(:file, :draft, :redirect_url, :replacement_id, :parent_document_url, access_limited: [])
-    )
+    base_asset_params.permit(:file,
+                             :draft,
+                             :redirect_url,
+                             :replacement_id,
+                             :parent_document_url,
+                             access_limited: [],
+                             auth_bypass_ids: [])
   end
 
   def find_asset(include_deleted: false)

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -18,17 +18,19 @@ class BaseAssetsController < ApplicationController
 
 protected
 
-  def normalize_redirect_url(params)
-    if params.has_key?(:redirect_url) && params[:redirect_url].blank?
-      params[:redirect_url] = nil
-    end
-    params
-  end
+  def base_asset_params
+    params.require(:asset).tap do |asset|
+      if asset.has_key?(:redirect_url) && asset[:redirect_url].blank?
+        asset[:redirect_url] = nil
+      end
 
-  def normalize_access_limited(params)
-    if params.has_key?(:asset) && params[:asset].has_key?(:access_limited) && params[:asset][:access_limited].empty?
-      params[:asset][:access_limited] = []
+      if asset.has_key?(:access_limited) && asset[:access_limited].empty?
+        asset[:access_limited] = []
+      end
+
+      if asset.has_key?(:auth_bypass_ids) && asset[:auth_bypass_ids].empty?
+        asset[:auth_bypass_ids] = []
+      end
     end
-    params
   end
 end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -10,15 +10,15 @@ class WhitehallAssetsController < BaseAssetsController
 private
 
   def asset_params
-    normalize_redirect_url(
-      params
-        .require(:asset)
-        .permit(
-          :file, :draft, :redirect_url, :replacement_id,
-          :legacy_url_path, :legacy_etag, :legacy_last_modified,
-          :parent_document_url, access_limited: []
-        )
-    )
+    base_asset_params.permit(:file,
+                             :draft,
+                             :redirect_url,
+                             :replacement_id,
+                             :legacy_url_path,
+                             :legacy_etag,
+                             :legacy_last_modified,
+                             :parent_document_url,
+                             access_limited: [])
   end
 
   def existing_asset_with_this_legacy_url_path

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -93,6 +93,16 @@ class Asset
     access_limited.include?(user.uid)
   end
 
+  def valid_auth_bypass_token?(token)
+    payload, = JWT.decode(token,
+                          Rails.application.secrets.jwt_auth_secret,
+                          true,
+                          algorithm: 'HS256')
+    payload['sub'].present? && auth_bypass_ids.include?(payload['sub'])
+  rescue JWT::DecodeError
+    false
+  end
+
   def public_url_path
     "/media/#{id}/#{filename}"
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,6 +34,8 @@ class Asset
 
   field :access_limited, type: Array, default: []
 
+  field :auth_bypass_ids, type: Array, default: []
+
   field :parent_document_url, type: String
 
   field :deleted_at, type: Time

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,10 @@ module AssetManager
     config.action_dispatch.rack_cache = nil
 
     config.assets.prefix = '/asset-manager'
+
+    unless Rails.application.secrets.jwt_auth_secret
+      raise "JWT auth secret is not configured. See config/secrets.yml"
+    end
   end
 
   mattr_accessor :govuk

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,9 +12,12 @@
 
 development:
   secret_key_base: '689f49f6c95d9dd41b525c1420017f339b027e4b54f92cd65de9bf1b39e98b81c287c66352c36d8aef8b496389ba0c9118c321624281ff1ba741d73edeccd7f8'
+  jwt_auth_secret: secret
 test:
   secret_key_base: '689f49f6c95d9dd41b525c1420017f339b027e4b54f92cd65de9bf1b39e98b81c287c66352c36d8aef8b496389ba0c9118c321624281ff1ba741d73edeccd7f8'
+  jwt_auth_secret: secret
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  jwt_auth_secret: <%= ENV['JWT_AUTH_SECRET'] %>

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it 'stores auth_bypass_ids on asset' do
+        attributes = valid_attributes.merge(auth_bypass_ids: %w[id1 id2])
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).auth_bypass_ids).to eq(%w[id1 id2])
+      end
+
       it 'stores parent_document_url on asset' do
         attributes = valid_attributes.merge(parent_document_url: 'parent-document-url')
         post :create, params: { asset: attributes }
@@ -204,6 +211,24 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset).access_limited).to eq([])
+      end
+
+      it 'stores auth_bypass_ids on existing asset' do
+        attributes = valid_attributes.merge(auth_bypass_ids: ['bypass-id'])
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).auth_bypass_ids).to eq(['bypass-id'])
+      end
+
+      it 'copes when auth_bypass_ids are passed in as an empty string' do
+        asset.update_attributes!(auth_bypass_ids: %w[bypass-1 bypass-2])
+
+        # We have to use an empty string as that is what gds-api-adapters/rest-client
+        # will generate instead of an empty array
+        attributes = valid_attributes.merge(auth_bypass_ids: '')
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).auth_bypass_ids).to eq([])
       end
 
       it 'stores redirect_url on existing asset' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -232,6 +232,30 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe '#valid_auth_bypass_token?' do
+    it 'returns true when given a valid token which is in the auth_bypass_ids' do
+      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
+      token = JWT.encode({ 'sub' => 'my-token' },
+                         Rails.application.secrets.jwt_auth_secret,
+                         'HS256')
+      expect(asset.valid_auth_bypass_token?(token)).to be true
+    end
+
+    it 'returns false when given a valid token which is not in the auth_bypass_ids' do
+      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
+      token = JWT.encode({ 'sub' => 'other-token' },
+                         Rails.application.secrets.jwt_auth_secret,
+                         'HS256')
+      expect(asset.valid_auth_bypass_token?(token)).to be false
+    end
+
+    it 'returns false when given an invalid token' do
+      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
+      token = SecureRandom.bytes(32)
+      expect(asset.valid_auth_bypass_token?(token)).to be false
+    end
+  end
+
   describe '#uuid' do
     it 'is generated on instantiation' do
       allow(SecureRandom).to receive(:uuid).and_return('uuid')

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Media requests", type: :request do
+  before do
+    not_logged_in
+    # create a user that can be used automatically with GDS SSO mock
+    stub_user
+  end
+
   describe "requesting an asset that doesn't exist" do
     it "responds with not found status" do
       get "/media/34/test.jpg"
@@ -38,6 +44,31 @@ RSpec.describe "Media requests", type: :request do
 
     it "sets the X-Frame-Options header to DENY" do
       expect(response.headers["X-Frame-Options"]).to eq('DENY')
+    end
+  end
+
+  describe "requesting a draft asset while not logged in" do
+    around do |example|
+      ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }
+    end
+
+    before { host! AssetManager.govuk.draft_assets_host }
+
+    let(:auth_bypass_id) { "bypass-id" }
+    let(:asset) do
+      FactoryBot.create(:uploaded_asset, draft: true, auth_bypass_ids: [auth_bypass_id])
+    end
+
+    it "redirects to login without a valid token" do
+      get "/media/#{asset.id}/asset.png"
+      expect(response).to redirect_to("/auth/gds")
+    end
+
+    it "serves the asset with a valid token" do
+      secret = Rails.application.secrets.jwt_auth_secret
+      valid_token = JWT.encode({ "sub" => auth_bypass_id }, secret, "HS256")
+      get "/media/#{asset.id}/asset.png", params: { token: valid_token }
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Whitehall media requests', type: :request do
   let(:presigned_url) { 'https://s3-host.test/presigned-url' }
 
   before do
+    stub_user
     allow(Services).to receive(:cloud_storage).and_return(cloud_storage)
   end
 

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,9 +1,19 @@
 module AuthenticationControllerHelpers
   def login_as(user)
     request.env['warden'] = double(
+      authenticate: true,
       authenticate!: true,
       authenticated?: true,
       user: user
+    )
+  end
+
+  def not_logged_in
+    request.env['warden'] = double(
+      authenticate: true,
+      authenticate!: true,
+      authenticated?: false,
+      user: nil
     )
   end
 
@@ -20,6 +30,10 @@ RSpec.configuration.include AuthenticationControllerHelpers, type: :controller
 module AuthenticationFeatureHelpers
   def login_as(user)
     GDS::SSO.test_user = user
+  end
+
+  def not_logged_in
+    GDS::SSO.test_user = nil
   end
 
   def stub_user


### PR DESCRIPTION
Trello: https://trello.com/c/dawXVwdW/439-asset-manager-files-are-not-available-when-using-access-tokens-or-if-someone-doesnt-have-asset-manager-permission

This is a feature that allows the presence of a token, in either a cookie or a query string, to bypass the authentication needed to view that asset on the draft stack. See https://github.com/alphagov/authenticating-proxy/pull/108 for more info.

This allows the storing of auth_bypass_ids on an asset and allows checking JWT tokens when requesting a draft asset to determine whether the asset should be served or not.