### PR TITLE
Allow updates to draft deleted assets

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -2,7 +2,7 @@ class AssetsController < BaseAssetsController
   before_action :restrict_request_format
 
   def update
-    @asset = find_asset
+    @asset = Asset.undeleted.or(Asset.where(draft: true)).find(params[:id])
 
     if @asset.update(asset_params)
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -392,6 +392,22 @@ RSpec.describe AssetsController, type: :controller do
 
           expect(body["draft"]).to be_truthy
         end
+
+        it "changes draft state for draft deleted asset" do
+          asset.update!(deleted_at: 1.hour.ago, draft: true)
+
+          put :update, params: { id: asset.id, asset: attributes.merge(draft: false) }
+
+          expect(asset.reload).not_to be_draft
+        end
+
+        it "preserves draft state for live deleted asset" do
+          asset.update!(deleted_at: 1.hour.ago, draft: false)
+
+          put :update, params: { id: asset.id, asset: attributes.merge(draft: true) }
+
+          expect(asset.reload).not_to be_draft
+        end
       end
     end
   end


### PR DESCRIPTION
In publishing apps (Whitehall), we have the following issue:

1. User replaces an attachment asset with a new one on a new edition of a published document.
2. User deletes the attachment.
3. User publishes the new edition of the document.
4. Replaced attachment asset remains live.

This happens because the deleted asset still has a value of "false" for the draft attribute, so the replacement on the old asset is not active. 

Since the user has deleted the attachment (in the publishing app), they are unlikely to become aware of the issue of the original asset remaining live. Because documents can have replacements across multiple editions, one such unintended live asset implicitly causes all the replaced assets pointing to it to implicitly remain live, providing outdated information to the public.

Whitehall attempts to update the deleted asset at the point of publish, but it is unable to do so because of [internal checks](https://github.com/alphagov/whitehall/blob/3971e93a2c7612d95e38c439c4bbf9752eaf5c2c/app/services/asset_manager/attachment_updater.rb#L3). These checks are aligned with the previous behaviour in Asset Manager: updates to deleted assets are not allowed. 

In order to address this, we propose allowing the update of draft deleted assets. Given that assets are still live on GOV.UK until they are both "deleted" and "live" (i.e. have a draft value of "false"), we are more accurately fulfilling the intent of the API by allowing updates to deleted draft assets. For this reason, we argue that this is not a breaking change.


[Trello](https://trello.com/c/I2Fmtu3L/3185-fix-draft-setting-causing-assets-to-be-live-when-they-should-not-be)
