### PR TITLE
Constrain `VirusScanWorker` to one concurrent worker per asset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem "pact", require: false
   gem "pact_broker-client", require: false
   gem "rspec-rails"
+  gem "rspec-sidekiq"
   gem "rubocop-govuk"
   gem "simplecov"
   gem "webmock", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "plek"
 gem "rack_strip_client_ip"
 gem "rails-controller-testing"
 gem "sentry-sidekiq"
+gem "sidekiq-unique-jobs"
 gem "sprockets-rails"
 gem "state_machines-mongoid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     brakeman (6.1.0)
+    brpoplpush-redis_script (0.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, < 6)
     bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -651,6 +654,12 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-unique-jobs (7.1.31)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (< 5.0)
+      sidekiq (>= 5.0, < 7.0)
+      thor (>= 0.20, < 3.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -738,6 +747,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sentry-sidekiq
+  sidekiq-unique-jobs
   simplecov
   sprockets-rails
   state_machines-mongoid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -604,6 +604,11 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
+    rspec-sidekiq (4.1.0)
+      rspec-core (~> 3.0)
+      rspec-expectations (~> 3.0)
+      rspec-mocks (~> 3.0)
+      sidekiq (>= 5, < 8)
     rspec-support (3.12.1)
     rubocop (1.55.0)
       json (~> 2.3)
@@ -745,6 +750,7 @@ DEPENDENCIES
   rails (= 7.1.2)
   rails-controller-testing
   rspec-rails
+  rspec-sidekiq
   rubocop-govuk
   sentry-sidekiq
   sidekiq-unique-jobs

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -3,6 +3,8 @@ require "services"
 class VirusScanWorker
   include Sidekiq::Worker
 
+  sidekiq_options lock: :until_and_while_executing
+
   def perform(asset_id)
     asset = Asset.find(asset_id)
     if asset.unscanned?

--- a/app/workers/virus_scan_worker.rb
+++ b/app/workers/virus_scan_worker.rb
@@ -11,12 +11,7 @@ class VirusScanWorker
       begin
         Rails.logger.info("#{asset_id} - VirusScanWorker#perform - Virus scan started")
         Services.virus_scanner.scan(asset.file.path)
-        # This is to deal with a concurrency issue in production
-        # It looks like sometimes VirusScannerWorker can be scheduled several times for one file
-        # And the other process might change the state already of as the virus scan take time
-        # This if condition is to avoid unnecessary state transitions and therefore other
-        # concurrency issues
-        asset.scanned_clean! if Asset.find(asset_id).unscanned?
+        asset.scanned_clean!
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,2 +1,25 @@
+SidekiqUniqueJobs.configure do |config|
+  config.enabled = !Rails.env.test? # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
+  config.lock_ttl = 1.hour
+end
+
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+end
+
+Sidekiq.configure_server do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
+end
+
 # Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7
 Sidekiq.strict_args!

--- a/spec/workers/virus_scan_worker_spec.rb
+++ b/spec/workers/virus_scan_worker_spec.rb
@@ -49,18 +49,6 @@ RSpec.describe VirusScanWorker do
     end
   end
 
-  context "when the asset becomes marked clean by another process" do
-    it "does change the asset state" do
-      allow(scanner).to receive(:scan) do
-        asset.scanned_infected!
-      end
-
-      worker.perform(asset.id)
-
-      expect(asset.reload).not_to be_clean
-    end
-  end
-
   context "when the asset is already marked as infected" do
     let(:asset) { FactoryBot.create(:infected_asset) }
 


### PR DESCRIPTION
This will prevent multiple jobs becoming enqueued for a single asset until the original job has finished executing.

We are currently seeing an issue where a user can replace the file after uploading but before the virus scan has completed. This results in a second virus scan being enqueued, which subsequently fails as the asset has been deleted from the filesystem. This should prevent that from happening.

[Trello card](https://trello.com/c/UWS9qEtj)