### PR TITLE
Add auth bypass id to whitehall endpoint

### DIFF
--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -21,6 +21,7 @@ private
       :parent_document_url,
       access_limited: [],
       access_limited_organisation_ids: [],
+      auth_bypass_ids: [],
     )
   end
 

--- a/spec/controllers/whitehall_assets_controller_spec.rb
+++ b/spec/controllers/whitehall_assets_controller_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe WhitehallAssetsController, type: :controller do
         expect(assigns(:asset).replacement).to eq(replacement)
       end
 
+      it "stores auth_bypass_ids on asset" do
+        attributes_with_auth_bypass = attributes.merge(auth_bypass_ids: %w[id1 id2])
+        post :create, params: { asset: attributes_with_auth_bypass }
+
+        expect(assigns(:asset).auth_bypass_ids).to eq(%w[id1 id2])
+      end
+
       it "stores parent_document_url on asset" do
         post :create, params: { asset: attributes.merge(parent_document_url: "parent-document-url") }
 


### PR DESCRIPTION
Some foundational work to allow shareable previews for Whitehall to access assets - Whitehall has its own create endpoint, so this PR adds auth_bypass_id (a UUID that allows for non-sign-on access to an edition and its related content via a token) to the allowed parameters for Whitehall assets. This is identical to what is done for non-Whitehall assets.

This commit also introduces some tests for the WhitehallMediaController to ensure that an asset can be accessed with an access token containing an auth_bypass_id. This repeats some tests in the non-Whitehall media controller, and the behaviour is already defined for the WhitehallMediaController via inheritance, but I thought the tests were useful from a documentation standpoint. 