### PR TITLE
WIP redirect favicon.ico requests to www.gov.uk/favicon.ico

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     Healthcheck::CloudStorage,
   )
 
+  get "/favicon.ico" => redirect("https://www.gov.uk/favicon.ico")
+
   resources :assets, only: %i[show create update destroy] do
     member do
       post :restore


### PR DESCRIPTION
- now that static isn't serving favicon.ico, we need to serve it on assets.publishing.service.gov.uk somehow, this seems the simplest solution.
- TODO: tests, redirect to appropriate environment?

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
