### PR TITLE
Raise an error if a path is given for a redirect_url

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -15,7 +15,9 @@ namespace :assets do
   desc "Mark an asset as a redirect"
   task :redirect, %i[id redirect_url] => :environment do |_t, args|
     asset = Asset.find(args.fetch(:id))
-    asset.update!(redirect_url: args.fetch(:redirect_url), deleted_at: nil)
+    redirect_url = args.fetch(:redirect_url)
+    abort "redirect_url must start with https://" unless redirect_url.start_with? "https://"
+    asset.update!(redirect_url: redirect_url, deleted_at: nil)
   end
 
   desc "Mark a Whitehall asset as a redirect"


### PR DESCRIPTION
If we end up with a path for an asset's `redirect_url`, then Rails
fills in its hostname, and so redirects to `assets-origin....`, which
is only accessible on the VPN.

Rather than implement a work-around in the asset controller, instead
just require that a full URL be given.