### PR TITLE
Upgrade net-imap to 0.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
Dependabot failed to generate the PR. Generated with `bundle update net-imap`.

To address:
- https://github.com/alphagov/asset-manager/security/dependabot/98
- https://github.com/alphagov/asset-manager/security/dependabot/99
- https://github.com/alphagov/asset-manager/security/dependabot/100
- https://github.com/alphagov/asset-manager/security/dependabot/101
- https://github.com/alphagov/asset-manager/security/dependabot/102

