### PR TITLE
Fix race condition where file is deleted while updating assets

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -108,8 +108,7 @@ class Asset
 
     after_transition to: :uploaded do |asset, _|
       asset.save!
-      FileUtils.rm_rf(File.dirname(asset.file.path))
-      Rails.logger.info("#{asset.id} - Asset#state_machine - File removed")
+      DeleteAssetFileFromNfsWorker.perform_in(5.minutes, asset.id.to_s)
     end
   end
 

--- a/app/workers/delete_asset_file_from_nfs_worker.rb
+++ b/app/workers/delete_asset_file_from_nfs_worker.rb
@@ -4,10 +4,9 @@ class DeleteAssetFileFromNfsWorker
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    asset_path = asset.file.path
     if asset.uploaded?
-      asset.remove_file!
-      FileUtils.rmdir(File.dirname(asset_path))
+      FileUtils.rm_rf(File.dirname(asset.file.path))
+      Rails.logger.info("#{asset.id} - DeleteAssetFileFromNfsWorker - File removed")
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "208f12bca8eb9bc7a921ab15d951b863dcb3abbc4bfafbd912cb453814fba63b",
+      "fingerprint": "cafb3c946b3ea6de50534f77286cf66f551d21910ceab7916651d888f5eb2280",
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/workers/delete_asset_file_from_nfs_worker.rb",
-      "line": 10,
+      "line": 8,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "FileUtils.rmdir(File.dirname(Asset.find(asset_id).file.path))",
+      "code": "FileUtils.rm_rf(File.dirname(Asset.find(asset_id).file.path))",
       "render_path": null,
       "location": {
         "type": "method",
@@ -18,9 +18,12 @@
       },
       "user_input": "Asset.find(asset_id).file",
       "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
       "note": ""
     }
   ],
-  "updated": "2021-02-23 15:17:02 +0000",
-  "brakeman_version": "5.0.0"
+  "updated": "2024-07-01 17:54:35 +0100",
+  "brakeman_version": "6.1.2"
 }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1055,22 +1055,9 @@ RSpec.describe Asset, type: :model do
         expect(asset.reload).to be_uploaded
       end
 
-      it "sets file attribute to blank" do
+      it "triggers the delete asset file worker" do
+        expect(DeleteAssetFileFromNfsWorker).to receive(:perform_in)
         asset.upload_success!
-
-        expect(asset.reload.file).to be_blank
-      end
-
-      it "removes the underlying file" do
-        asset.upload_success!
-
-        expect(File).not_to exist(path)
-      end
-
-      it "removes the underlying directory" do
-        asset.upload_success!
-
-        expect(File).not_to exist(File.dirname(path))
       end
     end
 


### PR DESCRIPTION
The [SaveToCloudStorageWorker](https://github.com/alphagov/asset-manager/blob/5d410e5f5c6680eeb5836011313a811485390cbe/app/workers/save_to_cloud_storage_worker.rb#L3) is kicked off as soon as virus scanning is complete and [the asset transitions to the clean state](https://github.com/alphagov/asset-manager/blob/f5f9c1a06b5d1a47d8c84227678b3ddea25bc94c/app/models/asset.rb#L97-L99).

When the SaveToCloudStorageWorker completes the upload, it [triggers the upload_success event](https://github.com/alphagov/asset-manager/blob/5d410e5f5c6680eeb5836011313a811485390cbe/app/workers/save_to_cloud_storage_worker.rb#L10), which [transitions to the uploaded state](https://github.com/alphagov/asset-manager/blob/f5f9c1a06b5d1a47d8c84227678b3ddea25bc94c/app/models/asset.rb#L105-L107).

There's an [after_transition callback which runs after the asset moves into the uploaded state](https://github.com/alphagov/asset-manager/blob/69c6870005310d025ba0fda00ec4bc7c252751cb/app/models/asset.rb#L109-L112), which removes the uploaded file.

Meanwhile, there's [a before_save callback which will update the file metadata before saving the asset](https://github.com/alphagov/asset-manager/blob/f5f9c1a06b5d1a47d8c84227678b3ddea25bc94c/app/models/asset.rb#L79). This callback will only run if the file hasn't been uploaded.

A race condition occurs if the before_save callback has started when the asset transitions into the uploaded state - one process deletes the file, while the other process continues to perform methods which expect the file to exist. This results in errors like these:

```
Errno::ENOENT (No such file or directory @ rb_file_s_stat - /mnt/asset-manager/assets/82/b5/6682b5cbaec8650b100901fd/REDACTED.csv):
  
app/models/asset.rb:251:in `stat'
app/models/asset.rb:251:in `file_stat'
app/models/asset.rb:172:in `size_from_file'
app/models/asset.rb:233:in `store_metadata'
app/controllers/assets_controller.rb:7:in `update'"
```

We can avoid this by delaying the deletion of the file. Once the asset is in the uploaded state, we won't perform operations which expect the file to exist in the before_save callback. There's no urgency behind removing the file, so we can do it a few minutes after the state transition.

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
