### PR TITLE
Add bulk fix assets rake task

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -80,8 +80,9 @@ namespace :assets do
             delete_and_update_draft(replacement_asset)
             processed_asset_ids[replacement_asset.id.to_s] = true
             puts "Asset ID: #{original_asset_id} - OK. Draft replacement #{replacement_asset.id} deleted and updated to false."
-          rescue StandardError
-            puts "Asset ID: #{original_asset_id} - ERROR. Asset replacement failed to save. Error: #{replacement_asset.errors.full_messages}."
+          rescue StandardError => e
+            message = replacement_asset.errors.full_messages.empty? ? e.message : replacement_asset.errors.full_messages
+            puts "Asset ID: #{original_asset_id} - ERROR. Asset replacement #{replacement_asset.id} failed to save. Error: #{message}."
           end
           next
         end
@@ -91,8 +92,9 @@ namespace :assets do
             delete_and_update_draft(original_asset)
             processed_asset_ids[original_asset_id] = true
             puts "Asset ID: #{original_asset_id} - OK. Asset is a replacement. Asset deleted and updated to false."
-          rescue StandardError
-            puts "Asset ID: #{original_asset_id} - ERROR. Asset failed to save. Error: #{original_asset.errors.full_messages}."
+          rescue StandardError => e
+            message = original_asset.errors.full_messages.empty? ? e.message : original_asset.errors.full_messages
+            puts "Asset ID: #{original_asset_id} - ERROR. Asset failed to save. Error: #{message}."
           end
           next
         end
@@ -111,8 +113,9 @@ namespace :assets do
           delete_and_update_draft(original_asset, should_update_draft: false)
           processed_asset_ids[original_asset_id] = true
           puts "Asset ID: #{original_asset_id} - OK. Asset has been deleted."
-        rescue StandardError
-          puts "Asset ID: #{original_asset_id} - ERROR. Asset failed to save. Error: #{original_asset.errors.full_messages}."
+        rescue StandardError => e
+          message = original_asset.errors.full_messages.empty? ? e : original_asset.errors.full_messages
+          puts "Asset ID: #{original_asset_id} - ERROR. Asset failed to save. Error: #{message}."
         end
       end
     end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -104,7 +104,7 @@ namespace :assets do
           next
         end
 
-        if original_asset.draft? || original_asset.deleted? || replacement_asset || original_asset.redirect_url
+        if original_asset.deleted? || replacement_asset || original_asset.redirect_url
           puts "Asset ID: #{original_asset_id} - SKIPPED. Asset is draft (#{original_asset.draft?}), deleted (#{original_asset.deleted?}), replaced (#{!replacement_asset.nil?}), or redirected (#{!original_asset.redirect_url.nil?})."
           next
         end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -75,7 +75,7 @@ namespace :assets do
           next
         end
 
-        if replacement_asset && replacement_asset.replacement.nil? && replacement_asset.draft?
+        if replacement_asset&.draft?
           begin
             delete_and_update_draft(replacement_asset)
             processed_asset_ids[replacement_asset.id.to_s] = true

--- a/spec/lib/tasks/assets_spec.rb
+++ b/spec/lib/tasks/assets_spec.rb
@@ -29,4 +29,208 @@ RSpec.describe "assets.rake" do
       expect { task.invoke("foo") }.to raise_error(Mongoid::Errors::DocumentNotFound)
     end
   end
+
+  # rubocop:disable RSpec/AnyInstance
+  context "when running a bulk fix" do
+    let(:asset_id) { BSON::ObjectId("6592008029c8c3e4dc76256c") }
+    let(:file) { Tempfile.new("csv_file") }
+    let(:filepath) { file.path }
+
+    before do
+      task.reenable # without this, calling `invoke` does nothing after first test
+      csv_file = <<~CSV
+        6592008029c8c3e4dc76256c
+      CSV
+      file.write(csv_file)
+      file.close
+    end
+
+    describe "assets:bulk_fix:fix_assets_and_draft_replacements" do
+      let(:task) { Rake::Task["assets:bulk_fix:fix_assets_and_draft_replacements"] }
+
+      it "skips the asset if asset is not found" do
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - SKIPPED. No asset found.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "only updates the draft state of the replacement if the asset replacement is already deleted" do
+        replacement = FactoryBot.create(:asset, draft: true, deleted_at: Time.zone.now, replacement_id: nil)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - OK. Draft replacement #{replacement.id} deleted and updated to false.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(replacement.reload.draft).to be false
+      end
+
+      it "deletes the asset replacement and updates the draft state if the replacement is not deleted" do
+        replacement = FactoryBot.create(:asset, draft: true, deleted_at: nil, replacement_id: nil)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - OK. Draft replacement #{replacement.id} deleted and updated to false.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(replacement.reload.deleted_at).not_to be_nil
+        expect(replacement.reload.draft).to be false
+      end
+
+      it "only updates the draft state if the asset is already deleted (asset is a replacement)" do
+        asset = FactoryBot.create(:asset, id: asset_id, draft: true, deleted_at: Time.zone.now)
+        FactoryBot.create(:asset, replacement_id: asset.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - is a replacement. Asset deleted and updated to false.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(asset.reload.deleted_at).not_to be_nil
+        expect(asset.reload.draft).to be false
+      end
+
+      it "deletes the asset and updates the draft state if the asset is not deleted (asset is a replacement)" do
+        asset = FactoryBot.create(:asset, id: asset_id, draft: true, deleted_at: nil)
+        FactoryBot.create(:asset, replacement_id: asset.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - is a replacement. Asset deleted and updated to false.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(asset.reload.deleted_at).not_to be_nil
+        expect(asset.reload.draft).to be false
+      end
+
+      it "skips the asset if asset is itself redirected (and not replaced by draft or itself a replacement)" do
+        FactoryBot.create(:asset, id: asset_id, draft: false, redirect_url: "https://example.com")
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - SKIPPED. Asset is draft (false), deleted (false), replaced (false), or redirected (true).
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "skips the asset, if the asset is further replaced (and not replaced by draft or itself a replacement)" do
+        replacement = FactoryBot.create(:asset, draft: false)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - SKIPPED. Asset is draft (false), deleted (false), replaced (true), or redirected (false).
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "skips the asset if asset is itself in draft (and not replaced by draft or itself a replacement)" do
+        FactoryBot.create(:asset, id: asset_id, draft: true)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - SKIPPED. Asset is draft (true), deleted (false), replaced (false), or redirected (false).
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "skips the asset, if the asset is already deleted (and is not itself a replacement)" do
+        FactoryBot.create(:asset, id: asset_id, deleted_at: Time.zone.now)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - SKIPPED. Asset is draft (false), deleted (true), replaced (false), or redirected (false).
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "catch-all case: it deletes the asset" do
+        FactoryBot.create(:asset, id: asset_id, draft: false, deleted_at: nil, replacement_id: nil, redirect_url: nil)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - OK. Asset has been deleted.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
+      it "rescues and logs if asset fails to save" do
+        asset = FactoryBot.create(:asset, id: asset_id, draft: true, deleted_at: nil)
+        FactoryBot.create(:asset, replacement_id: asset.id)
+
+        allow_any_instance_of(Asset).to receive(:save!).and_raise(StandardError)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - ERROR. Asset failed to save. Error: #{asset.errors.full_messages}.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(asset.reload.draft).to be true
+        expect(asset.reload.deleted_at).not_to be_nil
+      end
+
+      it "rescues and logs if asset fails to destroy" do
+        asset = FactoryBot.create(:asset, id: asset_id, draft: false, deleted_at: nil, replacement_id: nil, redirect_url: nil)
+
+        allow_any_instance_of(Asset).to receive(:destroy!).and_raise(StandardError)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - ERROR. Asset failed to save. Error: #{asset.errors.full_messages}.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(asset.reload.deleted_at).to be_nil
+      end
+
+      it "rescues and logs if asset replacement fails to save" do
+        replacement = FactoryBot.create(:asset, draft: true, deleted_at: nil)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        allow_any_instance_of(Asset).to receive(:save!).and_raise(StandardError)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - ERROR. Asset replacement failed to save. Error: #{replacement.errors.full_messages}.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(replacement.reload.draft).to be true
+        expect(replacement.reload.deleted_at).not_to be_nil
+      end
+
+      it "rescues and logs if asset replacement fails to destroy" do
+        replacement = FactoryBot.create(:asset, draft: true, deleted_at: nil)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        allow_any_instance_of(Asset).to receive(:destroy!).and_raise(StandardError)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - ERROR. Asset replacement failed to save. Error: #{replacement.errors.full_messages}.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(replacement.reload.draft).to be true
+        expect(replacement.reload.deleted_at).to be_nil
+      end
+
+      it "marks a line as 'done' in the CSV if line is processed" do
+        FactoryBot.create(:asset, id: asset_id, draft: true, deleted_at: nil)
+        task.invoke(filepath)
+        expect(File.read(filepath)).to eq "6592008029c8c3e4dc76256c,DONE\n"
+      end
+
+      it "skips processing a line if it is marked as DONE" do
+        file.open
+        csv_file = <<~CSV
+          6592008029c8c3e4dc76256c,DONE
+          6592008029c8c3e4dc76256d
+        CSV
+        file.write(csv_file)
+        file.close
+
+        skipped_asset = FactoryBot.create(:asset, id: "6592008029c8c3e4dc76256c", draft: true, deleted_at: nil)
+        asset = FactoryBot.create(:asset, id: "6592008029c8c3e4dc76256d", draft: false, deleted_at: nil)
+
+        expected_output = <<~OUTPUT
+          Asset ID: 6592008029c8c3e4dc76256d - OK. Asset has been deleted.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+        expect(skipped_asset.reload.deleted_at).to be_nil
+        expect(skipped_asset.reload.draft).to be true
+        expect(asset.reload.deleted_at).not_to be_nil
+        expect(asset.reload.draft).to be false
+        expect(File.read(filepath)).to eq "6592008029c8c3e4dc76256c,DONE\n6592008029c8c3e4dc76256d,DONE\n"
+      end
+    end
+  end
+  # rubocop:enable RSpec/AnyInstance
 end

--- a/spec/lib/tasks/assets_spec.rb
+++ b/spec/lib/tasks/assets_spec.rb
@@ -309,6 +309,17 @@ RSpec.describe "assets.rake" do
         expect(replacement.reload.state).to eq "uploaded"
       end
 
+      it "deletes the asset replacement, updates the draft state, if the asset has further replacements and the replacement is in draft" do
+        further_replacement = FactoryBot.create(:asset, draft: false)
+        replacement = FactoryBot.create(:asset, draft: true, replacement_id: further_replacement.id)
+        FactoryBot.create(:asset, id: asset_id, replacement_id: replacement.id)
+
+        expected_output = <<~OUTPUT
+          Asset ID: #{asset_id} - OK. Draft replacement #{replacement.id} deleted and updated to false.
+        OUTPUT
+        expect { task.invoke(filepath) }.to output(expected_output).to_stdout
+      end
+
       it "only updates the draft state if the asset is already deleted (asset is a replacement)" do
         asset = FactoryBot.create(:asset, id: asset_id, draft: true, deleted_at: Time.zone.now)
         FactoryBot.create(:asset, replacement_id: asset.id)


### PR DESCRIPTION
# Context
Multiple Zendesk tickets related to `whitehall` assets being live when they should not be, triggered an analysis of the problematic data - PR [here](https://github.com/alphagov/whitehall/pull/9351). We've already deleted a batch of assets that `whitehall` expected to be deleted but they were not, using [this rake task](https://github.com/alphagov/asset-manager/pull/1543). We have now investigated asset deletion states further, and we've produced [a set of assets](https://drive.google.com/file/d/1Baqsq3p_xstzSkZYMmgC1w6prJ_GqCs3/view?usp=drive_link) that, despite not being deleted in Whitehall, should not be live. In order to preserve some data integrity, we're choosing to fix the data with this rake task, rather than do a mass deletion. The assets in question are serving a chain of only superseded and deleted editions (nothing live) - see [extraction rake task](https://github.com/alphagov/whitehall/pull/9626/commits/0b0f1b9a87f67cdc47c6f001a67132c75874e943). 

We now know that there are a few broken flows in `whitehall` that are continuously producing incorrect asset states, specifically unintentionally live assets. This PR defines a rake task that should be able to tackle each asset and, if it matches some of the patterns that we know how to fix, should remedy the data, otherwise just delete it. 

# Breakdown of the rake task

One of the broken flows we've uncovered is: the user replaces an `Attachment` in `whitehall`, then they delete the replacement. The intended effect should be that the original assets of the attachment are not live anymore, nor are the replacements, since the `Attachment` is now deleted. The bug is that the replacement `Asset` in `asset-manager` remains in draft as deleted (`draft: true` and `deleted_at` not nil), when it should be going live as deleted. This causes the original asset to not redirect to the draft replacement. This is intentional, for example when we do not want a replacement redirect to be effective just yet, for example when working on a new draft.

We want to fix this by checking if the asset has a draft replacement or is itself a draft replacement. We delete the draft replacement/draft asset if it is not already deleted. Nonetheless, for the redirect to work, we also need to switch the draft state to false. The order is important, as the replacements themselves would become public if we don't action the deletion first. 

For assets that are not draft replacements nor have draft replacements, we want to allow them to continue redirecting, being replaced etc. Draft assets that are not replaced or redirected, should also be deleted, as they should not be available in the draft stack if they have been superseded. The current correct flows in `whitehall` suggest that the only possible states for an asset that has been superseded is either deleted or replaced, if it has not been otherwise redirected.

A final catch-all step ensures remaining assets (for which the steps above don't apply) are deleted.

# Data extraction 
In Whitehall Publisher, we've identified what data we need to extract by [extracting](https://github.com/alphagov/whitehall/pull/9626/commits/0b0f1b9a87f67cdc47c6f001a67132c75874e943) all the `AttachmentData`s where the [deleted?](https://github.com/alphagov/whitehall/blob/54f6ad01441f342d6d4906e5bdd8da92d5639874/app/models/attachment_data.rb#L91) method is false and relevant database fields to help guide our understanding of the data. The core theory was that assets corresponding to superseded or deleted editions, where the`AttachmentData`'s  `deleted?` method is false, should be further replaced or otherwise deleted, unless they have been redirected. 

This is the second part of the data extraction - see first part [here](https://github.com/alphagov/asset-manager/pull/1543#:~:text=card%20here.-,The%20data%20extraction,-We%20now%20know). Splitting the data extraction based on the [deleted?](https://github.com/alphagov/whitehall/blob/54f6ad01441f342d6d4906e5bdd8da92d5639874/app/models/attachment_data.rb#L91) method evaluation was a way to reason about deletion state in `whitehall`, since there is no obvious way in which that state is represented in the database. Whilst a soft delete is applied to the `Attachment` model, it is the `AttachmentData` model that actually manages the `Assets.` It deduces the deletion state based on the `Attachment` state and the `Edition `visibility. This logic is captured in this `deleted?` method, which is evaluated whenever we try to update `asset-manager`. It must be true for a delete value to be sent, and false for the other updates to be sent through - `replacement`, `draft`, `redirect_url`. 

NB: Whilst we have extracted data throughly, tackled the known bugs, and otherwise deleted all other assets we've reported on, there is a chance we may have missed some scenarios. This data is restricted to superseded and deleted editions and should have exhaustively fixed or deleted assets that pertain **only** to superseded and deleted editions. Anything outside of that has not been tackled here. Additionally, the current data extracted to be fixed is based on an older integration dump (end of October 2024), meaning there may be wrong `Assets` that got created between then and the time an upcoming code fix goes live. Nonetheless, this data patch should eliminate a great deal of risk from past data.

# Related fixes
We've also identified a broken flow that causes missing replacement links. If the user makes a new edition draft, and proceeds to make an attachment replacement without having saved the draft first, the live assets do not get set with a replacement in `asset-manager`. These assets will be fixed by running some updater logic from a [whitehall rake task](https://github.com/alphagov/whitehall/pull/9701). That will be run prior to this rake task, so that we have healthy replacement chains that we can then further fix.

Upcoming work will also tackle unpublished editions, ensuring redirects are set accordingly.

# Next steps
We'll attempt to fix the logic that causes the ongoing issues in an [upcoming card](https://trello.com/c/I2Fmtu3L/3185-fix-bug-causing-assets-to-be-live-when-they-should-not-be). The way in which we're proposing to fix the data in this rake task will translate to how we'll remedy the logic in `whitehall`. Fixing this data removes a big part of the risk, as does fixing the code. Nonetheless, there are batches of assets we've looked at, whose states we cannot account for. We've started ideating around some remodelling work of the attachments/assets workflow, to make it simpler, easier to understand and maintain, and bug-free.

# Links 
[Trello card](https://trello.com/c/YIs8YZmF/3146-investigate-attachments-on-superseded-editions-that-may-still-be-live)
[Assets investigation document](https://docs.google.com/document/d/11sFE7mxYeV8bEU_y4bU47L5rJT_jN-3IvFdbdvCr00w/edit?pli=1&tab=t.x2ilsr2t0bw3#heading=h.l5g5c38ze8k1)


Co-authored-by @minhngocd