### PR TITLE
Ensure asset metadata is updated when file name isn't changed

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -76,7 +76,7 @@ class Asset
 
   mount_uploader :file, AssetUploader
 
-  before_save :store_metadata, unless: :uploaded?, if: -> { changes.include?(:file) }
+  before_save :store_metadata, unless: :uploaded?
   after_save :schedule_virus_scan
   after_save :update_indirect_replacements_on_publish
   after_save :backpropagate_replacement

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1105,6 +1105,19 @@ RSpec.describe Asset, type: :model do
         expect(asset.save).to be_truthy
       end
     end
+
+    context "when the file name is unchanged" do
+      let(:saved_asset) { FactoryBot.create(:asset) }
+      let(:md5_hexdigest) { saved_asset.md5_hexdigest }
+      let(:original_filename) { saved_asset.file.send(:original_filename) }
+
+      it "updates the md5 hexdigest" do
+        asset = described_class.find(saved_asset.id) # find to clear memoization
+        asset.update!(file: load_fixture_file("lorem.txt", named: original_filename))
+
+        expect(asset.md5_hexdigest).not_to eq md5_hexdigest
+      end
+    end
   end
 
   describe "#replacement" do


### PR DESCRIPTION
https://trello.com/c/4PkYkOal

Asset metadata is not being updated when an asset is uploaded with a file which
has the same name as the previous file. This is because of a condition added in
#1258 that was intended to quieten some errors we were seeing at the time. This
same issue was addressed in #1263.

This is problematic as there is a guard statement in the S3 uploader that
prevents assets with an unchanged MD5 hexdigest from uploading.



---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
