### PR TITLE
Add logging to help diagnose ongoing issue with virus scanning

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -85,6 +85,11 @@ class Asset
   scope :undeleted, -> { where(deleted_at: nil) }
 
   state_machine :state, initial: :unscanned do
+    around_transition do |asset, transition, block|
+      Rails.logger.info("#{asset.id} - Asset#state_machine - event: #{transition.event}")
+      block.call
+    end
+
     event :scanned_clean do
       transition unscanned: :clean
     end
@@ -104,6 +109,7 @@ class Asset
     after_transition to: :uploaded do |asset, _|
       asset.save!
       FileUtils.rm_rf(File.dirname(asset.file.path))
+      Rails.logger.info("#{asset.id} - Asset#state_machine - File removed")
     end
   end
 

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -7,6 +7,7 @@ class VirusScanWorker
     asset = Asset.find(asset_id)
     if asset.unscanned?
       begin
+        Rails.logger.info("#{asset_id} - VirusScanWorker#perform - Virus scan started")
         Services.virus_scanner.scan(asset.file.path)
         asset.scanned_clean!
       rescue VirusScanner::InfectedFile => e


### PR DESCRIPTION
https://trello.com/c/9YZ5VItp

We have an ongoing issue where we are seeing the following errors related to missing files coming from the VirusScanWorker:
- Errno::ENOENT: No such file or directory
- StateMachines::InvalidTransition: Cannot transition state via :scanned_clean from :unscanned (Reason(s): File can't be blank)

Assets should go through the following stages:
1. unscanned => saved to the file system and scanned by ClamAV in a background job.
2. scanned  => Saved to AWS.
3. uploaded => removed from the file system.

However, it seems like the file has already been removed during the virus scanning stage.

This adds logging so that we can trace the history of assets which raise the above errors to try to diagnose the issue.

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
