### PR TITLE
Fix deployment error due to missing rubocop

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,7 +1,9 @@
-require "rubocop/rake_task"
+unless Rails.env.production?
+  require "rubocop/rake_task"
 
-RuboCop::RakeTask.new(:lint) do |t|
-  t.patterns = %w(app bin config Gemfile lib spec)
-  t.formatters = %w(clang)
-  t.options = %w(--parallel)
+  RuboCop::RakeTask.new(:lint) do |t|
+    t.patterns = %w(app bin config Gemfile lib spec)
+    t.formatters = %w(clang)
+    t.options = %w(--parallel)
+  end
 end


### PR DESCRIPTION
rubocop-govuk is only a dev dependency, so this task causes an error when run in production mode:

    15:32:26 *** [err :: backend-2.backend.staging.publishing.service.gov.uk] rake aborted!
    15:32:26 *** [err :: backend-2.backend.staging.publishing.service.gov.uk] LoadError: cannot load such file -- rubocop/rake_task