### PR TITLE
Remove gds_sso initializer file as it only contains default settings

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,7 +1,0 @@
-GDS::SSO.config do |config|
-  config.user_model   = "User"
-  config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndassetmanager"
-  config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.new.external_url_for("signon")
-  config.cache = Rails.cache
-end


### PR DESCRIPTION
This file is no longer required as the latest release of the gds-sso gem sets these defaults itself ref: https://github.com/alphagov/gds-sso/pull/241