### PR TITLE
Set all Log File paths to Stdout for ClamAV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,13 +78,13 @@ RUN apt update && apt install -y \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
         -e "s|.*\(User\) .*|\1 app|" \
-        -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/clamd.log|" \
+        -e "s|^\#\(LogFile\) .*|\1 /dev/stdout|" \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
         -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 app|" \
-        -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
+        -e "s|^\#\(UpdateLogFile\) .*|\1 /dev/stdout|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
@@ -92,7 +92,7 @@ RUN apt update && apt install -y \
         -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
-        -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \
+        -e "s|^\#\(LogFile\) .*|\1 /dev/stdout|" \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         -e "s|.*\(\ClamdSocket\) .*|\1 unix:/tmp/clamd.sock|" \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \


### PR DESCRIPTION
## What?
This switches the default Log file paths for the ClamAV config files to `/dev/stdout` to allow ClamAV to try and function in an unprivileged environment. Some other changes will be going into the Helm Chart to add some extra args to the `freshclam` command.