### PR TITLE
Support access limits by user organisation id without migrations

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -44,6 +44,7 @@ private
                              :replacement_id,
                              :parent_document_url,
                              access_limited: [],
+                             access_limited_organisation_ids: [],
                              auth_bypass_ids: [])
   end
 

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -24,6 +24,10 @@ protected
         asset[:redirect_url] = nil
       end
 
+      if asset.has_key?(:access_limited_user_ids)
+        asset[:access_limited] = asset[:access_limited_user_ids]
+      end
+
       if asset.has_key?(:access_limited) && asset[:access_limited].empty?
         asset[:access_limited] = []
       end

--- a/app/controllers/base_assets_controller.rb
+++ b/app/controllers/base_assets_controller.rb
@@ -28,6 +28,10 @@ protected
         asset[:access_limited] = []
       end
 
+      if asset.has_key?(:access_limited_organisation_ids) && asset[:access_limited_organisation_ids].empty?
+        asset[:access_limited_organisation_ids] = []
+      end
+
       if asset.has_key?(:auth_bypass_ids) && asset[:auth_bypass_ids].empty?
         asset[:auth_bypass_ids] = []
       end

--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -18,7 +18,8 @@ private
                              :legacy_etag,
                              :legacy_last_modified,
                              :parent_document_url,
-                             access_limited: [])
+                             access_limited: [],
+                             access_limited_organisation_ids: [])
   end
 
   def existing_asset_with_this_legacy_url_path

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,6 +34,8 @@ class Asset
 
   field :access_limited, type: Array, default: []
 
+  field :access_limited_organisation_ids, type: Array, default: []
+
   field :auth_bypass_ids, type: Array, default: []
 
   field :parent_document_url, type: String
@@ -87,10 +89,9 @@ class Asset
   end
 
   def accessible_by?(user)
-    return true unless draft?
-    return true if access_limited.empty?
+    return true unless draft? && access_limited?
 
-    access_limited.include?(user.uid)
+    access_limited.include?(user.uid) || access_limited_organisation_ids.include?(user.organisation_content_id)
   end
 
   def valid_auth_bypass_token?(token)
@@ -185,6 +186,10 @@ class Asset
   end
 
 protected
+
+  def access_limited?
+    access_limited.any? || access_limited_organisation_ids.any?
+  end
 
   def store_metadata
     self.etag = etag_from_file

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it 'stores access_limited blank string as empty array on access_limited' do
+        attributes = valid_attributes.merge(access_limited: '')
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).access_limited).to eq([])
+      end
+
       it 'stores access_limited_organisation_ids on asset' do
         attributes = valid_attributes.merge(access_limited_organisation_ids: ['org-id'])
         post :create, params: { asset: attributes }

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).file.path).to match(/asset\.png$/)
       end
 
+      it 'stores access_limited_user_ids as access_limited on asset' do
+        attributes = valid_attributes.merge(access_limited_user_ids: ['user-id'])
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).access_limited).to eq(['user-id'])
+      end
+
       it 'stores access_limited on asset' do
         attributes = valid_attributes.merge(access_limited: ['user-id'])
         post :create, params: { asset: attributes }
@@ -34,6 +41,13 @@ RSpec.describe AssetsController, type: :controller do
 
       it 'stores access_limited blank string as empty array on access_limited' do
         attributes = valid_attributes.merge(access_limited: '')
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).access_limited).to eq([])
+      end
+
+      it 'stores access_limited_user_ids blank string as empty array on access_limited' do
+        attributes = valid_attributes.merge(access_limited_user_ids: '')
         post :create, params: { asset: attributes }
 
         expect(assigns(:asset).access_limited).to eq([])
@@ -216,7 +230,18 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
-      it 'resets access_limited to an empty array for an existing asset with an access_limited array' do
+      it 'resets access_limits for an existing asset with a blank acess_limited_user_ids param' do
+        asset.update_attributes!(access_limited: ['user-uid'])
+
+        # We have to use an empty string as that is what gds-api-adapters/rest-client
+        # will generate instead of an empty array
+        attributes = valid_attributes.merge(access_limited_user_ids: '')
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).access_limited).to eq([])
+      end
+
+      it 'resets access_limits for an existing asset with a blank acess_limited param' do
         asset.update_attributes!(access_limited: ['user-uid'])
 
         # We have to use an empty string as that is what gds-api-adapters/rest-client

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it 'stores access_limited_organisation_ids on asset' do
+        attributes = valid_attributes.merge(access_limited_organisation_ids: ['org-id'])
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).access_limited_organisation_ids).to eq(['org-id'])
+      end
+
       it 'stores auth_bypass_ids on asset' do
         attributes = valid_attributes.merge(auth_bypass_ids: %w[id1 id2])
         post :create, params: { asset: attributes }
@@ -211,6 +218,24 @@ RSpec.describe AssetsController, type: :controller do
         put :update, params: { id: asset.id, asset: attributes }
 
         expect(assigns(:asset).access_limited).to eq([])
+      end
+
+      it 'stores access_limited_organisation_ids on existing asset' do
+        attributes = valid_attributes.merge(access_limited_organisation_ids: ['org-id'])
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).access_limited_organisation_ids).to eq(['org-id'])
+      end
+
+      it 'resets access_limited_organisation_ids to an empty array for an existing asset with an access_limited_organisation_ids array' do
+        asset.update_attributes!(access_limited_organisation_ids: ['org-id'])
+
+        # We have to use an empty string as that is what gds-api-adapters/rest-client
+        # will generate instead of an empty array
+        attributes = valid_attributes.merge(access_limited_organisation_ids: '')
+        put :update, params: { id: asset.id, asset: attributes }
+
+        expect(assigns(:asset).access_limited_organisation_ids).to eq([])
       end
 
       it 'stores auth_bypass_ids on existing asset' do

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).access_limited).to eq(['user-id'])
       end
 
+      it "stores access_limited_organisation_ids on asset" do
+        post :create, params: { asset: attributes.merge(access_limited_organisation_ids: ['org-id']) }
+
+        expect(assigns(:asset).access_limited_organisation_ids).to eq(['org-id'])
+      end
+
       it "stores replacement on asset" do
         replacement = FactoryBot.create(:asset)
         replacement_id = replacement.id.to_s

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it 'returns true if the asset is draft but not access limited' do
-      asset = FactoryBot.build(:asset, draft: true, access_limited: [])
+      asset = FactoryBot.build(:asset, draft: true)
       expect(asset).to be_accessible_by(nil)
     end
 
@@ -230,6 +230,18 @@ RSpec.describe Asset, type: :model do
     it 'returns false if the asset is draft and access limited and the user is not authorised to view it' do
       user = FactoryBot.build(:user, uid: 'user-id')
       asset = FactoryBot.build(:asset, draft: true, access_limited: ['another-user-id'])
+      expect(asset).not_to be_accessible_by(user)
+    end
+
+    it 'returns true if the asset is draft and access limited and the users org is authorised to view it' do
+      user = FactoryBot.build(:user, uid: 'user-id', organisation_content_id: 'org-id')
+      asset = FactoryBot.build(:asset, draft: true, access_limited_organisation_ids: ['org-id'])
+      expect(asset).to be_accessible_by(user)
+    end
+
+    it 'returns false if the asset is draft and access limited and the users org is not authorised to view it' do
+      user = FactoryBot.build(:user, uid: 'user-id', organisation_content_id: 'org-id-A')
+      asset = FactoryBot.build(:asset, draft: true, access_limited_organisation_ids: ['org-id-B'])
       expect(asset).not_to be_accessible_by(user)
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -211,38 +211,48 @@ RSpec.describe Asset, type: :model do
   end
 
   describe '#accessible_by?' do
-    it 'returns true if the asset is not draft' do
-      asset = FactoryBot.build(:asset, draft: false)
-      expect(asset).to be_accessible_by(nil)
+    context 'asset is live' do
+      let(:asset) { FactoryBot.build(:asset, draft: false) }
+
+      it 'returns true' do
+        expect(asset).to be_accessible_by(nil)
+      end
     end
 
-    it 'returns true if the asset is draft but not access limited' do
-      asset = FactoryBot.build(:asset, draft: true)
-      expect(asset).to be_accessible_by(nil)
+    context 'asset is a draft thats access_limited' do
+      let(:asset) do
+        FactoryBot.build(
+          :asset, draft: true, access_limited: ['user-id'], access_limited_organisation_ids: ['org-id']
+        )
+      end
+
+      it "returns true if user's id is authorised to view it" do
+        user = FactoryBot.build(:user, uid: 'user-id')
+        expect(asset).to be_accessible_by(user)
+      end
+
+      it "returns false if user's id is not authorised to view it" do
+        user = FactoryBot.build(:user, uid: 'another-id')
+        expect(asset).not_to be_accessible_by(user)
+      end
+
+      it "returns true if the user's org is authorised to view it" do
+        user = FactoryBot.build(:user, uid: 'another-id', organisation_content_id: 'org-id')
+        expect(asset).to be_accessible_by(user)
+      end
+
+      it "returns false if the user's org is not authorised to view it" do
+        user = FactoryBot.build(:user, uid: 'another-id', organisation_content_id: 'another-org-id')
+        expect(asset).not_to be_accessible_by(user)
+      end
     end
 
-    it 'returns true if the asset is draft and access limited and the user is authorised to view it' do
-      user = FactoryBot.build(:user, uid: 'user-id')
-      asset = FactoryBot.build(:asset, draft: true, access_limited: ['user-id'])
-      expect(asset).to be_accessible_by(user)
-    end
+    context 'asset is a draft thats not access limited' do
+      let(:asset) { FactoryBot.build(:asset, draft: true) }
 
-    it 'returns false if the asset is draft and access limited and the user is not authorised to view it' do
-      user = FactoryBot.build(:user, uid: 'user-id')
-      asset = FactoryBot.build(:asset, draft: true, access_limited: ['another-user-id'])
-      expect(asset).not_to be_accessible_by(user)
-    end
-
-    it 'returns true if the asset is draft and access limited and the users org is authorised to view it' do
-      user = FactoryBot.build(:user, uid: 'user-id', organisation_content_id: 'org-id')
-      asset = FactoryBot.build(:asset, draft: true, access_limited_organisation_ids: ['org-id'])
-      expect(asset).to be_accessible_by(user)
-    end
-
-    it 'returns false if the asset is draft and access limited and the users org is not authorised to view it' do
-      user = FactoryBot.build(:user, uid: 'user-id', organisation_content_id: 'org-id-A')
-      asset = FactoryBot.build(:asset, draft: true, access_limited_organisation_ids: ['org-id-B'])
-      expect(asset).not_to be_accessible_by(user)
+      it 'returns true' do
+        expect(asset).to be_accessible_by(nil)
+      end
     end
   end
 

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Access limited assets", type: :request do
   let(:user_1) { FactoryBot.create(:user, uid: 'user-1-id') }
   let(:user_2) { FactoryBot.create(:user, uid: 'user-2-id') }
-  let(:asset) { FactoryBot.create(:uploaded_asset, draft: true, access_limited: ['user-1-id']) }
+  let(:user_3) { FactoryBot.create(:user, uid: 'user-3-id', organisation_content_id: 'org-a') }
+  let(:user_4) { FactoryBot.create(:user, uid: 'user-4-id', organisation_content_id: 'org-b') }
+  let(:asset) { FactoryBot.create(:uploaded_asset, draft: true, access_limited: ['user-1-id'], access_limited_organisation_ids: ['org-a']) }
 
   before do
     host! AssetManager.govuk.draft_assets_host
@@ -19,6 +21,22 @@ RSpec.describe "Access limited assets", type: :request do
 
   it 'are not accessible to users who are not authorised to view them' do
     login_as user_2
+
+    get download_media_path(id: asset, filename: asset.filename)
+
+    expect(response).to be_forbidden
+  end
+
+  it 'are accessible to users in organisations authorised to view them' do
+    login_as user_3
+
+    get download_media_path(id: asset, filename: asset.filename)
+
+    expect(response).to be_successful
+  end
+
+  it 'are not accessible to users in organisations not authorised to view them' do
+    login_as user_4
 
     get download_media_path(id: asset, filename: asset.filename)
 


### PR DESCRIPTION
Following #677 (which was reverted due to incorrect migrations), this PR aims to support access limiting by organisation id without modifying the existing data schema. 

This PR adds a new field called access_limited_organisation_ids to Asset model to store permitted user organisations.

This also introduces a new parameter `access_limited_user_ids` which maps to `access_limited`