### PR TITLE
Update brakeman ignore filename and fingerprint

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,10 +3,10 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "cafb3c946b3ea6de50534f77286cf66f551d21910ceab7916651d888f5eb2280",
+      "fingerprint": "155e44e14f18fda5a12398863221313972bc9d88e342059541442a7fc295de57",
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
-      "file": "app/workers/delete_asset_file_from_nfs_worker.rb",
+      "file": "app/sidekiq/delete_asset_file_from_nfs_job.rb",
       "line": 8,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "FileUtils.rm_rf(File.dirname(Asset.find(asset_id).file.path))",


### PR DESCRIPTION
A file was renamed in a1ead6a827f80dbf0c4c030626edac8ebda62c1d but the corresponding entry in the brakeman ignore file was not updated.

Therefore updating to stop the warning being raised, even though we previously intended for it to be ignored.

[Trello card](https://trello.com/c/p1A4ztJl)