### PR TITLE
Attempt permission fix for Clam AV Logs Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,8 @@ RUN apt update && apt-get install -y libbz2-1.0 \
         tzdata \
         netcat-traditional && \
     mkdir -p /var/run/clamav /var/lib/clamav /usr/local/share/clamav && \
-    chown app:app /var/run/clamav /var/lib/clamav /usr/local/share/clamav
+    install -d -m 755 -g "app" -o "app" "/var/log/clamav" && \
+    chown -R app:app /var/run/clamav /var/lib/clamav /usr/local/share/clamav
 
 WORKDIR $APP_HOME
 


### PR DESCRIPTION
## What?
We are encountering some permission errors in the Freshclam jobs:

```
ERROR: Problem with internal logger (UpdateLogFile = /var/log/clamav/freshclam.log).
ERROR: initialize: libfreshclam init failed.
ERROR: Initialization error!
ERROR: Can't open /var/log/clamav/freshclam.log in append mode (check permissions!).
```

These permission errors are related to the `/var/log/clamav` directory. In Cisco's Debian Dockerfile, they do this:
```bash
install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
```

So let's do something similar for ours, except use the `app` user and group.