### PR TITLE
Use seconds for expires_in rather than minutes

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -39,7 +39,7 @@ class S3Storage
   end
 
   def presigned_url_for(asset, http_method: "GET")
-    object_for(asset).presigned_url(http_method, expires_in: 1.minute)
+    object_for(asset).presigned_url(http_method, expires_in: 60.seconds)
   end
 
   def exists?(asset)


### PR DESCRIPTION
Received this error when deploying to production
`{"exception_class":"ArgumentError","exception_message":"expected :expires_in to be a number of seconds","stacktrace":["lib/s3_storage.rb:42:in `presigned_url_for'","app/controllers/media_controller.rb:95:in `proxy_to_s3_via_nginx'","app/controllers/media_controller.rb:51:in `download'"]}`

The aws-sdk gem was updated in the Rails upgrade, so assume it has something to do with that