### PR TITLE
Redirect to external host when asset is replaced

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -88,7 +88,16 @@ protected
   end
 
   def redirect_to_replacement_for(asset)
-    redirect_to asset.replacement.public_url_path, status: :moved_permanently
+    # explicitly use the external asset host
+    target_host =
+      if asset.replacement.draft?
+        AssetManager.govuk.draft_assets_host
+      else
+        AssetManager.govuk.assets_host
+      end
+
+    redirect_to "//#{target_host}/#{asset.replacement.public_url_path}",
+      status: :moved_permanently
   end
 
   def add_link_header(asset)

--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -12,6 +12,11 @@ class GovukConfiguration
     nil
   end
 
+  def assets_host
+    assets_base_uri = @plek.external_url_for('assets')
+    URI.parse(assets_base_uri).host
+  end
+
   def draft_assets_host
     draft_assets_base_uri = @plek.external_url_for('draft-assets')
     URI.parse(draft_assets_base_uri).host

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -460,7 +460,8 @@ RSpec.describe MediaController, type: :controller do
       it 'redirects to replacement for asset' do
         get :download, params
 
-        expect(response).to redirect_to(replacement.public_url_path)
+        expected_url = "//#{AssetManager.govuk.assets_host}/#{replacement.public_url_path}"
+        expect(response).to redirect_to(expected_url)
       end
 
       it 'responds with 301 moved permanently status' do
@@ -494,7 +495,8 @@ RSpec.describe MediaController, type: :controller do
 
           get :download, params
 
-          expect(response).to redirect_to(replacement.public_url_path)
+          expected_url = "//#{AssetManager.govuk.draft_assets_host}/#{replacement.public_url_path}"
+          expect(response).to redirect_to expected_url
         end
       end
     end

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -136,7 +136,8 @@ RSpec.describe WhitehallMediaController, type: :controller do
       it 'redirects to replacement for asset' do
         get :download, params: { path: path, format: format }
 
-        expect(response).to redirect_to(replacement.public_url_path)
+        expected_url = "//#{AssetManager.govuk.assets_host}/#{replacement.public_url_path}"
+        expect(response).to redirect_to(expected_url)
       end
 
       it 'responds with 301 moved permanently status' do
@@ -170,7 +171,8 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           get :download, params: { path: path, format: format }
 
-          expect(response).to redirect_to(replacement.public_url_path)
+          expected_url = "//#{AssetManager.govuk.draft_assets_host}/#{replacement.public_url_path}"
+          expect(response).to redirect_to(expected_url)
         end
       end
     end


### PR DESCRIPTION
When an asset is replaced, explicitly use the external host when
redirecting.  Otherwise Rails uses the request host, which may be some
weird internal thing which won't work.