### PR TITLE
Replace govuk lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
 require: rubocop-rspec
+inherit_gem:
+  rubocop-govuk:
+    - "config/default.yml"
+
 inherit_from: .rubocop_todo.yml
 
 RSpec/NestedGroups:

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,28 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'addressable'
-gem 'aws-sdk', '~> 2.0'
-gem 'carrierwave', '~> 0.11.2'
-gem 'carrierwave-mongoid', '~> 0.10.0', require: 'carrierwave/mongoid'
-gem 'gds-sso', '~> 14.2'
-gem 'govuk_app_config', '~> 2.0'
-gem 'govuk_sidekiq', '~> 3.0'
-gem 'jwt', '~> 2.2'
-gem 'mongoid', '~> 6.2.0'
-gem 'nokogiri', '~> 1.10.5'
-gem 'plek', '~> 3.0'
-gem 'rack_strip_client_ip', '0.0.2'
-gem 'rails', '5.2.3'
-gem 'rails-controller-testing'
-gem 'state_machines-mongoid', '~> 0.2.0'
-gem 'unicorn', '5.5.1'
+gem "addressable"
+gem "aws-sdk", "~> 2.0"
+gem "carrierwave", "~> 0.11.2"
+gem "carrierwave-mongoid", "~> 0.10.0", require: "carrierwave/mongoid"
+gem "gds-sso", "~> 14.2"
+gem "govuk_app_config", "~> 2.0"
+gem "govuk_sidekiq", "~> 3.0"
+gem "jwt", "~> 2.2"
+gem "mongoid", "~> 6.2.0"
+gem "nokogiri", "~> 1.10.5"
+gem "plek", "~> 3.0"
+gem "rack_strip_client_ip", "0.0.2"
+gem "rails", "5.2.3"
+gem "rails-controller-testing"
+gem "state_machines-mongoid", "~> 0.2.0"
+gem "unicorn", "5.5.1"
 
 group :development, :test do
-  gem 'byebug'
-  gem 'climate_control'
-  gem 'database_cleaner'
-  gem 'factory_bot_rails'
-  gem 'govuk-lint'
-  gem 'rspec-rails'
-  gem 'simplecov-rcov'
+  gem "byebug"
+  gem "climate_control"
+  gem "database_cleaner"
+  gem "factory_bot_rails"
+  gem "govuk-lint"
+  gem "rspec-rails"
+  gem "simplecov-rcov"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem "climate_control"
   gem "database_cleaner"
   gem "factory_bot_rails"
-  gem "govuk-lint"
   gem "rspec-rails"
+  gem "rubocop-govuk"
   gem "simplecov-rcov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
       railties (>= 4.2.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.2)
     gds-api-adapters (57.4.2)
       addressable
       link_header
@@ -102,11 +101,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -225,9 +219,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (13.0.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -261,19 +252,16 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     rubocop-rspec (1.36.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.2.5)
@@ -341,7 +329,6 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails
   gds-sso (~> 14.2)
-  govuk-lint
   govuk_app_config (~> 2.0)
   govuk_sidekiq (~> 3.0)
   jwt (~> 2.2)
@@ -352,9 +339,10 @@ DEPENDENCIES
   rails (= 5.2.3)
   rails-controller-testing
   rspec-rails
+  rubocop-govuk
   simplecov-rcov
   state_machines-mongoid (~> 0.2.0)
   unicorn (= 5.5.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/create_asset
+++ b/bin/create_asset
@@ -2,6 +2,6 @@
 
 require File.expand_path("../config/environment", __dir__)
 
-require 'cli'
+require "cli"
 
 CLI.new.create_asset(*ARGV)

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils # rubocop:disable Style/MixinUsage
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../', __dir__)
+APP_ROOT = Pathname.new File.expand_path("../", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,9 +14,9 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
@@ -28,11 +28,11 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils # rubocop:disable Style/MixinUsage
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../', __dir__)
+APP_ROOT = Pathname.new File.expand_path("../", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,16 +14,16 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/update_asset
+++ b/bin/update_asset
@@ -2,6 +2,6 @@
 
 require File.expand_path("../config/environment", __dir__)
 
-require 'cli'
+require "cli"
 
 CLI.new.update_asset(*ARGV)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,7 @@
-desc "Run govuk-lint with similar params to CI"
-task "lint" do
-  sh "bundle exec govuk-lint-ruby --format clang app bin config Gemfile lib spec"
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new(:lint) do |t|
+  t.patterns = %w(app bin config Gemfile lib spec)
+  t.formatters = %w(clang)
+  t.options = %w(--parallel)
 end


### PR DESCRIPTION
The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
with a set of shared configs.

See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

This adds rake tasks to enable running rubocop.

This also fixes previous linting violations.