### PR TITLE
Validate public assets have public document URLs

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -280,5 +280,9 @@ protected
     unless uri && %w[http https].include?(uri.scheme)
       errors.add(:parent_document_url, "must be an http(s) URL")
     end
+
+    if uri && uri.host.start_with?("draft-origin") && !draft?
+      errors.add(:parent_document_url, "must be a public GOV.UK URL")
+    end
   end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -68,10 +68,10 @@ RSpec.describe AssetsController, type: :controller do
       end
 
       it "stores parent_document_url on asset" do
-        attributes = valid_attributes.merge(parent_document_url: "parent-document-url")
+        attributes = valid_attributes.merge(parent_document_url: "http://parent-document-url")
         post :create, params: { asset: attributes }
 
-        expect(assigns(:asset).parent_document_url).to eq("parent-document-url")
+        expect(assigns(:asset).parent_document_url).to eq("http://parent-document-url")
       end
 
       it "stores a specified content type" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -197,6 +197,38 @@ RSpec.describe Asset, type: :model do
           expect(asset.errors[:parent_document_url]).to include(message)
         end
       end
+
+      context "and the URL points to the draft stack" do
+        before do
+          asset.parent_document_url = "https://draft-origin.publishing.service.gov.uk/government/news/test"
+        end
+
+        context "when the asset is a draft" do
+          before do
+            asset.draft = true
+          end
+
+          it "is valid" do
+            expect(asset).to be_valid
+          end
+        end
+
+        context "when the asset is published" do
+          before do
+            asset.draft = false
+          end
+
+          it "is invalid" do
+            expect(asset).not_to be_valid
+          end
+
+          it "has the expected error message" do
+            asset.valid?
+            message = "must be a public GOV.UK URL"
+            expect(asset.errors[:parent_document_url]).to include(message)
+          end
+        end
+      end
     end
 
     context "when content_type is not specified" do


### PR DESCRIPTION
There are over 1000 assets in the Asset Manager database which are not drafts, but have a parent document URL that points to the draft stack. Whilst this doesn't seem to break anything, that shouldn't really be possible so it would seem to make sense to apply some validation.

We expect this may help us to diagnose an issue where at least some of those 1000+ assets were unexpectedly made public ahead of their parent document being published. If this validation had been in place we think it would have prevented the issue.

I'm not really sure that we should be keeping parent document URLs in Asset Manager as it seems like a rather circular relationship, but anyway, it might prove useful in this case!