### PR TITLE
Start building asset-manager for ARM.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 ARG clam_engine=clamav-1.2.1.linux.x86_64.deb
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile Gemfile.lock .ruby-version ./
@@ -12,7 +12,7 @@ COPY . .
 RUN bootsnap precompile --gemfile .
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 
 ARG clam_engine
 ENV GOVUK_APP_NAME=asset-manager


### PR DESCRIPTION
## What?
This starts running asset-manager builds through the multi-arch workflow so we get ARM builds for use with our Graviton-based nodes.