### PR TITLE
Trivial: standardise on netcat-openbsd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN apt update && apt-get install -y libbz2-1.0 \
         libxml2 \
         zlib1g \
         tzdata \
-        netcat-traditional && \
+        netcat-openbsd && \
     mkdir -p /var/run/clamav /var/lib/clamav /usr/local/share/clamav && \
     chown app:app /var/run/clamav /var/lib/clamav /usr/local/share/clamav
 


### PR DESCRIPTION
Shouldn't matter much but might as well keep this consistent (both with what we used to install under 22.04 and with what's in govuk-infrastructure/toolbox).

The OpenBSD implementation lacks `-e` (which is a plus) and is a bit more modern and actively maintained.

netcat is used in the [healthcheck script](https://github.com/Cisco-Talos/clamav-docker/blob/main/clamav/1.3/debian/scripts/clamdcheck.sh) in the underlying clamav container.