### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,7 +1,9 @@
 directory = if Rails.env.test?
-              "#{Rails.root}/tmp/test_uploads"
+              Rails.root.join("tmp/test_uploads")
+            elsif ENV["GOVUK_APP_ROOT"]
+              "#{ENV['GOVUK_APP_ROOT']}/uploads"
             else
-              "#{ENV['GOVUK_APP_ROOT'] || Rails.root}/uploads"
+              Rails.root.join("uploads")
             end
 
 AssetManager.carrier_wave_store_base_dir = directory


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.