### PR TITLE
Add standard header to protect .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,16 @@ inherit_mode:
   merge:
     - Exclude
 
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************
+
 # This isn't supported by Mongoid
 Rails/FindBy:
   Enabled: false


### PR DESCRIPTION
https://trello.com/c/Cr2TnMtI/193-make-it-easier-to-agree-with-rubocop-govuk

This follows the convention established in [1].

[1]: https://github.com/alphagov/content-publisher/pull/2411