### PR TITLE
Don't virus scan when redirect url is present

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -242,7 +242,7 @@ protected
   end
 
   def schedule_virus_scan
-    VirusScanWorker.perform_async(id) if unscanned?
+    VirusScanWorker.perform_async(id) if unscanned? && redirect_url.blank?
   end
 
   def file_stat

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -456,6 +456,14 @@ RSpec.describe Asset, type: :model do
 
       a.save!
     end
+
+    it "does not schedule a scan if a redirect url is present" do
+      a = FactoryBot.create(:asset, redirect_url: "/some-redirect")
+
+      expect(VirusScanWorker).not_to receive(:perform_async)
+
+      a.save!
+    end
   end
 
   describe "when an asset is marked as clean" do


### PR DESCRIPTION
If we receive a request [1] to create an asset, and then very quickly after that receive a request [2] to redirect the asset (i.e. the asset is changed in a publishing app, resulting in a new asset being created and the existing asset redirecting to the new asset), we can receive a `StateMachine:InvalidTransition` error.

This is because a concurrency issue to do with what happens when an asset is saved. We have an after save callback which a) schedules a virus scan if the asset is unscanned, which b) marks the asset as clean when this virus scan is complete and passes.

When we receive a create [1] and redirect [2] in short succession, the following happens:

1) we receive request [1] and schedule a virus check since the asset is unscanned
2) we receive request [2] and schedule a virus check since the asset is still unscanned
3) we complete the check from request [1] and mark the asset as clean
4) we complete the check from request [2] and try to mark the asset as clean

However, the process in step 4 will raise an error, since we are trying to mark a clean asset as clean again.

This commit fixes the issue by not scheduling virus scan checks for assets with redirects.
This works because we should have already scanned these assets, but also because we do not need to upload these assets to the S3 bucket since we will only serve redirects for them.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/AwECBIdD/313-spike-into-fix-for-statemachinesinvalidtransition)
