### PR TITLE
Enable serving whitehall asset from media download endpoint

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -150,8 +150,7 @@ protected
 
   def asset_servable?
     asset.filename_valid?(params[:filename]) &&
-      asset.uploaded? &&
-      asset.mainstream?
+      asset.uploaded?
   end
 
   def asset

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -121,10 +121,6 @@ class Asset
     "/media/#{id}/#{filename}"
   end
 
-  def mainstream?
-    true
-  end
-
   def file=(file)
     old_filename = filename
     super(file).tap do

--- a/app/models/whitehall_asset.rb
+++ b/app/models/whitehall_asset.rb
@@ -44,8 +44,4 @@ class WhitehallAsset < Asset
   def public_url_path
     legacy_url_path
   end
-
-  def mainstream?
-    false
-  end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe MediaController, type: :controller do
         get :download, **params
       end
 
+      context "with a whitehall asset" do
+        let(:asset) { FactoryBot.create(:uploaded_whitehall_asset) }
+
+        it "proxies whitehall asset to S3 via Nginx" do
+          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
+
+          get :download, **params
+        end
+      end
+
       it "sets Cache-Control header to expire in 30 minutes and be publicly cacheable" do
         get :download, **params
 
@@ -513,16 +523,6 @@ RSpec.describe MediaController, type: :controller do
 
     context "with a valid clean file" do
       let(:asset) { FactoryBot.create(:clean_asset) }
-
-      it "responds with 404 Not Found" do
-        get :download, **params
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "with an otherwise servable whitehall asset" do
-      let(:path) { "/government/uploads/asset.png" }
-      let(:asset) { FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: path) }
 
       it "responds with 404 Not Found" do
         get :download, **params

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Asset, type: :model do
       described_class.new(file: load_fixture_file("asset.png"))
     end
 
-    it "returns public URL path for mainstream asset" do
+    it "returns public URL path for asset" do
       expected_path = download_media_path(id: asset.id, filename: asset.filename)
       expect(asset.public_url_path).to eq(expected_path)
     end
@@ -1032,14 +1032,6 @@ RSpec.describe Asset, type: :model do
 
     it "cannot be called from outside the Asset class" do
       expect { asset.md5_hexdigest = "md5-value" }.to raise_error(NoMethodError)
-    end
-  end
-
-  describe "#mainstream?" do
-    let(:asset) { described_class.new }
-
-    it "returns truth-y" do
-      expect(asset).to be_mainstream
     end
   end
 

--- a/spec/models/whitehall_asset_spec.rb
+++ b/spec/models/whitehall_asset_spec.rb
@@ -137,14 +137,6 @@ RSpec.describe WhitehallAsset, type: :model do
     end
   end
 
-  describe "#mainstream?" do
-    let(:asset) { described_class.new }
-
-    it "returns false-y" do
-      expect(asset).not_to be_mainstream
-    end
-  end
-
   describe ".from_params" do
     let(:format_from_params) { "png" }
     let(:path_from_params) { "government/uploads/path/to/asset" }


### PR DESCRIPTION
Previous behaviour separated whitehall assets from regular assets by implementing a boolean check (mainstream?) which was false for whitehall assets.

We are changing the behaviour of assets in whitehall, so that all assets (unless already published) will use the non-legacy download endpoint. 

The underlying reason is that whitehall is moving away from using `legacy_url_path` for identifying assets, therefore the media endpoints need to work for whitehall assets too. 

[Trello card here](https://trello.com/c/UC1jt0TH/179-assetmanager-should-be-able-to-serve-whitehallassets-from-asset-download-endpoints)

