### PR TITLE
Add healthcheck for connectivity with S3 bucket

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
+require "healthcheck/cloud_storage"
+
 Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::Mongoid,
     GovukHealthcheck::SidekiqRedis,
+    Healthcheck::CloudStorage,
   )
 
   resources :assets, only: %i[show create update destroy] do

--- a/lib/healthcheck/cloud_storage.rb
+++ b/lib/healthcheck/cloud_storage.rb
@@ -1,0 +1,13 @@
+require "services"
+
+module Healthcheck
+  class CloudStorage
+    def name
+      :cloud_storage
+    end
+
+    def status
+      Services.cloud_storage.healthy? ? GovukHealthcheck::OK : GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -62,6 +62,16 @@ class S3Storage
     raise ObjectNotFoundError, "S3 object not found for asset: #{asset.id}"
   end
 
+  def healthy?
+    response = client.head_bucket({ bucket: @bucket_name })
+    # We expect that not being able to connect to the bucket should raise an exception, but the following line
+    # guards against the possibility that it returns an unsuccessful response instead as there is some ambiguity in the
+    # documentation vs observed behaviour
+    response.successful?
+  rescue Aws::S3::Errors::ServiceError
+    false
+  end
+
 private
 
   def replication_status(asset)

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -53,5 +53,9 @@ class S3Storage
     def relative_path_for(asset)
       source_path_for(asset).relative_path_from(@source_root)
     end
+
+    def healthy?
+      true
+    end
   end
 end

--- a/spec/lib/healthcheck/cloud_storage_spec.rb
+++ b/spec/lib/healthcheck/cloud_storage_spec.rb
@@ -1,0 +1,25 @@
+require "healthcheck/cloud_storage"
+require "services"
+require "rails_helper"
+
+RSpec.describe Healthcheck::CloudStorage do
+  describe "#status" do
+    let(:storage) { instance_double("S3Storage") }
+
+    before do
+      allow(Services).to receive(:cloud_storage).and_return(storage)
+    end
+
+    it "returns OK when connected to the storage service" do
+      allow(storage).to receive(:healthy?).and_return(true)
+
+      expect(described_class.new.status).to eq GovukHealthcheck::OK
+    end
+
+    it "returns CRITICAL when the storage connection fails" do
+      allow(storage).to receive(:healthy?).and_return(false)
+
+      expect(described_class.new.status).to eq GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -315,4 +315,33 @@ RSpec.describe S3Storage do
       end
     end
   end
+
+  describe "#healthy?" do
+    let(:head_bucket_params) { { bucket: bucket_name } }
+
+    let(:response) { instance_double("Seahorse::Client::Response") }
+
+    it "returns true when s3 bucket is reachable" do
+      allow(response).to receive(:successful?).and_return(true)
+      allow(s3_client).to receive(:head_bucket)
+                            .with(head_bucket_params).and_return(response)
+
+      expect(storage.healthy?).to eq true
+    end
+
+    it "returns false when struct returns returns false to successful?" do
+      allow(response).to receive(:successful?).and_return(false)
+      allow(s3_client).to receive(:head_bucket)
+                            .with(head_bucket_params).and_return(response)
+
+      expect(storage.healthy?).to eq false
+    end
+
+    it "returns false when calling head_bucket returns an error" do
+      allow(s3_client).to receive(:head_bucket)
+                            .with(head_bucket_params).and_raise(Aws::S3::Errors::NotFound.new(nil, nil))
+
+      expect(storage.healthy?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a healthcheck that checks for connectivity with the s3 bucket, as part of work to improve checks before enabling continuous deployment for the app.

It uses the head_bucket method from the aws s3 api, which returns a successful response if the bucket requested exists and the requester has access to it. In the case where we get this successful response, we return a GovukHealthcheck::OK response.

We return a GovukHealthcheck::CRITICAL status in the following cases:

* an error is raised by the call to head_bucket
* head_bucket returns an unsuccessful response

This is because there is some ambiguity in the [documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#head_bucket-instance_method) vs observed behaviour, so we want to protect against both cases.

[Trello card](https://trello.com/c/Sj4UTatV/126-enable-continuous-deployment-for-asset-manager)