### PR TITLE
Add a rake task to export mirrorable assets

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,20 @@
+require 'csv'
+
+namespace :export do
+  desc 'Export CSV of mirrorable (publicly visible, non-replaced, non-redirected) assets'
+  task :mirrorable do
+    params = {
+      deleted_at: nil,
+      replacement_id: nil,
+      redirect_url: nil,
+      :draft.in => [nil, false],
+    }
+
+    CSV.open('mirrorable.csv', 'wb') do |csv|
+      csv << %w[uuid public_url_path]
+      Asset.where(params).each do |asset|
+        csv << [asset.uuid, asset.public_url_path]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Something should be in the mirrors if:

- it's not been deleted
- it's not been replaced
- it's not been redirected
- it's not a draft