### PR TITLE
Remove frozen string literal override

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class MediaController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :set_token_payload


### PR DESCRIPTION
Ruby 3.4 enables frozen string literals by default, so we no longer need to declare it in multiple places across the application.<br><br>[Release notes](https://github.com/ruby/ruby/releases/tag/v3_4_0)