### PR TITLE
Update `.gitignore` to exclude all log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /db/*.sqlite3
 
 # Ignore all logfiles and tempfiles.
-/log/*.log
+/log/*.log*
 /tmp
 
 /coverage


### PR DESCRIPTION
Some log files are suffixed with a number, e.g. `log/development.log.0`.

Therefore adding these to the `.gitignore` file so they don't accidentally get committed.