### PR TITLE
Updating ClamAV engine with offical version 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ruby_version=3.2.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
-
+ARG clam_engine=clamav-1.2.1.linux.x86_64.deb
 
 FROM $builder_image AS builder
 
@@ -14,13 +14,15 @@ RUN bootsnap precompile --gemfile .
 
 FROM $base_image
 
+ARG clam_engine
 ENV GOVUK_APP_NAME=asset-manager
 
 # TODO: move ClamAV into a completely separate service.
-RUN install_packages clamav clamav-daemon clamdscan shared-mime-info && \
-    rm -fr /etc/clamav/* && \
-    mkdir -p /var/run/clamav && \
-    chown app:app /var/run/clamav /var/lib/clamav
+RUN install_packages wget shared-mime-info && \
+    wget https://www.clamav.net/downloads/production/$clam_engine && \
+    apt install ./$clam_engine && rm ./$clam_engine && \
+    mkdir -p /var/run/clamav /var/lib/clamav /usr/local/share/clamav && \
+    chown app:app /var/run/clamav /var/lib/clamav /usr/local/share/clamav
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH


### PR DESCRIPTION
 Currently adding latest version found on https://www.clamav.net/downloads
 
 As a todo:
 Can improve this by using curl to ascertain the latest release then
 injecting that as variable `$LATEST` rather then hardcoding the current
 version.
 
 Thus the wget line will change to:
` wget https://www.clamav.net/downloads/production/clamav-$LATEST.linux.x86_64.deb`
 
https://trello.com/c/TicAq9G1/1238-update-clamav-engine-to-latest-version


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
