### PR TITLE
Adding softlink to /tmp filesystem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update -qy && \
 # TODO: remove Clamav from container and run it as a seperate container
     apt-get install -y clamav
 
+RUN mkdir /app && ln -fs /tmp /app
+
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan && \
     freshclam && \
     sed -i '/UpdateLogFile/d' /etc/clamav/freshclam.conf


### PR DESCRIPTION
This should allow writing to /app/tmp directory and fix the current permission denied errors
in EKS.

This is part of non-root container work:
https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot