### PR TITLE
Fix forbidden response when downloading assets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def error_403
+    error 403, "Forbidden. You don't have permission to access this resource."
+  end
+
   def error_404
     error 404, "not found"
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -10,7 +10,7 @@ class MediaController < ApplicationController
     end
 
     unless authorized_for_asset?(asset)
-      head :forbidden
+      error_403
       return
     end
 


### PR DESCRIPTION
Previously the Content Type header was still being set as the asset content type, which caused unexpected behaviour in browsers. Now we return a 403 message to the user and set the content type header to always be set to application/json to render the message.