### PR TITLE
Explicitly require "ostruct" in bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "mongo", "~> 2.23.0"
 gem "mongoid"
 gem "nokogiri"
 gem "observer"
+gem "ostruct" # Remove once included in mongoid
 gem "plek"
 gem "rack_strip_client_ip"
 gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -799,6 +799,7 @@ DEPENDENCIES
   mongoid
   nokogiri
   observer
+  ostruct
   pact (~> 1.67)
   pact_broker-client
   plek


### PR DESCRIPTION
In Ruby 4.0, some standard library components (including ostruct) are no longer automatically available as “default gems.” So when something like Mongoid tries to `require 'ostruct'` it fails with:

```
from /app/bin/puma:16:in '<main>'
/usr/local/lib/ruby/4.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- ostruct (LoadError) Did you mean?  tsort
	from /usr/local/lib/ruby/4.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from /usr/local/bundle/ruby/4.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
	from /usr/local/bundle/ruby/4.0/gems/mongoid-9.0.10/lib/mongoid/indexable.rb:6:in '<main>'
```

Also run `bundle binstubs --all`

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
