### PR TITLE
Move `rspec-sidekiq` to test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ group :development, :test do
   gem "pact", require: false
   gem "pact_broker-client", require: false
   gem "rspec-rails"
-  gem "rspec-sidekiq"
   gem "rubocop-govuk"
   gem "simplecov"
   gem "webmock", require: false
@@ -40,4 +39,8 @@ end
 
 group :development do
   gem "listen"
+end
+
+group :test do
+  gem "rspec-sidekiq"
 end


### PR DESCRIPTION
This gem is being installed in the `development` environment, meaning it runs when using the application locally, resulting in jobs not actually getting enqueued.

Moving it to be `test` only, since that is the only time it is actually needed.

[Trello card](https://trello.com/c/knx2tuL4)