### PR TITLE
Added pact provider state for `/media/{id}/{filename}`

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -55,6 +55,12 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "an asset exists with id 4dca570c2975bc0d6d437491 and filename asset.png" do
+    set_up do
+      FactoryBot.create(:uploaded_asset, id: "4dca570c2975bc0d6d437491")
+    end
+  end
+
   provider_state "a whitehall asset exists with legacy url path /government/uploads/some-edition/hello.txt and id 4dca570c2975bc0d6d437491" do
     set_up do
       FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: "/government/uploads/some-edition/hello.txt", id: "4dca570c2975bc0d6d437491")


### PR DESCRIPTION
This change is added so that the new pact test introduced inside `gds-api-adapter` for `/media/{id}/{filename}` is able to run correctly refer `https://github.com/alphagov/gds-api-adapters/pull/1211#issue-1892210198`

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
