### PR TITLE
Add correct mime type for .odp files

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -13,6 +13,7 @@ Mime::Type.register "application/vnd.ms-excel", :xlt
 Mime::Type.register "application/vnd.ms-excel.sheet.macroEnabled.12", :xlsm
 Mime::Type.register "application/vnd.ms-powerpoint", :ppt
 Mime::Type.register "application/vnd.oasis.opendocument.spreadsheet", :ods
+Mime::Type.register "application/vnd.oasis.opendocument.presentation", :odp
 Mime::Type.register "application/vnd.oasis.opendocument.text", :odt
 Mime::Type.register "application/vnd.openxmlformats-officedocument.presentationml.presentation", :pptx
 Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx


### PR DESCRIPTION
We're currently serving `application/octet-stream` instead which makes Internet Explorer think the files are zip files.