### PR TITLE
Preserve draft redirect query

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -84,7 +84,9 @@ protected
   end
 
   def redirect_to_draft_assets_host
-    redirect_to host: AssetManager.govuk.draft_assets_host, format: params[:format]
+    redirect_to host: AssetManager.govuk.draft_assets_host,
+                format: params[:format],
+                params: request.query_parameters
   end
 
   def redirect_to_replacement_for(asset)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :whitehall_assets, only: %i(create)
   get '/whitehall_assets/*path' => 'whitehall_assets#show'
 
-  get "/media/:id/:filename" => "media#download", :constraints => { filename: /.*/ }
+  get "/media/:id/:filename" => "media#download", :constraints => { filename: /.*/ }, as: :download_media
   get "/government/uploads/*path" => "whitehall_media#download"
 
   if AssetManager.s3.fake?

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe MediaController, type: :controller do
         it "redirects to the new file name" do
           get :download, params: { id: asset, filename: old_file_name }
 
-          expect(response.location).to match(%r(\A/media/#{asset.id}/asset.png))
+          expect(response.location).to match(download_media_path(id: asset, filename: "asset.png"))
         end
       end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Asset, type: :model do
+  include Rails.application.routes.url_helpers
+
   describe 'validation' do
     subject(:asset) { FactoryBot.build(:asset, attributes) }
 
@@ -315,10 +317,12 @@ RSpec.describe Asset, type: :model do
   end
 
   describe '#public_url_path' do
-    subject(:asset) { Asset.new }
+    subject(:asset) {
+      Asset.new(file: load_fixture_file("asset.png"))
+    }
 
     it 'returns public URL path for mainstream asset' do
-      expected_path = "/media/#{asset.id}/#{asset.filename}"
+      expected_path = download_media_path(id: asset.id, filename: asset.filename)
       expect(asset.public_url_path).to eq(expected_path)
     end
   end

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Access limited assets", type: :request do
   it 'are accessible to users who are authorised to view them' do
     login_as user_1
 
-    get "/media/#{asset.id}/#{asset.filename}"
+    get download_media_path(id: asset, filename: asset.filename)
 
     expect(response).to be_successful
   end
@@ -20,7 +20,7 @@ RSpec.describe "Access limited assets", type: :request do
   it 'are not accessible to users who are not authorised to view them' do
     login_as user_2
 
-    get "/media/#{asset.id}/#{asset.filename}"
+    get download_media_path(id: asset, filename: asset.filename)
 
     expect(response).to be_forbidden
   end

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -47,6 +47,33 @@ RSpec.describe "Media requests", type: :request do
     end
   end
 
+  describe "requesting a draft asset from live" do
+    around do |example|
+      ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }
+    end
+
+    let(:asset) do
+      FactoryBot.create(:uploaded_asset, draft: true)
+    end
+
+    it "redirects to the draft host" do
+      get download_media_path(id: asset, filename: "asset.png")
+
+      expect(response).to redirect_to(download_media_url(host: AssetManager.govuk.draft_assets_host,
+                                                         id: asset,
+                                                         filename: "asset.png"))
+    end
+
+    it "preserves any query params" do
+      get download_media_path(id: asset, filename: "asset.png", params: { foo: "bar" })
+
+      expect(response).to redirect_to(download_media_url(host: AssetManager.govuk.draft_assets_host,
+                                                         id: asset,
+                                                         filename: "asset.png",
+                                                         params: { foo: "bar" }))
+    end
+  end
+
   describe "requesting a draft asset while not logged in" do
     around do |example|
       ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Media requests", type: :request do
 
   describe "requesting an asset that doesn't exist" do
     it "responds with not found status" do
-      get "/media/34/test.jpg"
+      get download_media_path(id: 34, filename: "test.jpg")
       expect(response).to have_http_status(:not_found)
     end
   end
@@ -26,10 +26,10 @@ RSpec.describe "Media requests", type: :request do
       allow(cloud_storage).to receive(:presigned_url_for)
         .with(asset, http_method: http_method).and_return(presigned_url)
 
-      get "/media/#{asset.id}/asset.png", headers: {
+      get download_media_path(id: asset, filename: "asset.png", headers: {
         "HTTP_X_SENDFILE_TYPE" => "X-Accel-Redirect",
         "HTTP_X_ACCEL_MAPPING" => "#{Rails.root}/tmp/test_uploads/assets/=/raw/"
-      }
+      })
     end
 
     it "sets the X-Accel-Redirect header" do
@@ -87,14 +87,14 @@ RSpec.describe "Media requests", type: :request do
     end
 
     it "redirects to login without a valid token" do
-      get "/media/#{asset.id}/asset.png"
+      get download_media_path(id: asset, filename: "asset.png")
       expect(response).to redirect_to("/auth/gds")
     end
 
     it "serves the asset with a valid token" do
       secret = Rails.application.secrets.jwt_auth_secret
       valid_token = JWT.encode({ "sub" => auth_bypass_id }, secret, "HS256")
-      get "/media/#{asset.id}/asset.png", params: { token: valid_token }
+      get download_media_path(id: asset, filename: "asset.png", params: { token: valid_token })
       expect(response).to be_successful
     end
   end

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     asset_details = JSON.parse(response.body)
     expect(asset_details["id"]).to match(%r{http://www.example.com/assets/#{asset.id}})
 
-    get "/media/#{asset.id}/lorem.txt"
+    get download_media_path(id: asset, filename: "lorem.txt")
     expect(response).to have_http_status(:not_found)
 
     VirusScanWorker.drain
 
-    get "/media/#{asset.id}/lorem.txt"
+    get download_media_path(id: asset, filename: "lorem.txt")
     expect(response).to have_http_status(:not_found)
 
     SaveToCloudStorageWorker.drain
 
-    get "/media/#{asset.id}/lorem.txt"
+    get download_media_path(id: asset, filename: "lorem.txt")
     expect(response).to have_http_status(:success)
 
     redirect_url = headers['X-Accel-Redirect']
@@ -60,12 +60,12 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     asset_details = JSON.parse(response.body)
     expect(asset_details["id"]).to match(%r{http://www.example.com/assets/#{asset.id}})
 
-    get "/media/#{asset.id}/eicar.com"
+    get download_media_path(id: asset, filename: "eicar.com")
     expect(response).to have_http_status(:not_found)
 
     VirusScanWorker.drain
 
-    get "/media/#{asset.id}/eicar.com"
+    get download_media_path(id: asset, filename: "eicar.com")
     expect(response).to have_http_status(:not_found)
   end
 end


### PR DESCRIPTION
https://trello.com/c/xpS0zlU4/803-download-an-attachment-file-through-content-publisher

This ensures we preserve any query params when downloading draft asset, which supports anonymous preview of draft assets via Content Publisher.