### PR TITLE
Bump `google-protobuf` to 3.25.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,10 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.2)
+    google-protobuf (3.25.3)
+    google-protobuf (3.25.3-aarch64-linux)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos-types (1.12.0)
       google-protobuf (~> 3.18)
     govuk_app_config (9.9.1)
@@ -764,4 +767,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.24
+   2.5.3


### PR DESCRIPTION
This was removed from the Gemfile.lock during [the Ruby 3.3 update](https://github.com/alphagov/asset-manager/commit/90209aa81deb9b58f77441207ed1bb34decd99a2) but not removed as an actual dependency, therefore any subsequent runs of `bundle install` have resulted in the incompatible version of the gem being reinstalled.

Therefore upgrading to a version of `google-protobuf` that is compatible with Ruby 3.3.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
