### PR TITLE
Disable Sidekiq unique jobs logger in testing

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 SidekiqUniqueJobs.configure do |config|
   config.enabled = !Rails.env.test? # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
+  config.logger_enabled = !Rails.env.test?
   config.lock_ttl = 1.hour
 end
 


### PR DESCRIPTION
Currently, we get spammed by Sidekiq unique jobs logs when running the test suite.

Disable logs in testing as described here
https://github.com/mhenrixon/sidekiq-unique-jobs?tab=readme-ov-file#uniqueness.

<img width="794" alt="image" src="https://github.com/alphagov/asset-manager/assets/47089130/d1bb3f04-6e41-4225-b170-49004869ed64">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
