### PR TITLE
Don't rely on updated_at to determine whether asset is deleted

### DIFF
--- a/app/controllers/whitehall_assets_controller.rb
+++ b/app/controllers/whitehall_assets_controller.rb
@@ -30,8 +30,13 @@ private
   end
 
   def find_asset(include_deleted: false)
-    scope = include_deleted ? WhitehallAsset : WhitehallAsset.undeleted
-    scope.from_params(
+    WhitehallAsset.undeleted.from_params(
+      path: params[:path], format: params[:format],
+    )
+  rescue Mongoid::Errors::DocumentNotFound => e
+    raise e unless include_deleted
+
+    WhitehallAsset.deleted.order(deleted_at: :desc).from_params(
       path: params[:path], format: params[:format],
     )
   end


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

The Whitehall legacy_url_path is not a unique identifier for an asset
and there can be one that is current and multiple ones from the past
that are deleted.

The method to look up an asset relied on updated_at to determine which
asset is most-recent. As updated_at is an automatically changed
attribute this is risky as any misguided manipulations of models can
cause this to change and then mean that attempts to look up a current
item fail due to a deleted item taking precedence.

Looking into the database I found 260 assets with this problem (which is
a tiny percentage of the overall number of assets but enough to indicate
the logic assumption wasn't strong enough).

This issue can cause Asset Manager to tell Whitehall that an asset is
deleted when it is not and cause Whitehall to raise an exception because
it doesn't know what to do when an asset doesn't exist.