### PR TITLE
Add Sidekiq user interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ In non-production environments if the `AWS_S3_BUCKET_NAME` environment variable 
 
 Check the [docs](docs/) directory for detailed instructions, including API documentation.
 
+## Viewing the Sidekiq UI
+
+We have access to the Sidekiq UI but because Asset Manager doesn't have a
+frontend we have to use port forwarding to see it in our live environments.
+
+You'll need to have access to our EKS clusters before you can follow these
+instructions. There's [documentation here](https://docs.publishing.service.gov.uk/kubernetes/get-started/access-eks-cluster/#access-a-cluster-that-you-have-accessed-before) on how to do that. This means that
+you'll need full production access before you can view the Sidekiq UI.
+
+To view the UI run:
+
+```
+kubectl -n apps port-forward deployment/asset-manager 8080:8080
+```
+
+and then navigate to localhost:8080/sidekiq
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,7 @@ Rails.application.routes.draw do
   if AssetManager.s3.fake?
     mount Rack::File.new(AssetManager.fake_s3.root), at: AssetManager.fake_s3.path_prefix, as: "fake_s3"
   end
+
+  require "sidekiq_unique_jobs/web"
+  mount Sidekiq::Web, at: "/sidekiq"
 end


### PR DESCRIPTION
This makes the Sidekiq UI available to developers with production access.

This has been implemented in the same way as in [Publishing API](https://github.com/alphagov/publishing-api/pull/2839), albeit also adding the options for `sidekiq-unique-jobs` that is used by this application.

[Trello card](https://trello.com/c/knx2tuL4)