### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ node ('mongodb-3.2') {
       govuk.setEnvar('TEST_COVERAGE', 'true')
       govuk.setEnvar('JWT_AUTH_SECRET', 'secret')
     },
-    sassLint: false,
     publishingE2ETests: true,
     brakeman: true,
     afterTest: {


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80