### PR TITLE
Stop patching `/etc/clamav/*.conf` in the container build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,12 @@ ENV GOVUK_UPLOADS_ROOT=/tmp/uploads
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         clamav clamav-daemon clamdscan shared-mime-info && \
+    rm -fr /etc/clamav/* && \
     rm -fr /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
-RUN sed -Ei 's/\/var\/log\/clamav\/\w+\.log/\/dev\/stderr/; \
-             s/LogRotate true/LogRotate false/; \
-             s/LocalSocketGroup clamav/LocalSocketGroup app/; \
-             s/LogFileUnlock false/LogFileUnlock true/; \
-             s/TestDatabases yes/TestDatabases no/' \
-        /etc/clamav/*clam*.conf
 RUN mkdir -p /var/run/clamav && chown app:app /var/run/clamav /var/lib/clamav
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY . /app
 FROM $base_image
 
 ENV GOVUK_APP_NAME=asset-manager
-ENV GOVUK_UPLOADS_ROOT=/tmp/uploads
 # TODO: move ClamAV into a completely separate service.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Turns out it's not really worth doing this, since nobody would want to run with this config anyway. We replace the whole of `/etc/clamav` via a configmap when running in k8s, and that's part of the Helm chart so there's no real portability issue here.

Patching this config in the Dockerfile just adds a potential source of confusion.

Instead let's just remove the default configs for ClamAV, since those won't work properly in a container.

Partially reverts 575363a.

Also avoid setting `GOVUK_UPLOADS_ROOT`, as it makes more sense to do that in the Helm chart, where we're configuring the volumeMount that it uses.

https://trello.com/c/moEiT5BG