### PR TITLE
Add the option to use username and password with mongodb

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -16,5 +16,5 @@ production:
       options:
         read:
           mode: :primary
-        user: <%= ENV["MONGODB_USERNAME"] || null %>
-        password: <%= ENV["MONGODB_PASSWORD"] || null %>
+        user: <%= ENV["MONGODB_USERNAME"] || "" %>
+        password: <%= ENV["MONGODB_PASSWORD"] || "" %>

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -16,3 +16,5 @@ production:
       options:
         read:
           mode: :primary
+        user: <%= ENV["MONGODB_USERNAME"] || null %>
+        password: <%= ENV["MONGODB_PASSWORD"] || null %>


### PR DESCRIPTION
There is a desire to move from mongodb from AWS documentdb but
documentdb requires compulsory authentication.

This PR attempts to modify config of the mongoid to read
the username and password from the environment.
If the environment variables are not set, we use null
to hopefully login as before to the non-authenticated
mongodb.