### PR TITLE
Add a temporary task to update the legacy urls for topical event assets

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -25,4 +25,21 @@ namespace :assets do
     asset = WhitehallAsset.find_by!(legacy_url_path: args.fetch(:legacy_url_path))
     Rake::Task["assets:redirect"].invoke(asset.id, args.fetch(:redirect_url))
   end
+
+  desc "Update a Whitehall asset legacy url path for a topical event featuring image"
+  task update_topical_event_legacy_url_paths: :environment do |_t|
+    legacy_urls_to_update = WhitehallAsset.where("legacy_url_path": /\/government\/uploads\/system\/uploads\/classification_featuring_image_data/).pluck(:legacy_url_path)
+
+    total = legacy_urls_to_update.size
+    puts "updating #{legacy_urls_to_update.size} assets"
+    legacy_urls_to_update.each_with_index do |legacy_url, index|
+      if (index % 1000).zero?
+        puts "#{index}/#{total} completed"
+      end
+      new_url = legacy_url.gsub(/\/classification_featuring_image_data/, "/topical_event_featuring_image_data")
+      WhitehallAsset
+        .where(legacy_url_path: legacy_url)
+        .update_all({ "$set" => { legacy_url_path: new_url } })
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,8 @@ require "rspec/rails"
 # require only the support files necessary.
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
+Rails.application.load_tasks
+
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/tasks/assets_tasks_spec.rb
+++ b/spec/tasks/assets_tasks_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "asset tasks" do
+  describe "assets:update_topical_event_legacy_url_paths" do
+    let(:task) { Rake::Task["assets:update_topical_event_legacy_url_paths"] }
+
+    before { task.reenable }
+
+    def legacy_url(asset_name, model_name)
+      "/government/uploads/system/uploads/#{model_name}/file/1234/#{asset_name}.jpeg"
+    end
+
+    it "updates any assets with legacy urls matching /classification_featuring_image_data to /topical_event_image_data" do
+      classification_featuring_urls = (1..5).map { |i| legacy_url("asset-#{i}", "classification_featuring_image_data") }
+      non_matching_url = legacy_url("asset-10", "not_a_classification_featuring_image_data")
+      (classification_featuring_urls + [non_matching_url]).each { |url| FactoryBot.create(:whitehall_asset, legacy_url_path: url) }
+
+      expect { task.invoke }.to output.to_stdout
+
+      task.invoke
+
+      topical_event_featuring_assets = WhitehallAsset.where(legacy_url_path: /\/government\/uploads\/system\/uploads\/topical_event_featuring_image_data/)
+      expected_urls = (1..5).map { |i| legacy_url("asset-#{i}", "topical_event_featuring_image_data") }
+      expect(topical_event_featuring_assets.pluck(:legacy_url_path)).to eq expected_urls
+      expect(WhitehallAsset.where(legacy_url_path: /\/government\/uploads\/system\/uploads\/classification_featuring_image_data/).count).to eq 0
+    end
+
+    it "only changes the legacy url path of assets with urls including classification_featuring_image_data" do
+      asset_name = "asset-1"
+      asset = FactoryBot.create(:whitehall_asset, legacy_url_path: legacy_url(asset_name, "classification_featuring_image_data"), created_at: Time.zone.local(2022, 1, 1))
+
+      expect { task.invoke }.to output.to_stdout
+
+      task.invoke
+
+      asset_after_update = WhitehallAsset.where(legacy_url_path: legacy_url(asset_name, "topical_event_featuring_image_data")).first
+      ignored_keys = %w[legacy_url_path updated_at last_modified]
+      expect(asset.attributes.except(*ignored_keys)).to eq asset_after_update.attributes.except(*ignored_keys)
+    end
+  end
+end


### PR DESCRIPTION
The ClassificationFeaturingImageData model was renamed in Whitehall, and this is used on the fly to generate the asset url, meaning that when a topical event was republished, its asset urls pointed to the new location (/topical_event_featuring_image_data) rather than the legacy url those assets are currently found at (/classification_featuring_image_data). This temporary rake task fixes this issue by updating all the legacy url paths for classsification_featuing_image_data to be topical_event_image_data. 

A long term fix for this would be to store the image urls in Whitehall, so they are not dynamically generated each time. But this is an immediate fix these document types for now.

The fix flow should be - run this task, and then republish all topical events immediately.

https://trello.com/c/3q6al3ol/207-fix-issue-with-topical-event-featured-document-image-urls 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
