### PR TITLE
Fix HMRC .zip upload rake task

### DIFF
--- a/lib/tasks/govuk_assets.rake
+++ b/lib/tasks/govuk_assets.rake
@@ -23,7 +23,7 @@ namespace :govuk_assets do
     hmrc_url_base = "/government/uploads/uploaded/hmrc"
 
     Dir.glob(File.join(directory, "*.zip")).each do |file_path|
-      WhitehallAsset.create_or_replace(file_path, "#{hmrc_url_base}/#{file_path}")
+      WhitehallAsset.create_or_replace(file_path, "#{hmrc_url_base}/#{File.basename(file_path)}")
     end
   end
 


### PR DESCRIPTION
This was attempted in d2897ec463e3efdc3139a5c3d94257bc9a46ce31, but didn't
quite correct the bug introduced by the refactor in d2897ec463e3efdc3139a5c3d94257bc9a46ce31.
The original code was `create_or_replace_hmrc_asset(file_path, File.basename(file_path))`,
so I think this commit will fix it for good.