### PR TITLE
Added some documentation of the various authorisation options available for assets

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,11 @@ curl http://asset-manager.dev.gov.uk/assets --form "asset[file]=@tmp.txt"
   "name":"tmp.txt",
   "content_type":"text/plain",
   "file_url":"http://assets-origin.dev.gov.uk/media/597b098a759b743e0b759a96/tmp.txt",
-  "state":"unscanned"
+  "state":"unscanned",
+  "draft": false,
+  "access_limited": [],
+  "access_limited_organisation_ids": [],
+  "auth_bypass_ids": []
 }
 ```
 
@@ -37,7 +41,8 @@ curl http://asset-manager.dev.gov.uk/assets/597b098a759b743e0b759a96
   "name":"tmp.txt",
   "content_type":"text/plain",
   "file_url":"http://assets-origin.dev.gov.uk/media/597b098a759b743e0b759a96/tmp.txt",
-  "state":"unscanned"
+  "state":"unscanned",
+  "draft": false
 }
 
 # After virus scanning
@@ -48,7 +53,8 @@ curl http://asset-manager.dev.gov.uk/assets/597b098a759b743e0b759a96
   "name":"tmp.txt",
   "content_type":"text/plain",
   "file_url":"http://assets-origin.dev.gov.uk/media/597b098a759b743e0b759a96/tmp.txt",
-  "state":"clean"
+  "state":"clean",
+  "draft": false
 }
 ```
 
@@ -84,7 +90,11 @@ curl http://asset-manager.dev.gov.uk/assets/597b098a759b743e0b759a96 --request P
   "name":"tmp123.txt",
   "content_type":"text/plain",
   "file_url":"http://assets-origin.dev.gov.uk/media/597b098a759b743e0b759a96/tmp123.txt",
-  "state":"unscanned"
+  "state":"unscanned",
+  "draft": false,
+  "access_limited": [],
+  "access_limited_organisation_ids": [],
+  "auth_bypass_ids": []
 }
 
 # Request asset using original filename

--- a/docs/authorisation.md
+++ b/docs/authorisation.md
@@ -1,0 +1,36 @@
+# Authorisation
+
+In some cases, assets should not be publicly accessible. This only applies when they are in the "draft" state, which typically
+means that they are associated with a content item which is present on the "draft" stack in content store, but not present on the "live" stack.
+All assets associated with "live" content must be publicly available.
+
+There are three types of authorisation that can be applied to assets in the "draft" state:
+
+- Authorisation based on the user ID
+- Authorisation based on the user's organisation
+- Authorisation based on a bypass token
+
+To apply any of the above authorisation protocols, the `draft` key must have a value of `true` in the request body sent to the
+create or update asset API endpoints.
+
+## Authorisation based on the user ID
+
+To provide an allowlist of users that should be able to access an asset, include the `access_limited` key in the request body
+when creating or updating an asset. The value should be an array of Signon user IDs. An empty array means "no restrictions of this type".
+
+## Authorisation based on the user's organisation ID
+
+To provide an allowlist of organisations whose users should be able to access an asset, include the `access_limited_organisation_ids` key in the request body
+when creating or updating an asset. The value should be an array of organisation content IDs. An empty array means "no restrictions of this type".
+
+## Authorisation based on a bypass token
+
+Some publishing applications have a shareable preview feature, which allows publishers to share draft versions of content with
+people that do not have a Signon account. The publishing app generates an authorisation bypass token, and the token ID can be
+passed to asset manager to prevent general public access to the asset.
+
+To apply bypass token authorisation to a draft asset, include the `auth_bypass_ids` key in the request body when creating or updating an
+asset. The value should be an array of auth bypass token IDs. The value must be an array because publishing apps may create
+multiple shareable preview links for a content item. An empty array means "no restrictions of this type". 
+
+


### PR DESCRIPTION
I've been attempting to rationalise the handling of attachment assets in Whitehall. To do that I needed to understand what some of the parameters Whitehall includes in the requests that it sends to Asset Manager do. I found that there wasn't any documentation describing those parameters, so I thought I would add some. Let me know if there are any inaccuracies.

I did think about including this documentation within the API document, but the way that is formatted at the moment doesn't lend itself brilliantly to describing individual keys within a request body, so I went for a separate doc in the end. 
