### PR TITLE
Fix clamdscan in container image. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ FROM $base_image
 
 ENV GOVUK_APP_NAME=asset-manager
 # TODO: move ClamAV into a completely separate service.
-RUN apt update && \
-    apt install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         clamav clamav-daemon clamdscan shared-mime-info && \
     rm -fr /var/lib/apt/lists/*
 
@@ -30,4 +30,4 @@ RUN sed -Ei 's/\/var\/log\/clamav\/\w+\.log/\/dev\/stderr/; \
 RUN mkdir -p /var/run/clamav && chown app:app /var/run/clamav /var/lib/clamav
 
 USER app
-CMD bundle exec puma
+CMD ["bundle", "exec", "puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,35 +4,30 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 FROM $builder_image AS builder
 
 WORKDIR /app
-
 COPY Gemfile Gemfile.lock .ruby-version /app/
-
-RUN apt update && \
-    apt install shared-mime-info -y && \
-    bundle install
-
+RUN bundle install
 COPY . /app
-
-# TODO: investigate if this is needed.
-RUN rm -rf /app/tmp
 
 
 FROM $base_image
 
-ENV GOVUK_APP_NAME=asset-manager GOVUK_ASSET_ROOT=http://assets-origin.dev.gov.uk
-
+ENV GOVUK_APP_NAME=asset-manager
+# TODO: move ClamAV into a completely separate service.
 RUN apt update && \
-    apt install -y --no-install-recommends clamav clamav-daemon shared-mime-info && \
+    apt install -y --no-install-recommends \
+        clamav clamav-daemon clamdscan shared-mime-info && \
     rm -fr /var/lib/apt/lists/*
 
 WORKDIR /app
-
-RUN ln -fs /tmp /app/tmp && \
-    chown -R app:app /etc/clamav /var/lib/clamav
-
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
+RUN sed -Ei 's/\/var\/log\/clamav\/\w+\.log/\/dev\/stderr/; \
+             s/LogRotate true/LogRotate false/; \
+             s/LocalSocketGroup clamav/LocalSocketGroup app/; \
+             s/LogFileUnlock false/LogFileUnlock true/; \
+             s/TestDatabases yes/TestDatabases no/' \
+        /etc/clamav/*clam*.conf
+RUN mkdir -p /var/run/clamav && chown app:app /var/run/clamav /var/lib/clamav
 
 USER app
-
 CMD bundle exec puma


### PR DESCRIPTION
- Install clamdscan package, which was missing.
- Patch the config files for clamd and freshclam to fix logging and permissions.
- Avoid installing shared-mime-info package twice, as it doesn't seem to be needed in the build stage.
- Fix a couple of Dockerfile lints.

Really we want ClamAV to run as a separate service so that we can sandbox it more restrictively and run it with the absolute minimum of privileges, but we'll tackle that in another PR.

This change only affects Kubernetes/Docker and not EC2 (i.e. current production).

Tested: ran locally in Docker:

```
$ docker build -t asset-manager
...
$ docker run -it -v clam-sigs:/var/lib/clamav asset-manager bash

app@242503f4a4c4:~$ clamd &
...
app@242503f4a4c4:~$ clamdscan Gemfile
/app/Gemfile: OK
app@242503f4a4c4:~$ cat >eicar.txt
...EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
^D
app@242503f4a4c4:/tmp$ clamdscan eicar.txt 
Sat Nov  5 16:28:06 2022 -> /tmp/eicar.txt: Eicar-Signature(69630e4574ec6798239b091cda43dca0:69) FOUND
/tmp/eicar.txt: Eicar-Signature FOUND
```