### PR TITLE
Remove explicit unicorn dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "rack_strip_client_ip", "0.0.2"
 gem "rails", "5.2.4.1"
 gem "rails-controller-testing"
 gem "state_machines-mongoid", "~> 0.2.0"
-gem "unicorn", "5.5.2"
 
 group :development, :test do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,6 @@ DEPENDENCIES
   rubocop-govuk
   simplecov-rcov
   state_machines-mongoid (~> 0.2.0)
-  unicorn (= 5.5.2)
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
We can instead get it from govuk_app_config.