### PR TITLE
Pin Carrierwave gem at version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "addressable"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
 gem "bootsnap", require: false
-gem "carrierwave"
+gem "carrierwave", "< 3" # pin at v2 to avoid breaking changes
 gem "carrierwave-mongoid", require: "carrierwave/mongoid"
 gem "gds-sso"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,7 +687,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   byebug
-  carrierwave
+  carrierwave (< 3)
   carrierwave-mongoid
   climate_control
   database_cleaner


### PR DESCRIPTION
Bumping carrierwave to version 3.0 caused an error [1] in Sentry. It is not clear whether any of the breaking changes in v3 have caused this, nor how long it would take to debug and fix the incompatibilities.

The Whitehall asset management team have pinned carrierwave to v2, and they have on their roadmap to look at the future of using carrierwave in whitehall [2].

They've pointed out that whitehall's use of carrierwave is more complex than asset-manager's, so the issues may be unrelated, but I still think there's value in coordinating our versions.

[1] Details in the PR that reverted the bump https://github.com/alphagov/asset-manager/pull/1152
[2] https://github.com/alphagov/whitehall/pull/8007

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
