### PR TITLE
Create a database user seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+
+User.create!(
+  name: "Test user",
+  permissions: %w[signin],
+  organisation_content_id: gds_organisation_id,
+) unless User.where(name: "Test user").exists?


### PR DESCRIPTION
This will be used in the e2e tests combined with GDS SSO mock mode to enable authenticated access to the API without needing to pass in a bearer token.

This is based off the one in email-alert-api: https://github.com/alphagov/email-alert-api/blob/master/db/seeds.rb

Once this is merged, it should enable https://github.com/alphagov/travel-advice-publisher/pull/602 to pass correctly.