### PR TITLE
Add aliases for renamed Sidekiq jobs

### DIFF
--- a/app/sidekiq/delete_asset_file_from_nfs_job.rb
+++ b/app/sidekiq/delete_asset_file_from_nfs_job.rb
@@ -10,3 +10,5 @@ class DeleteAssetFileFromNfsJob
     end
   end
 end
+
+DeleteAssetFileFromNfsWorker = DeleteAssetFileFromNfsJob

--- a/app/sidekiq/save_to_cloud_storage_job.rb
+++ b/app/sidekiq/save_to_cloud_storage_job.rb
@@ -11,3 +11,5 @@ class SaveToCloudStorageJob
     end
   end
 end
+
+SaveToCloudStorageWorker = SaveToCloudStorageJob

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -19,3 +19,5 @@ class VirusScanJob
     end
   end
 end
+
+VirusScanWorker = VirusScanJob


### PR DESCRIPTION
The workers were renamed in https://github.com/alphagov/asset-manager/pull/1493, but some jobs were already enqueued with the old names.  Therefore temporarily adding the old names as aliases until they have been processed.

This is the suggestion in the [Sidekiq FAQs](https://github.com/sidekiq/sidekiq/wiki/FAQ#how-do-i-safely-rename-a-worker).

[Trello card](https://trello.com/c/K9ds4XZX)