### PR TITLE
Attempt to avoid some of the Enoent issues

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -76,7 +76,7 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  before_save :store_metadata, unless: :uploaded?
+  before_save :store_metadata, unless: :uploaded?, if: -> { changes.include?(:file) }
   after_save :schedule_virus_scan
   after_save :update_indirect_replacements_on_publish
   after_save :backpropagate_replacement

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -9,7 +9,12 @@ class VirusScanWorker
       begin
         Rails.logger.info("#{asset_id} - VirusScanWorker#perform - Virus scan started")
         Services.virus_scanner.scan(asset.file.path)
-        asset.scanned_clean!
+        # This is to deal with a concurrency issue in production
+        # It looks like sometimes VirusScannerWorker can be scheduled several times for one file
+        # And the other process might change the state already of as the virus scan take time
+        # This if condition is to avoid unnecessary state transitions and therefore other
+        # concurrency issues
+        asset.scanned_clean! if Asset.find(asset_id).unscanned?
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!

--- a/spec/workers/virus_scan_worker_spec.rb
+++ b/spec/workers/virus_scan_worker_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe VirusScanWorker do
     end
   end
 
+  context "when the asset becomes marked clean by another process" do
+    it "does change the asset state" do
+      allow(scanner).to receive(:scan) do
+        asset.scanned_infected!
+      end
+
+      worker.perform(asset.id)
+
+      expect(asset.reload).not_to be_clean
+    end
+  end
+
   context "when the asset is already marked as infected" do
     let(:asset) { FactoryBot.create(:infected_asset) }
 


### PR DESCRIPTION
Asset attempts to read metadata of the file every time the asset is saved. This seems to lead in error in production as the below stack trace shows. It looks like several processes attempt to change the state of the asset at the same time, some of the processes remove the actual local file which then causes the subjequent processes to fail reading the local file.

In any case, reading the local file should be necessary only rarely - not every time when Asset state is modified. This pr attempts to minize the reads.

It also looks like in production VirusScannerWorker gets executed several times at the same time on the same asset. I don't know why this happens, but this pr attemps to avoid unnecessary state transition from the VirusScanner, if another process has already taken over the state of the asset.

IDK if this fixes these issues, but maybe it might help reduce the noise in sentry 🤷‍♀️ 


[Please see logit here](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/goto/348c9c4fb1250dd55eeae8baf0f1ac58?security_tenant=global)

1. When debugging ERROR::ENOENT issues in production, i can see that file read attempts fail when Asset state is changed.

```
/app/app/models/asset.rb:251:in `stat'
/app/app/models/asset.rb:251:in `file_stat'
/app/app/models/asset.rb:164:in `last_modified_from_file'
/app/app/models/asset.rb:160:in `etag_from_file'
/app/app/models/asset.rb:230:in `store_metadata'
/usr/local/bundle/ruby/3.2.0/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:403:in `block in make_lambda'
```

2. When debugging ERROR::ENOENT issues in production, i can see that Virus scanner triggered twice for the same asset.

```
30 Nov, 2023 @ 17:37:45.485 | 6568c869cc1ec5000d8eefe6 - VirusScanWorker#perform - Virus scan started
30 Nov, 2023 @ 17:37:45.303 | 6568c869cc1ec5000d8eefe6 - VirusScanWorker#perform - Virus scan started
```



[Trello](https://trello.com/c/kqUYHSO2/270-debug-errorenoent-issues-in-asset-manager)