### PR TITLE
Provide better logs for "File can't be blank" errors

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1029,6 +1029,12 @@ RSpec.describe Asset, type: :model do
 
         expect(File.exist?(path)).to be_falsey
       end
+
+      it "removes the underlying directory" do
+        asset.upload_success!
+
+        expect(File.exist?(File.dirname(path))).to be_falsey
+      end
     end
 
     context "when asset is infected" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1035,6 +1035,18 @@ RSpec.describe Asset, type: :model do
 
         expect(File.exist?(File.dirname(path))).to be_falsey
       end
+
+      it "provides contextual detail to the Errno::ENOTEMPTY exception" do
+        FileUtils.cp(path, "#{File.dirname(path)}/some_other_file.csv")
+
+        expect(GovukError).to receive(:notify).with(Errno::ENOTEMPTY, extra: {
+          asset_id: asset.id,
+          filename: asset.filename,
+          other_files_in_dir: ["some_other_file.csv"],
+        })
+
+        asset.upload_success!
+      end
     end
 
     context "when asset is infected" do

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Virus scanning of uploaded images", type: :request, disable_clou
     get download_media_path(id: asset, filename: "lorem.txt")
     expect(response).to have_http_status(:not_found)
 
+    allow(Services.virus_scanner).to receive(:scan)
     VirusScanWorker.drain
 
     get download_media_path(id: asset, filename: "lorem.txt")


### PR DESCRIPTION
This PR:

* Fixes one broken test locally
* Adds a missing test for directory deletion
* Catches an edge case where the directory can't be deleted, and provides better logging information so we can figure out the root cause

Trello: https://trello.com/c/FDu35RHS/1977-5-investigate-whitehall-sending-blank-file-when-updating-assets