### PR TITLE
Make Dependabot config stricter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: ruby

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,27 @@ updates:
     schedule:
       interval: daily
     allow:
-      # Allow only direct updates for all dependencies (i.e. ignore subdependencies)
-      - dependency-type: direct
       # Security updates
       - dependency-name: brakeman
+        dependency-type: direct
       # Internal gems
       - dependency-name: "gds*"
+        dependency-type: direct
       - dependency-name: "gov*"
+        dependency-type: direct
       - dependency-name: "*-govuk"
+        dependency-type: direct
       - dependency-name: plek
+        dependency-type: direct
       # Framework gems
       - dependency-name: factory_bot
+        dependency-type: direct
       - dependency-name: rails
+        dependency-type: direct
       - dependency-name: rspec
+        dependency-type: direct
       - dependency-name: rspec-rails
+        dependency-type: direct
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
A follow-on from #786 that fixes:

1. a misconfiguration issue whereby non-named dependencies are still having PRs raised (see #788, #790 and #791)
1. suppresses 'ruby' upgrade PRs, as we have to manually do this in a very specific way. (see #787)

https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair