### PR TITLE
Redirect draft asset to replacement if replacement is live

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -5,6 +5,12 @@ class MediaController < ApplicationController
   before_action :set_token_payload
 
   def download
+    if asset.replacement.present? && (!asset.replacement.draft? || requested_from_draft_assets_host?)
+      set_default_expiry
+      redirect_to_replacement_for(asset)
+      return
+    end
+
     if redirect_to_draft_assets_host_for?(asset)
       redirect_to_draft_assets_host
       return
@@ -27,12 +33,6 @@ class MediaController < ApplicationController
 
     if asset.redirect_url.present?
       redirect_to asset.redirect_url
-      return
-    end
-
-    if asset.replacement.present? && (!asset.replacement.draft? || requested_from_draft_assets_host?)
-      set_default_expiry
-      redirect_to_replacement_for(asset)
       return
     end
 

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -516,6 +516,20 @@ RSpec.describe MediaController, type: :controller do
         expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
       end
 
+      context "and the asset is draft and is requested from not the draft host" do
+        before do
+          request.headers["X-Forwarded-Host"] = "not-#{AssetManager.govuk.draft_assets_host}"
+          asset.update_attribute(:draft, true)
+        end
+
+        it "redirects if the replacement is live" do
+          get :download, params
+
+          expected_url = "//#{AssetManager.govuk.assets_host}#{replacement.public_url_path}"
+          expect(response).to redirect_to(expected_url)
+        end
+      end
+
       context "and the replacement is draft" do
         before do
           replacement.update_attribute(:draft, true)


### PR DESCRIPTION
We know that, somehow, there are links in the wild to draft assets
which have live replacements.  There doesn't seem much point in
sending people to signon in such cases.