### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "jwt"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "~> 2.16.3"
 gem "mongoid"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       rexml
     crass (1.0.6)
     database_cleaner (1.99.0)
+    date (3.3.3)
     diff-lcs (1.5.0)
     dig_rb (1.0.1)
     docile (1.4.0)
@@ -191,8 +192,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.4.1)
@@ -213,11 +217,12 @@ GEM
       mongoid (>= 3.0, < 8.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -443,7 +448,7 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.2.1)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tins (1.32.1)
       sync
     tzinfo (2.0.5)
@@ -493,7 +498,6 @@ DEPENDENCIES
   govuk_sidekiq
   jwt
   listen
-  mail (~> 2.7.1)
   mongo (~> 2.16.3)
   mongoid
   nokogiri


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
