### PR TITLE
Unblock Builds, need to unbundle ClamAV soon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:


### PR DESCRIPTION
## What?
At present, the build is tightly coupled to an x86_64 version of ClamAV. In order to un-break the builds, we're going to keep Asset Manager on x86 until we can decouple ClamAV from the build.