### PR TITLE
Do not attempt to open file if it does not exist

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -156,19 +156,19 @@ class Asset
   end
 
   def etag_from_file
-    sprintf("%<mtime>x-%<size>x", mtime: last_modified_from_file, size: file_stat.size)
+    sprintf("%<mtime>x-%<size>x", mtime: last_modified_from_file, size: file_stat.size) if file_exists?
   end
 
   def last_modified_from_file
-    file_stat.mtime
+    file_stat.mtime if file_exists?
   end
 
   def md5_hexdigest_from_file
-    @md5_hexdigest_from_file ||= Digest::MD5.hexdigest(file.file.read)
+    @md5_hexdigest_from_file ||= Digest::MD5.hexdigest(file.file.read) if file_exists?
   end
 
   def size_from_file
-    file_stat.size
+    file_stat.size if file_exists?
   end
 
   def update_indirect_replacements_on_publish
@@ -244,6 +244,10 @@ protected
 
   def schedule_virus_scan
     VirusScanWorker.perform_async(id.to_s) if unscanned? && redirect_url.blank?
+  end
+
+  def file_exists?
+    File.exist?(file.path)
   end
 
   def file_stat

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -615,6 +615,19 @@ RSpec.describe Asset, type: :model do
       asset.restore
       expect(asset.deleted_at).to be_nil
     end
+
+    context "when the file has already been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "adds a deleted_at timestamp to the record" do
+        expect(asset.deleted_at).not_to be_nil
+      end
+    end
   end
 
   describe "extension" do
@@ -861,6 +874,19 @@ RSpec.describe Asset, type: :model do
       asset_size = size_hex.to_i(16)
       expect(asset_size).to eq(size)
     end
+
+    context "when the file has been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(asset.etag_from_file).to be_nil
+      end
+    end
   end
 
   describe "#etag" do
@@ -918,6 +944,19 @@ RSpec.describe Asset, type: :model do
     it "returns time file was last modified" do
       expect(asset.last_modified_from_file).to eq(mtime)
     end
+
+    context "when the file has been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(asset.last_modified_from_file).to be_nil
+      end
+    end
   end
 
   describe "#last_modified" do
@@ -972,6 +1011,19 @@ RSpec.describe Asset, type: :model do
     it "returns the size of the file" do
       expect(asset.size_from_file).to eq(size)
     end
+
+    context "when the file has been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(asset.size_from_file).to be_nil
+      end
+    end
   end
 
   describe "#size" do
@@ -1023,6 +1075,19 @@ RSpec.describe Asset, type: :model do
 
     it "returns MD5 hex digest for asset file content" do
       expect(asset.md5_hexdigest_from_file).to eq(md5_hexdigest)
+    end
+
+    context "when the file has been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(asset.md5_hexdigest_from_file).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
`File.stat(path)` raises `Errno::ENOENT` if the file does not exist.

In the case that a file has already been deleted (e.g. by another worker), we don't need to raise an error, just fail gracefully.

Therefore only attempting to load the file if it actually exists.

Also adds a test that covers the behaviour that caught this issue: attemting to soft-delete a file that has already been removed from the filesystem.

[Trello card](https://trello.com/c/gRpytEO7)