### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,20 @@ updates:
       default-days: 3
     schedule:
       interval: daily
+    groups:
+      test:
+        patterns:
+          - "climate_control"
+          - "database_cleaner-*"
+          - "factory_bot*"
+          - "pact*"
+          - "rspec-*"
+          - "simplecov"
+          - "webmock"
+      mongo: 
+        patterns:
+          - "mongo*"
+          - "*-mongoid"
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,15 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     allow:
       - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
-    schedule:
-      interval: daily
     groups:
       test:
         patterns:
@@ -31,17 +33,22 @@ updates:
   # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 25
-    schedule:
-      interval: weekly
     ignore:
       - dependency-name: ruby
+
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
-    schedule:
-      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily
 
@@ -12,11 +14,15 @@ updates:
   # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
     ignore:
       - dependency-name: ruby
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     schedule:
       interval: daily
     groups:
@@ -30,6 +31,7 @@ updates:
     directory: /
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 25
     schedule:
       interval: weekly
     ignore:
@@ -38,5 +40,6 @@ updates:
     directory: /
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     schedule:
       interval: daily


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.