### PR TITLE
Permit publishing applications to specify a content type

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -36,6 +36,7 @@ private
       :redirect_url,
       :replacement_id,
       :parent_document_url,
+      :content_type,
       access_limited: [],
       access_limited_organisation_ids: [],
       auth_bypass_ids: [],

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -32,6 +32,8 @@ class Asset
   field :size, type: Integer
   protected :size=
 
+  field :content_type, type: String
+
   field :access_limited, type: Array, default: []
 
   field :access_limited_organisation_ids, type: Array, default: []
@@ -127,7 +129,7 @@ class Asset
     File.extname(filename).downcase.delete(".")
   end
 
-  def content_type
+  def content_type_from_extension
     mime_type = Mime::Type.lookup_by_extension(extension)
     mime_type ? mime_type.to_s : AssetManager.default_content_type
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -5,6 +5,15 @@ class Asset
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  # based on https://tools.ietf.org/html/rfc6838#section-4.2
+  CONTENT_TYPE_FORMAT = %r{
+    \A
+    \w[\w!#&\-^_.+]+ # type
+    / # separating slash
+    \w[\w!#&\-^_.+]+ # subtype
+    \Z
+  }x.freeze
+
   index deleted_at: 1
 
   belongs_to :replacement, class_name: "Asset", optional: true, index: true
@@ -52,6 +61,13 @@ class Asset
             format: {
               with: /[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}/,
               message: "must match the format defined in rfc4122",
+            }
+
+  validates :content_type,
+            format: {
+              with: CONTENT_TYPE_FORMAT,
+              message: "must match the format defined in rfc6838",
+              allow_nil: true,
             }
 
   validate :check_specified_replacement_exists

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -11,7 +11,7 @@ class AssetPresenter
       },
       id: @view_context.asset_url(@asset.id),
       name: @asset.filename,
-      content_type: @asset.content_type,
+      content_type: @asset.content_type || @asset.content_type_from_extension,
       size: @asset.size,
       file_url: URI.join(Plek.new.asset_root, Addressable::URI.encode(@asset.public_url_path)).to_s,
       state: @asset.state,

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).parent_document_url).to eq("parent-document-url")
       end
 
+      it "stores a specified content type" do
+        attributes = valid_attributes.merge(content_type: "application/pdf")
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).content_type).to eq("application/pdf")
+      end
+
       it "responds with created status" do
         post :create, params: { asset: valid_attributes }
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -567,13 +567,13 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "content_type" do
+  describe "content_type_from_extension" do
     context "when asset file has extension" do
       context "and the extension is a recognised mime type" do
         let(:asset) { described_class.new(file: load_fixture_file("asset.png")) }
 
         it "returns content type based on asset file extension" do
-          expect(asset.content_type).to eq(Mime::Type.lookup("image/png").to_s)
+          expect(asset.content_type_from_extension).to eq(Mime::Type.lookup("image/png").to_s)
         end
       end
 
@@ -581,7 +581,7 @@ RSpec.describe Asset, type: :model do
         let(:asset) { described_class.new(file: Tempfile.new(["file", ".unknown-extension"])) }
 
         it "returns default content type" do
-          expect(asset.content_type).to eq("application/octet-stream")
+          expect(asset.content_type_from_extension).to eq("application/octet-stream")
         end
       end
     end
@@ -590,146 +590,146 @@ RSpec.describe Asset, type: :model do
       let(:asset) { described_class.new(file: load_fixture_file("asset-without-extension")) }
 
       it "returns default content type" do
-        expect(asset.content_type).to eq("application/octet-stream")
+        expect(asset.content_type_from_extension).to eq("application/octet-stream")
       end
     end
 
     it "handles .jpg file extensions" do
       file = Tempfile.new(["file", ".jpg"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("image/jpeg")
+      expect(asset.content_type_from_extension).to eq("image/jpeg")
     end
 
     it "handles .jpeg file extensions" do
       file = Tempfile.new(["file", ".jpeg"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("image/jpeg")
+      expect(asset.content_type_from_extension).to eq("image/jpeg")
     end
 
     it "handles .gif file extensions" do
       file = Tempfile.new(["file", ".gif"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("image/gif")
+      expect(asset.content_type_from_extension).to eq("image/gif")
     end
 
     it "handles .png file extensions" do
       file = Tempfile.new(["file", ".png"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("image/png")
+      expect(asset.content_type_from_extension).to eq("image/png")
     end
 
     it "handles .pdf file extensions" do
       file = Tempfile.new(["file", ".pdf"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/pdf")
+      expect(asset.content_type_from_extension).to eq("application/pdf")
     end
 
     it "handles .csv file extensions" do
       file = Tempfile.new(["file", ".csv"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("text/csv")
+      expect(asset.content_type_from_extension).to eq("text/csv")
     end
 
     it "handles .rtf file extensions" do
       file = Tempfile.new(["file", ".rtf"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("text/rtf")
+      expect(asset.content_type_from_extension).to eq("text/rtf")
     end
 
     it "handles .doc file extensions" do
       file = Tempfile.new(["file", ".doc"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/msword")
+      expect(asset.content_type_from_extension).to eq("application/msword")
     end
 
     it "handles .docx file extensions" do
       file = Tempfile.new(["file", ".docx"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+      expect(asset.content_type_from_extension).to eq("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
     end
 
     it "handles .xls file extensions" do
       file = Tempfile.new(["file", ".xls"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.ms-excel")
+      expect(asset.content_type_from_extension).to eq("application/vnd.ms-excel")
     end
 
     it "handles .xlsx file extensions" do
       file = Tempfile.new(["file", ".xlsx"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+      expect(asset.content_type_from_extension).to eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     end
 
     it "handles .odt file extensions" do
       file = Tempfile.new(["file", ".odt"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.oasis.opendocument.text")
+      expect(asset.content_type_from_extension).to eq("application/vnd.oasis.opendocument.text")
     end
 
     it "handles .ods file extensions" do
       file = Tempfile.new(["file", ".ods"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.oasis.opendocument.spreadsheet")
+      expect(asset.content_type_from_extension).to eq("application/vnd.oasis.opendocument.spreadsheet")
     end
 
     it "handles .svg file extensions" do
       file = Tempfile.new(["file", ".svg"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("image/svg+xml")
+      expect(asset.content_type_from_extension).to eq("image/svg+xml")
     end
 
     it "handles .dot file extensions" do
       file = Tempfile.new(["file", ".dot"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/msword")
+      expect(asset.content_type_from_extension).to eq("application/msword")
     end
 
     it "handles .ppt file extensions" do
       file = Tempfile.new(["file", ".ppt"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.ms-powerpoint")
+      expect(asset.content_type_from_extension).to eq("application/vnd.ms-powerpoint")
     end
 
     it "handles .pptx file extensions" do
       file = Tempfile.new(["file", ".pptx"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.openxmlformats-officedocument.presentationml.presentation")
+      expect(asset.content_type_from_extension).to eq("application/vnd.openxmlformats-officedocument.presentationml.presentation")
     end
 
     it "handles .rdf file extensions" do
       file = Tempfile.new(["file", ".rdf"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/rdf+xml")
+      expect(asset.content_type_from_extension).to eq("application/rdf+xml")
     end
 
     it "handles .xlsm file extensions" do
       file = Tempfile.new(["file", ".xlsm"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.ms-excel.sheet.macroEnabled.12")
+      expect(asset.content_type_from_extension).to eq("application/vnd.ms-excel.sheet.macroEnabled.12")
     end
 
     it "handles .xlt file extensions" do
       file = Tempfile.new(["file", ".xlt"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/vnd.ms-excel")
+      expect(asset.content_type_from_extension).to eq("application/vnd.ms-excel")
     end
 
     it "handles .txt file extensions and adds the charset parameter" do
       file = Tempfile.new(["file", ".txt"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("text/plain; charset=utf-8")
+      expect(asset.content_type_from_extension).to eq("text/plain; charset=utf-8")
     end
 
     it "handles .gml file extensions" do
       file = Tempfile.new(["file", ".gml"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/gml+xml")
+      expect(asset.content_type_from_extension).to eq("application/gml+xml")
     end
 
     it "handles .dxf file extensions" do
       file = Tempfile.new(["file", ".dxf"])
       asset = described_class.new(file: file)
-      expect(asset.content_type).to eq("application/dxf")
+      expect(asset.content_type_from_extension).to eq("application/dxf")
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -198,6 +198,42 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
+
+    context "when content_type is not specified" do
+      it "is valid" do
+        asset.content_type = nil
+        expect(asset).to be_valid
+      end
+    end
+
+    context "when content_type is specified" do
+      it "accepts valid media types" do
+        %w[
+          text/plain
+          application/atom+xml
+          application/EDI-X12
+          application/xml-dtd
+          application/zip
+          application/vnd.openxmlformats-officedocument.presentationml
+          video/quicktime
+          very#unusual/but&valid
+        ].each do |media_type|
+          asset.content_type = media_type
+          expect(asset).to be_valid
+        end
+      end
+
+      it "is rejects an invalid media type" do
+        %w[
+          */*
+          application/with$invalid%characters
+          text/with-parameter;parameter=123
+        ].each do |media_type|
+          asset.content_type = media_type
+          expect(asset).not_to be_valid
+        end
+      end
+    end
   end
 
   describe "creation" do

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe AssetPresenter do
       expect(json).to include(deleted: false)
     end
 
+    context "when the asset has a content type specified" do
+      let(:asset) { FactoryBot.build(:asset, content_type: "application/pdf") }
+
+      it "returns the content type set on the asset" do
+        expect(json).to include(content_type: "application/pdf")
+      end
+    end
+
     context "when the asset has been saved" do
       before do
         asset.save


### PR DESCRIPTION
Trello: https://trello.com/c/fHPHwU5H/980-look-into-content-publisher-xss-pdf-issue

This allows a publishing application to specify the content type of an
asset which overrides Asset Manager's default behaviour of using the
filename as a means to determine an asset's content type.

The problem this resolves is when a publishing application decides an
asset is of one type and then Asset Manager disagrees and serves the
file based on the extension - for example if someone (oddly) uploaded a
PDF with a ".html" extension. This issue could cause a confusing error
experience for users and could potentially lead to security issues
of spoofing types of documents.

In considering the application of this I did wonder whether Asset
Manager should just be changed to determine content type based off
reading the file rather than extension (potentially using the
marcel [1] gem) however I concluded that this would be quite a
substantial change with a tough migration.

I concluded that given publishing applications are already determining
content type manually, validating it and presenting this information
to the Publishing API [2] then they can ultimately be considered the
source of truth for this and it isn't ideal for Asset Manager to do the
same calculation, in case they differ.

This change does however leave some future questions (I'm sorry) about
what to do about content type detection in this repo, it may well be
applicable that one day we switch to automatic content type look up in
Asset Manager and allow publishers to override that.

[1]: https://github.com/basecamp/marcel
[2]: https://github.com/alphagov/content-publisher/blob/153de410e4bc377c4a9f5745fe3304cba626156c/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb#L11