### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "jwt"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "~> 2.16.3"
 gem "mongoid"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,7 @@ DEPENDENCIES
   govuk_sidekiq
   jwt
   listen
+  mail (~> 2.7.1)
   mongo (~> 2.16.3)
   mongoid
   nokogiri


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
