### PR TITLE
Remove request test for positive virus scan

### DIFF
--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -32,40 +32,4 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     get cloud_url
     expect(response).to have_http_status(:success)
   end
-
-  # Extension to UploadedFile to represent an uploaded virus
-  # without having to have a 'virus' committed into source control.
-  #
-  # This is using the EICAR test virus (details: http://www.eicar.org/86-0-Intended-use.html)
-  class UploadedVirus < Rack::Test::UploadedFile
-    def initialize
-      @content_type = "text/plain"
-      @original_filename = 'eicar.com'
-
-      @tempfile = Tempfile.new(@original_filename)
-      @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
-
-      @tempfile.write 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STAN'
-      @tempfile.write 'DARD-ANTIVIRUS-TEST-FILE!$H+H*'
-      @tempfile.rewind
-    end
-  end
-
-  specify "uploading an infected asset, and not seeing it available after virus scanning" do
-    post "/assets", params: { asset: { file: UploadedVirus.new } }
-    expect(response).to have_http_status(:created)
-
-    asset = Asset.last
-
-    asset_details = JSON.parse(response.body)
-    expect(asset_details["id"]).to match(%r{http://www.example.com/assets/#{asset.id}})
-
-    get download_media_path(id: asset, filename: "eicar.com")
-    expect(response).to have_http_status(:not_found)
-
-    VirusScanWorker.drain
-
-    get download_media_path(id: asset, filename: "eicar.com")
-    expect(response).to have_http_status(:not_found)
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/hwMoAOau/3-%F0%9F%90%B3-get-all-apps-working-on-docker

This test no longer runs successfully on GDS issued laptops as the ESET
software detects the contents as a virus and quarantines the file, which
is very hard to debug.

This test is also rather strange as it will still pass even if the file
is not identified as having a virus. This is because the endpoint will
return a 404 until a file has been uploaded to cloud storage.