### PR TITLE
Avoid writing to the image filesystem by default.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
+.dockerignore
 .git
 .gitignore
+Dockerfile
 Jenkinsfile
+Procfile
 README.md
-CONTRIBUTING.md
-LICENSE
-log/*
+coverage
+docs
+log
+spec
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY . /app
 FROM $base_image
 
 ENV GOVUK_APP_NAME=asset-manager
+ENV GOVUK_UPLOADS_ROOT=/tmp/uploads
 # TODO: move ClamAV into a completely separate service.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,5 +1,7 @@
 directory = if Rails.env.test?
               Rails.root.join("tmp/test_uploads")
+            elsif ENV["GOVUK_UPLOADS_ROOT"]
+              ENV["GOVUK_UPLOADS_ROOT"]
             elsif ENV["GOVUK_APP_ROOT"]
               "#{ENV['GOVUK_APP_ROOT']}/uploads"
             else


### PR DESCRIPTION
Essentially the same change as https://github.com/alphagov/whitehall/commit/3d13ac8.

This only affects running in Docker / Kubernetes. No change in EC2 / current production.

Also some minor cleanup in `.dockerignore` while we're there.

Tested: [deployed to integration](https://github.com/alphagov/asset-manager/actions/runs/3410602597) and was able to [create an asset](https://github.com/alphagov/asset-manager/blob/main/docs/api.md#create-an-asset).