### PR TITLE
Only require file to be set when creating a new instance of the Asset

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -53,7 +53,7 @@ class Asset
 
   field :deleted_at, type: Time
 
-  validates :file, presence: true, unless: :uploaded?
+  validates :file, presence: true, if: :unscanned?
 
   validates :uuid,
             presence: true,


### PR DESCRIPTION
It looks like the validation rule that expects a file to be present is not working well in production where there are several instances of Asset Manager and there are several concurrent processes trying to update the asset metadata.

This PR would make it so what the only time we really need the file to be a required field is when we're creating a new asset.

Whitehall is getting a number of  HTTP 422 from Asset Manager.
[sentry](https://govuk.sentry.io/issues/4586734135/?alert_rule_id=9401721&alert_type=issue&environment=production&notification_uuid=616583c4-a0fe-47e6-bcf8-46833b9d8ae3&project=202259&referrer=slack)

