### PR TITLE
Build ClamAV to run as "app" user for container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,8 +135,7 @@ WORKDIR $APP_HOME
 COPY --from=clam_builder "/clamav" "/"
 
 RUN ln -s /usr/bin/clam* /usr/local/bin && \
-    ln -s /usr/bin/freshclam /usr/local/bin && \
-    chown 0755 /usr/local/bin/clam* /usr/local/bin/freshclam
+    ln -s /usr/bin/freshclam /usr/local/bin
 
 COPY --from=app_builder $BUNDLE_PATH $BUNDLE_PATH
 COPY --from=app_builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,13 +77,13 @@ RUN apt update && apt install -y \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
-        -e "s|.*\(User\) .*|\1 clamav|" \
+        -e "s|.*\(User\) .*|\1 app|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/clamd.log|" \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
         -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
-        -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
+        -e "s|.*\(DatabaseOwner\) .*|\1 app|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
@@ -134,7 +134,9 @@ WORKDIR $APP_HOME
 
 COPY --from=clam_builder "/clamav" "/"
 
-RUN ln -s /usr/bin/clam* /usr/local/bin
+RUN ln -s /usr/bin/clam* /usr/local/bin && \
+    ln -s /usr/bin/freshclam /usr/local/bin && \
+    chown 0755 /usr/local/bin/clam* /usr/local/bin/freshclam
 
 COPY --from=app_builder $BUNDLE_PATH $BUNDLE_PATH
 COPY --from=app_builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR


### PR DESCRIPTION
## What?
This changes the clam configuration files to try and run the Clam services as the "app" user in the container to try and avoid any permissions problems being experienced. This may explain why we are getting permissions issues when freshclam is trying to run in integration.

Also set the permissions for the symlinks in /usr/local/bin to match the permissions elsewhere (the ones we created seem to default to 0777).