### PR TITLE
Asset public URL paths start with a '/'

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -96,7 +96,7 @@ protected
         AssetManager.govuk.assets_host
       end
 
-    redirect_to "//#{target_host}/#{asset.replacement.public_url_path}",
+    redirect_to "//#{target_host}#{asset.replacement.public_url_path}",
       status: :moved_permanently
   end
 

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe MediaController, type: :controller do
       it 'redirects to replacement for asset' do
         get :download, params
 
-        expected_url = "//#{AssetManager.govuk.assets_host}/#{replacement.public_url_path}"
+        expected_url = "//#{AssetManager.govuk.assets_host}#{replacement.public_url_path}"
         expect(response).to redirect_to(expected_url)
       end
 
@@ -495,7 +495,7 @@ RSpec.describe MediaController, type: :controller do
 
           get :download, params
 
-          expected_url = "//#{AssetManager.govuk.draft_assets_host}/#{replacement.public_url_path}"
+          expected_url = "//#{AssetManager.govuk.draft_assets_host}#{replacement.public_url_path}"
           expect(response).to redirect_to expected_url
         end
       end

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
       it 'redirects to replacement for asset' do
         get :download, params: { path: path, format: format }
 
-        expected_url = "//#{AssetManager.govuk.assets_host}/#{replacement.public_url_path}"
+        expected_url = "//#{AssetManager.govuk.assets_host}#{replacement.public_url_path}"
         expect(response).to redirect_to(expected_url)
       end
 
@@ -171,7 +171,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           get :download, params: { path: path, format: format }
 
-          expected_url = "//#{AssetManager.govuk.draft_assets_host}/#{replacement.public_url_path}"
+          expected_url = "//#{AssetManager.govuk.draft_assets_host}#{replacement.public_url_path}"
           expect(response).to redirect_to(expected_url)
         end
       end


### PR DESCRIPTION
Adding another one results in redirects to '$host//$path', which falls
through to the s3 bucket.