### PR TITLE
Fix missing content_type headers

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -96,7 +96,11 @@ protected
       headers["X-Accel-Redirect"] = "/cloud-storage-proxy/#{url}"
     end
 
-    head :ok, content_type: asset.content_type
+    head :ok, content_type: content_type(asset)
+  end
+
+  def content_type(asset)
+    asset.content_type || asset.content_type_from_extension
   end
 
   def redirect_to_draft_assets_host_for?(asset)


### PR DESCRIPTION
This applies a fix for handling the situation where an assets
content_type is nil. In these situations we should fallback to
determining the content type from the files extension.

When a content_type of nil is returned Rails will set this to text/html
and this will cause the response to be misrendered for other content
types.

I'm a bit concerned about the level of mocking in the integration test
for this makes this more of a unit test, however my quick attempts to
unpick this weren't fruitful.


Before:
![Screenshot 2021-01-21 at 15 33 15](https://user-images.githubusercontent.com/282717/105373460-a00d9e80-5bfe-11eb-8ab2-cd7dca378c2b.png)

After:
![Screenshot 2021-01-21 at 15 36 44](https://user-images.githubusercontent.com/282717/105373481-a3a12580-5bfe-11eb-9496-b4481a2d4f34.png)