### PR TITLE
Reuse AWS client between S3 requests

### DIFF
--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -81,7 +81,7 @@ private
   end
 
   def object_for(asset)
-    Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.uuid)
+    Aws::S3::Object.new(bucket_name: @bucket_name, key: asset.uuid, client:)
   end
 
   def head_object_for(asset)
@@ -89,6 +89,6 @@ private
   end
 
   def client
-    Aws::S3::Client.new
+    @client ||= Aws::S3::Client.new
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe S3Storage do
   before do
     allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
     allow(Aws::S3::Object).to receive(:new)
-      .with(s3_object_params).and_return(s3_object)
+      .with(hash_including(s3_object_params)).and_return(s3_object)
   end
 
   describe ".build" do


### PR DESCRIPTION
At the moment, we create new AWS clients whenever we download or head an object. Each time we do this, the client requests a new set of AWS credentials using the pod's (or the node's?) metadata endpoint.

This causes a problem when asset-manager is under high load, because the AWS metadata endpoint has a rate limit. Eventually, we start getting 429 errors back from the metadata endpoint, which the AWS client reports as:

    Aws::Sigv4::Errors::MissingCredentialsError: missing credentials

(At least according to issue #2823 in aws-sdk-ruby)

We see this as a spike of 500 errors every night when the mirror script runs:

![image](https://github.com/alphagov/asset-manager/assets/1696784/7d7326b5-aeeb-45e9-a366-1d43d004381e)


The `S3Storage` instance in asset-manager is created once when the app loads, and set as `Services.cloud_storage`. In other words it's effectively a singleton - the same instance will be used by all requests.

`Aws::S3::Client` instances are thread safe, and can be reused between requests (again, according to issue #2823 in aws-sdk-ruby).

By creating the client once, instead of once per request, we'll avoid hitting the AWS metadata endpoint on every request to S3, which should mean that we don't get rate limited.

I've lightly tested this on integration by making sure I can still upload and download assets. No errors in the logs.

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️