### PR TITLE
Bump govuk_app_config to 4.6 and install sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "nokogiri"
 gem "plek"
 gem "rack_strip_client_ip"
 gem "rails-controller-testing"
+gem "sentry-sidekiq"
 gem "sprockets-rails"
 gem "state_machines-mongoid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,12 +138,12 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk_app_config (4.5.0)
+    govuk_app_config (4.6.0)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
       puma (~> 5.6)
-      sentry-rails (~> 5.2)
-      sentry-ruby (~> 5.2)
+      sentry-rails (~> 5.3)
+      sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
     govuk_sidekiq (5.0.0)
@@ -172,7 +172,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -216,7 +216,7 @@ GEM
       timeout
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.4)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     null_logger (0.0.1)
@@ -346,14 +346,17 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
-    sentry-rails (5.2.1)
+    sentry-rails (5.3.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.2.1)
-    sentry-ruby (5.2.1)
+      sentry-ruby-core (~> 5.3.0)
+    sentry-ruby (5.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.2.1)
-    sentry-ruby-core (5.2.1)
+      sentry-ruby-core (= 5.3.0)
+    sentry-ruby-core (5.3.0)
       concurrent-ruby
+    sentry-sidekiq (5.3.0)
+      sentry-ruby-core (~> 5.3.0)
+      sidekiq (>= 3.0)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -432,6 +435,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   rubocop-govuk
+  sentry-sidekiq
   simplecov
   sprockets-rails
   state_machines-mongoid


### PR DESCRIPTION
In order to track sidekiq errors apps that use Sidekiq need to install
sentry-sidekiq, this installs it.

Without it a warning will occur on application initialisation and
Sidekiq errors won't be tracked by Sentry.