### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      # Allow only direct updates for all dependencies (i.e. ignore subdependencies)
+      - dependency-type: direct
+      # Security updates
+      - dependency-name: brakeman
+      # Internal gems
+      - dependency-name: "gds*"
+      - dependency-name: "gov*"
+      - dependency-name: "*-govuk"
+      - dependency-name: plek
+      # Framework gems
+      - dependency-name: factory_bot
+      - dependency-name: rails
+      - dependency-name: rspec
+      - dependency-name: rspec-rails
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1033,7 +1033,7 @@ RSpec.describe Asset, type: :model do
       it "removes the underlying directory" do
         asset.upload_success!
 
-        expect(File.exist?(File.dirname(path))).to be_falsey
+        expect(File).not_to exist(File.dirname(path))
       end
     end
 


### PR DESCRIPTION
In accordance with [RFC 126], we're configuring Dependabot to only
raise Pull Requests for the following three categories:

1. Security updates
2. Internal libraries
3. Framework libraries

Things have moved on slighly since the RFC; we're now using
[GitHub native] configs rather than the legacy `.dependabot`
approach. The syntax is slightly different to the example config
provided in the RFC but most of it is easily transferable.

Security updates (1) [aren't handled by Dependabot config][security].
Rather, they are enabled or disabled per-repository or per-org
through the GitHub UI.

We've handled (2) and (3) in config, and have set it to only raise
PRs for direct updates, i.e. updates to subdependencies of the
named dependencies will not raise PRs.

Trello: https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair

[GitHub native]: https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
[security]: https://github.community/t/how-to-get-dependabot-to-trigger-for-security-updates-only/117257/5
[RFC 126]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-126-custom-configuration-for-dependabot.md