### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN bundle config set without 'development test'
 RUN bundle install --jobs 4
 ADD . $APP_HOME
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck/ready || exit 1
 
 CMD foreman run web

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,4 @@ Rails.application.routes.draw do
   if AssetManager.s3.fake?
     mount Rack::File.new(AssetManager.fake_s3.root), at: AssetManager.fake_s3.path_prefix, as: "fake_s3"
   end
-
-  get "/healthcheck", to: GovukHealthcheck.rack_response(
-    GovukHealthcheck::Mongoid,
-    GovukHealthcheck::SidekiqRedis,
-  )
 end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
