### PR TITLE
Delete file and directory in one forced call

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -85,17 +85,7 @@ class Asset
 
     after_transition to: :uploaded do |asset, _|
       asset.save!
-      FileUtils.remove_file(asset.file.path)
-      dir = File.dirname(asset.file.path)
-      begin
-        FileUtils.rmdir(dir)
-      rescue Errno::ENOTEMPTY => e
-        GovukError.notify(e, extra: {
-          asset_id: asset.id,
-          filename: asset.filename,
-          other_files_in_dir: Dir["#{dir}/*"].map { |path| File.basename(path) },
-        })
-      end
+      FileUtils.rm_rf(File.dirname(asset.file.path))
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1035,18 +1035,6 @@ RSpec.describe Asset, type: :model do
 
         expect(File.exist?(File.dirname(path))).to be_falsey
       end
-
-      it "provides contextual detail to the Errno::ENOTEMPTY exception" do
-        FileUtils.cp(path, "#{File.dirname(path)}/some_other_file.csv")
-
-        expect(GovukError).to receive(:notify).with(Errno::ENOTEMPTY, extra: {
-          asset_id: asset.id,
-          filename: asset.filename,
-          other_files_in_dir: ["some_other_file.csv"],
-        })
-
-        asset.upload_success!
-      end
     end
 
     context "when asset is infected" do


### PR DESCRIPTION
Prior to this change, we had the equivalent of this:

```
filepath = asset.file.path
FileUtils.remove_file(filepath)
FileUtils.rmdir(File.dirname(filepath))
```

For some reason we [were getting `Errno::ENOTEMPTY` errors][sentry]
being thrown at the `rmdir` call, but despite [logging which
files were in the directory][pr773], it looked as though the
directory was empty.

It isn't clear why the error was being thrown...
1. Perhaps `remove_file` is async
2. Perhaps our `Dir` logging code wasn't doing what we expect
3. Perhaps CarrierWave still held a 'handle' on the file and it
   wasn't truly 'deleted' yet?
4. Perhaps there is a hidden file in the dir, beginning with '.'

Either way, there's no reason why we need to be deleting the file
and then its parent directory in this order. There's no risk of
collisions - take this example:

```
asset.file.path
=> "/govuk/asset-manager/tmp/test_uploads/assets/da/4b/5eda4ba656b7ba0001072792/asset.png"

File.dirname(asset.file.path)
=> "5eda4ba656b7ba0001072792"
```

It is impossible for any other file to have that hash name
as its parent directory, so it should be perfectly safe to
simply delete the directory right off the bat.
This should prevent the `ENOTEMPTY` error (as we're doing a
equivalent of a 'rm -f'). This should prevent assets from
getting in a confused state where the asset is no longer
'uploaded'.

Trello: https://trello.com/c/FDu35RHS/1977-5-investigate-whitehall-sending-blank-file-when-updating-assets

[pr773]: https://github.com/alphagov/asset-manager/pull/773
[sentry]: https://sentry.io/organizations/govuk/issues/1715248395/?environment=production&project=202208&query=is%3Aunresolved+%22Errno%3A%3AENOTEMPTY%22&statsPeriod=1h