### PR TITLE
Reduce caching period for assets to 30 minutes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ private
 
   def set_default_expiry
     unless Rails.env.development?
-      expires_in 24.hours, public: true
+      expires_in 30.minutes, public: true
     end
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -187,10 +187,10 @@ RSpec.describe MediaController, type: :controller do
         get :download, params
       end
 
-      it "sets Cache-Control header to expire in 24 hours and be publicly cacheable" do
+      it "sets Cache-Control header to expire in 30 minutes and be publicly cacheable" do
         get :download, params
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
       end
 
       context "when the file name in the URL represents an old version" do
@@ -510,10 +510,10 @@ RSpec.describe MediaController, type: :controller do
         expect(response).to have_http_status(:moved_permanently)
       end
 
-      it "sets the Cache-Control response header to 24 hours" do
+      it "sets the Cache-Control response header to 30 minutes" do
         get :download, params
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
       end
 
       context "and the replacement is draft" do

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -146,10 +146,10 @@ RSpec.describe WhitehallMediaController, type: :controller do
         expect(response).to have_http_status(:moved_permanently)
       end
 
-      it "sets the Cache-Control response header to 24 hours" do
+      it "sets the Cache-Control response header to 30 minutes" do
         get :download, params: { path: path, format: format }
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
       end
 
       context "and the replacement is draft" do

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe "Whitehall media requests", type: :request do
       expect(response.headers["Content-Disposition"]).to eq('inline; filename="asset.png"')
     end
 
-    it "sets the Cache-Control response header to 24 hours" do
-      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public")
+    it "sets the Cache-Control response header to 30 minutes" do
+      expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
     end
 
     it "sets the X-Frame-Options response header to DENY" do


### PR DESCRIPTION
We recently had an issue where an asset was correctly unpublished, but it took manual intervention to remove it from Fastly cache.  Reducing the period that an asset is cached to 30 minutes should mitigate this issue somewhat. 

The intention is to reduce this further, but we want to mitigate the risk of hammering asset-manager too much until we've had sufficient time to test this properly.