### PR TITLE
Remove file synchronously with FileUtils

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -85,7 +85,7 @@ class Asset
 
     after_transition to: :uploaded do |asset, _|
       asset.save!
-      asset.remove_file!
+      FileUtils.remove_file(asset.file.path)
       dir = File.dirname(asset.file.path)
       begin
         FileUtils.rmdir(dir)


### PR DESCRIPTION
Sometimes we were getting Errno::ENOTEMPTY calls in the `rmdir`
call on the following line, which we attribute to the 'remove_file!'
method being asynchronous.

Code added in 91f19998f1a804ab5839c77d3bd41466d91408e3 allowed us
to see what files exist in the directory after the exception was
raised, but this would return an empty array, suggesting that
whatever file existed to cause the error had since been removed in
the time between the exception being raised and the 'Dir' call.
I won't revert that commit yet in case it provides more useful
information in future errors.

In the current version of carrierwave utilised by Asset Manager,
(0.11.2), the `remove_file!` method deletes the file from disk but
doesn't remove the `file` property from the model, so we can
accomplish the same behaviour manually be removing the file
ourselves. This also leaves less 'magic' in the code; it's clearer
to see what's going on.

Trello: https://trello.com/c/FDu35RHS/1977-5-investigate-whitehall-sending-blank-file-when-updating-assets