### PR TITLE
Return not_modified headers from MediaController

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -91,12 +91,13 @@ protected
     headers["Last-Modified"] = asset.last_modified.httpdate
     headers["Content-Disposition"] = AssetManager.content_disposition.header_for(asset)
 
-    unless request.fresh?(response)
+    if request.fresh?(response)
+      head :not_modified
+    else
       url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
       headers["X-Accel-Redirect"] = "/cloud-storage-proxy/#{url}"
+      head :ok, content_type: content_type(asset)
     end
-
-    head :ok, content_type: content_type(asset)
   end
 
   def content_type(asset)


### PR DESCRIPTION
An aspect of this app I found rather head scratching is that it returns
a `head :ok` even when a response is fresh and a file isn't
sent. From an investigation I learnt that later in the Rack middleware
this 200 response is being converted into a 304 [1] implicitly. This causes
some confusion where the Rails log thinks it's returned a 200 whereas the
app has actually returned a 304.

For example this is the Nginx vs Rails log for the same request:

January 21st 2021, 20:59:02.440 200 GET /government/uploads/system/uploads/default_news_organisation_image_data/file/159/s300_HCA_sign.JPG HTTP/1.0 asset-manager
January 21st 2021, 20:59:02.000 304 GET /government/uploads/system/uploads/default_news_organisation_image_data/file/159/s300_HCA_sign.JPG HTTP/1.1 assets-origin-json.event.access

To try resolve the bafflement of future developers I decided to adapt
this to be explicit instead.

The resulting implementation isn't as nice as I hoped it could be. I
wanted to handle this outside of the `proxy_to_s3_via_nginx` method as
this is going beyond that method's name. However I was foiled by a rather
rigid testing approach that makes this private method a key part of the
tested API so I had to resign myself to extending it.

This also adds some shared examples to the tests to try make them less
verbose. The tests here seem a bit too thorough - they're just testing
Rails' own `fresh?` implementation, but it felt a rather inconsistent
action to start chopping away at them so I left them - sorry!

[1]: https://github.com/rack/rack/blob/a05f8d56f9ac4da14dddb8f312a3b43644f73397/lib/rack/conditional_get.rb#L24-L42