### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ docs
 log
 spec
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 
 
 FROM $base_image
@@ -23,6 +24,7 @@ RUN install_packages clamav clamav-daemon clamdscan shared-mime-info && \
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,29 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version /app/
+WORKDIR $APP_HOME
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install
-COPY . /app
+COPY . .
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=asset-manager
-# TODO: move ClamAV into a completely separate service.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        clamav clamav-daemon clamdscan shared-mime-info && \
-    rm -fr /etc/clamav/* && \
-    rm -fr /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
-RUN mkdir -p /var/run/clamav && chown app:app /var/run/clamav /var/lib/clamav
+# TODO: move ClamAV into a completely separate service.
+RUN install_packages clamav clamav-daemon clamdscan shared-mime-info && \
+    rm -fr /etc/clamav/* && \
+    mkdir -p /var/run/clamav && \
+    chown app:app /var/run/clamav /var/lib/clamav
+
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "7.0.4"
 gem "addressable"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "bootsnap", require: false
 gem "carrierwave"
 gem "carrierwave-mongoid", require: "carrierwave/mongoid"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.4.0)
     bson (4.15.0)
     builder (3.2.4)
@@ -209,6 +211,7 @@ GEM
     mongoid-grid_fs (2.4.0)
       mime-types (>= 1.0, < 4.0)
       mongoid (>= 3.0, < 8.0)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
@@ -477,6 +480,7 @@ DEPENDENCIES
   addressable
   aws-sdk-core
   aws-sdk-s3
+  bootsnap
   brakeman
   byebug
   carrierwave

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Use `install_packages` from the base image to reduce apt-get boilerplate.
- Remove unnecessary use of `bundle exec`.
- Update .dockerignore.

Tested: app boots with `docker run`.