### PR TITLE
Simplify and speed up the clamav build.

### DIFF
--- a/lib/govuk_configuration.rb
+++ b/lib/govuk_configuration.rb
@@ -23,6 +23,6 @@ class GovukConfiguration
   end
 
   def clamscan_path
-    @env.fetch("ASSET_MANAGER_CLAMSCAN_PATH", "govuk_clamscan")
+    @env.fetch("ASSET_MANAGER_CLAMSCAN_PATH", "clamdscan")
   end
 end

--- a/lib/virus_scanner.rb
+++ b/lib/virus_scanner.rb
@@ -2,8 +2,8 @@ require "open3"
 
 # Simple wrapper around ClamAV
 #
-# This expects govuk_clamscan to exist on the PATH, and be a symlink
-# to either clamscan or clamdscan
+# This expects AssetManager.govuk.clamscan_path to be an executable command
+# that is compatible with clamscan or clamdscan.
 class VirusScanner
   class Error < StandardError; end
 

--- a/spec/lib/govuk_configuration_spec.rb
+++ b/spec/lib/govuk_configuration_spec.rb
@@ -63,14 +63,6 @@ RSpec.describe GovukConfiguration do
         expect(config.clamscan_path).to eq("alternative-path")
       end
     end
-
-    context "when environment does not include an ASSET_MANAGER_CLAMSCAN_PATH value" do
-      let(:env) { {} }
-
-      it "returns govuk_clamscan" do
-        expect(config.clamscan_path).to eq("govuk_clamscan")
-      end
-    end
   end
 
   describe "#draft_assets_host" do

--- a/spec/lib/virus_scanner_spec.rb
+++ b/spec/lib/virus_scanner_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe VirusScanner do
     end
 
     it "calls out to clamdscan" do
-      expect(Open3).to receive(:capture2e).with("govuk_clamscan", "--no-summary", file_path)
+      expect(Open3).to receive(:capture2e).with("clamdscan", "--no-summary", file_path)
 
       scanner.scan(file_path)
     end


### PR DESCRIPTION
- Use govuk-ruby-builder for clamav. Simplifies the Dockerfile by eliminating boilerplate and speeds up the build by not having to install a bunch of stuff that already ships with govuk-ruby-builder.
- Don't run the clamav Python testsuite; it's super slow and we're building from an official source tarball with a very common config, so it's not worth blowing up asset-manager's build time.
- Add a crude but fast and somewhat effective smoke test for the two clam binaries that asset-manager needs.
- Use the system Rust instead of faffing about installing it ourselves, since we don't antipcate any need to run on PowerPC any time soon.
- Remove a bunch of unneeded Apt packages.
- Remove some unneeded workarounds, e.g. install the clam binaries in the desired directory (which happens to be the default one from the CMakelists.txt anyway) rather than symlinking them afterwards.
- Remove some _cough_ [GPLed code] _cough_ that was mistakenly copy-pasted into the Dockerfile of our MIT-licensed codebase here.
- Use a valid command for clamdscan so that it works by default rather than requiring brittle configuration on deployment.

[GPLed code]: https://www.github.com/Cisco-Talos/clamav-docker/blob/bf4c0c2/clamav/1.3/debian/Dockerfile

Tested: built and ran locally with Docker Desktop, copied configs into `/usr/local/etc/*clam*.conf`, successfully ran `freshclam` and scanned some files with `clamdscan` connecting to `clamd` via TCP on 127.0.0.1 (which is [how we do it in prod](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/asset-manager/templates/clamav-configmap.yaml#L14)).

Rollout: needs manual e2e testing in integration or staging before pushing to prod. (Done — successfully created a document with at attachment and an image in integration via whitehall-admin).