### PR TITLE
Bump `sidekiq` from 6.5.5 to 6.5.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,10 +540,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.18.0)
-      connection_pool
+    redis (4.8.1)
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.8.1)
@@ -621,10 +618,10 @@ GEM
     sentry-sidekiq (5.13.0)
       sentry-ruby (~> 5.13.0)
       sidekiq (>= 3.0)
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
-      redis (>= 4.5.0)
+      redis (>= 4.5.0, < 5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -720,4 +717,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.24
+   2.4.10


### PR DESCRIPTION
Resolves https://github.com/alphagov/transition/security/dependabot/37.

This also downgrades `redis`, since support for Redis 5.x was removed from sidekiq in
https://github.com/sidekiq/sidekiq/commit/d566154107e6543ccb42e0d2e7eddfb529f0933e.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
