### PR TITLE
Rescue from `StateMachines::InvalidTransition`

### DIFF
--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -12,6 +12,8 @@ class VirusScanWorker
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!
+      rescue StateMachines::InvalidTransition
+        # If the asset has been amended whilst virus scanning takes place, the `scanned_clean` method will fail as it will be an invalid transition in state
       end
     end
   end


### PR DESCRIPTION
During virus scanning, it is possible that the asset has been amended. In this case, the asset's state will have changed from `unscanned` to something else.

This subsequent change of state by `scanned_clean` will not be permitted, as [the initial state on this transition must be `unscanned`](https://github.com/alphagov/asset-manager/blob/e56fac303c873bb81287f95f24cd1876b2fe1e16/app/models/asset.rb#L87-L90).

Rescuing from the exception will stop this being reported to Sentry, as the behaviour is expected.

The comment in the rescue block is required to appease rubocop.

[Sentry issue](https://sentry.io/organizations/govuk/issues/3276679916/?project=202208&referrer=slack).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
