### PR TITLE
Fix transitive redirection breaking with draft assets

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -78,18 +78,24 @@ RSpec.describe Asset, type: :model do
     end
 
     context "when replacements are replaced" do
-      let(:first_replacement) { FactoryBot.create(:asset) }
-      let(:final_replacement) { FactoryBot.create(:asset) }
+      let(:first_replacement) { FactoryBot.create(:asset, draft: false) }
+      let(:second_replacement) { FactoryBot.create(:asset, draft: true) }
 
       before do
         asset.replacement = first_replacement
-        asset.save
-        first_replacement.replacement = final_replacement
-        first_replacement.save
+        asset.save!
+        first_replacement.replacement = second_replacement
+        first_replacement.save!
       end
 
-      it "updates the original asset" do
-        expect(asset.reload.replacement_id).to eq(final_replacement.id)
+      it "doesn't update the original asset if the second replacement is a draft" do
+        expect(asset.reload.replacement_id).to eq(first_replacement.id)
+      end
+
+      it "updates the original asset when the second replacement is published" do
+        second_replacement.draft = false
+        second_replacement.save!
+        expect(asset.reload.replacement_id).to eq(second_replacement.id)
       end
     end
 


### PR DESCRIPTION
Redirecting to replacements is done in media_controller.rb, as the
first thing in the download method:

    if asset.replacement.present? && (!asset.replacement.draft? || requested_from_draft_assets_host?)
      set_default_expiry
      redirect_to_replacement_for(asset)
      return
    end

In prose, redirection to a replacement happens if and only if these
two requirements are met:

1. The asset has a replacement.
2. The replacement is not a draft (or it is being accessed from the
   draft host).

So if a publisher creates a new draft of a document, and replaces some
assets, the live assets won't redirect until the document is published
and the assets become live.  So far so good.

The problem is to do with `asset.replacement`.  When an asset is
replaced, anything which has the original asset as its replacement is
updated to point to the new replacement.  This is done in asset.rb:

    def update_indirect_replacements
      return unless replacement.present?

      Asset.unscoped.where(replacement_id: self.id).each do |asset|
        asset.replacement = replacement
        asset.save
      end
    end

This behaviour was implemented 2 years ago (by me) in commit 93b225e
to prevent long chains of redirects.  Web browsers typically impose a
limit on the number of redirects they follow, so this feature is
needed.

So this is how the problem occurs:

1. Asset 1 is created and published
2. A new draft is created, which replaces Asset 1 with Asset 2.
   Asset 1 does not redirect because Asset 2 is a draft.
3. The draft is published.
   Asset 1 now redirects to Asset 2.
4. A new draft is created, which replaces Asset 2 with Asset 3.
   Asset 2 does not redirect because Asset 3 is a draft.
5. Asset Manager automatically updates Asset 1 to point directly to Asset 3.
   Asset 1 no longer redirects to Asset 2 because it has no connection to Asset 2.
   Asset 1 doesn't redirect to Asset 3 because Asset 3 is a draft.
   So Asset 1 is visible again!  Oh no!

The solution has 2 parts:

1. Make `update_indirect_replacements` only apply when the replacement
   is live.

2. Add another `after_save` handler to update the `replacement_id` of
   grandchild assets when an asset is published.

The new handler will kick off `update_indirect_replacements`, though
I'm not sure if that's strictly necessary any more.  Since the
transitive closure logic has been in place for two years now, any
asset replaced since then will have had any redirect chains collapsed
to one step already.  So `update_indirect_replacements` only does
something useful for assets which haven't been touched since then.

---

[Trello card](https://trello.com/c/dsIeWe0W/1904-5-plan-how-to-address-issues-with-asset-manager-drafts)