### PR TITLE
Allow an auth bypass token to grant access to all draft assets

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -94,14 +94,8 @@ class Asset
     access_limited.include?(user.uid) || access_limited_organisation_ids.include?(user.organisation_content_id)
   end
 
-  def valid_auth_bypass_token?(token)
-    payload, = JWT.decode(token,
-                          Rails.application.secrets.jwt_auth_secret,
-                          true,
-                          algorithm: "HS256")
-    payload["sub"].present? && auth_bypass_ids.include?(payload["sub"])
-  rescue JWT::DecodeError
-    false
+  def valid_auth_bypass_token?(auth_bypass_id)
+    auth_bypass_ids.include?(auth_bypass_id)
   end
 
   def public_url_path

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -185,11 +185,11 @@ class Asset
     deleted_at.present?
   end
 
-protected
-
   def access_limited?
     access_limited.any? || access_limited_organisation_ids.any?
   end
+
+protected
 
   def store_metadata
     self.etag = etag_from_file

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -257,26 +257,16 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#valid_auth_bypass_token?" do
-    it "returns true when given a valid token which is in the auth_bypass_ids" do
+    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids" do
       asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
-      token = JWT.encode({ "sub" => "my-token" },
-                         Rails.application.secrets.jwt_auth_secret,
-                         "HS256")
-      expect(asset.valid_auth_bypass_token?(token)).to be true
+      auth_bypass_id = "my-token"
+      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be true
     end
 
-    it "returns false when given a valid token which is not in the auth_bypass_ids" do
+    it "returns false when given an auth_bypass_id which is not in the auth_bypass_ids" do
       asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
-      token = JWT.encode({ "sub" => "other-token" },
-                         Rails.application.secrets.jwt_auth_secret,
-                         "HS256")
-      expect(asset.valid_auth_bypass_token?(token)).to be false
-    end
-
-    it "returns false when given an invalid token" do
-      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
-      token = SecureRandom.bytes(32)
-      expect(asset.valid_auth_bypass_token?(token)).to be false
+      auth_bypass_id = "different-token"
+      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be false
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1116,4 +1116,22 @@ RSpec.describe Asset, type: :model do
       expect(asset.parent_document_url).to eql("parent-document-url")
     end
   end
+
+  describe "#access_limited?" do
+    let(:asset) { described_class.new }
+
+    it "is true if the access is limited to a user" do
+      asset.access_limited = %w[user-id]
+      expect(asset.access_limited?).to be true
+    end
+
+    it "is true if the access is limited to an organisation" do
+      asset.access_limited_organisation_ids = %w[organisation-id]
+      expect(asset.access_limited?).to be true
+    end
+
+    it "is false if the access is not limited to neither users nor organisations" do
+      expect(asset.access_limited?).to be false
+    end
+  end
 end


### PR DESCRIPTION
## User story
**As a** burgeoning fact checker
**I want** to check content related to step by steps and see the assets
**So that** the pages don't look broken

## What
Opens up access to draft assets when the `draft_asset_manager_access` value is present in the JWT payload but will not grant access to draft assets that are marked as access limited to users or organisations.

## Why
Asset manager should be aware of a flag which was added in https://github.com/alphagov/collections-publisher/pull/815 that can be set in an auth_bypass_token that allows users access to draft assets.

This is a key part in allowing assets to be available as part of a multi-page fact check. This allows a user access to draft assets they normally wouldn’t have access to.

[Trello card](https://trello.com/c/DoD8SPbI/145-in-asset-manager-allow-an-auth-bypass-token-to-grant-access-to-all-draft-assets)

####  Co-authored by @brucebolt 