### PR TITLE
Bump version of govuk app config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    govuk_app_config (7.1.0)
+    govuk_app_config (7.2.0)
       logstasher (~> 2.1)
       plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)


### PR DESCRIPTION
This should stop us from getting noisy Puma errors logged to sentry

[Trello](https://trello.com/c/OLZZoNNI/597-handle-pumahttpparsererror-errors-in-sentry)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
