### PR TITLE
Fix static URL for assets (local dev env)

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -97,6 +97,9 @@ protected
 
     if request.fresh?(response)
       head :not_modified
+    elsif AssetManager.s3.fake?
+      url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
+      redirect_to url
     else
       url = Services.cloud_storage.presigned_url_for(asset, http_method: request.request_method)
       headers["X-Accel-Redirect"] = "/cloud-storage-proxy/#{url}"

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe S3Storage::Fake do
   end
 
   describe "#presigned_url_for" do
+    let(:s3) { S3Configuration.build }
+
     before do
+      allow(AssetManager).to receive(:s3).and_return(s3)
+      allow(s3).to receive(:fake?).and_return(false)
       storage.upload(asset)
     end
 

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe "Access limited assets", type: :request do
   let(:user_3) { FactoryBot.create(:user, uid: "user-3-id", organisation_content_id: "org-a") }
   let(:user_4) { FactoryBot.create(:user, uid: "user-4-id", organisation_content_id: "org-b") }
   let(:asset) { FactoryBot.create(:uploaded_asset, draft: true, access_limited: ["user-1-id"], access_limited_organisation_ids: %w[org-a]) }
+  let(:s3) { S3Configuration.build }
 
   before do
+    allow(AssetManager).to receive(:s3).and_return(s3)
+    allow(s3).to receive(:fake?).and_return(false)
     host! AssetManager.govuk.draft_assets_host
   end
 

--- a/spec/requests/access_limited_whitehall_assets_spec.rb
+++ b/spec/requests/access_limited_whitehall_assets_spec.rb
@@ -4,8 +4,11 @@ RSpec.describe "Access limited Whitehall assets", type: :request do
   let(:user_1) { FactoryBot.create(:user, uid: "user-1-id") }
   let(:user_2) { FactoryBot.create(:user, uid: "user-2-id") }
   let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, draft: true, access_limited: ["user-1-id"]) }
+  let(:s3) { S3Configuration.build }
 
   before do
+    allow(AssetManager).to receive(:s3).and_return(s3)
+    allow(s3).to receive(:fake?).and_return(false)
     host! AssetManager.govuk.draft_assets_host
   end
 

--- a/spec/requests/media_requests_spec.rb
+++ b/spec/requests/media_requests_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Media requests", type: :request do
+  let(:s3) { S3Configuration.build }
+
   before do
+    allow(AssetManager).to receive(:s3).and_return(s3)
+    allow(s3).to receive(:fake?).and_return(false)
     not_logged_in
     # create a user that can be used automatically with GDS SSO mock
     stub_user

--- a/spec/requests/whitehall_media_requests_spec.rb
+++ b/spec/requests/whitehall_media_requests_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe "Whitehall media requests", type: :request do
         state:,
       )
     end
+    let(:s3) { S3Configuration.build }
 
     before do
       allow(cloud_storage).to receive(:presigned_url_for)
                                 .with(asset, http_method:).and_return(presigned_url)
-
+      allow(AssetManager).to receive(:s3).and_return(s3)
+      allow(s3).to receive(:fake?).and_return(false)
       get path
     end
 
@@ -75,11 +77,13 @@ RSpec.describe "Whitehall media requests", type: :request do
   describe "request for an uploaded asset" do
     let(:path) { "/government/uploads/asset.png" }
     let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: path) }
+    let(:s3) { S3Configuration.build }
 
     before do
       allow(cloud_storage).to receive(:presigned_url_for)
                                 .with(asset, http_method:).and_return(presigned_url)
-
+      allow(AssetManager).to receive(:s3).and_return(s3)
+      allow(s3).to receive(:fake?).and_return(false)
       get path,
           headers: {
             "HTTP_X_SENDFILE_TYPE" => "X-Accel-Redirect",
@@ -142,6 +146,12 @@ RSpec.describe "Whitehall media requests", type: :request do
           legacy_url_path: path,
         )
       end
+      let(:s3) { S3Configuration.build }
+
+      before do
+        allow(AssetManager).to receive(:s3).and_return(s3)
+        allow(s3).to receive(:fake?).and_return(false)
+      end
 
       it "serves the asset without a valid token" do
         get path
@@ -186,6 +196,12 @@ RSpec.describe "Whitehall media requests", type: :request do
           auth_bypass_ids: [auth_bypass_id],
           access_limited: %w[some-other-user],
         )
+      end
+      let(:s3) { S3Configuration.build }
+
+      before do
+        allow(AssetManager).to receive(:s3).and_return(s3)
+        allow(s3).to receive(:fake?).and_return(false)
       end
 
       it "does not serve the asset without a valid token" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -37,6 +37,8 @@ Pact.provider_states_for "GDS API Adapters" do
     WebMock.reset!
     DatabaseCleaner.clean_with :truncation
     GDS::SSO.test_user = create(:user)
+    AssetManager.s3 = S3Configuration.build
+    allow(AssetManager.s3).to receive(:fake?).and_return(false)
   end
 
   tear_down do


### PR DESCRIPTION
In local development using govuk-docker, we want to be able to preview Assets in Whitehall - this means rather than relying on Nginx we need to use a redirect to serve assets. The cloud-storage-proxy does not work in local env because of using fake s3, which serves the assets from the local file system.

We have also had to change the virus scanning tests to match the new behaviour. 

This PR is dependant of https://github.com/alphagov/govuk-docker/pull/685. Please make sure to update govuk-docker.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
