### PR TITLE
[PP-7726] Add new 'scanning' state to the Asset state machine

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -90,8 +90,12 @@ class Asset
       block.call
     end
 
+    event :begun_scan do
+      transition unscanned: :scanning
+    end
+
     event :scanned_clean do
-      transition unscanned: :clean
+      transition scanning: :clean
     end
 
     after_transition to: :clean do |asset, _|
@@ -99,7 +103,7 @@ class Asset
     end
 
     event :scanned_infected do
-      transition unscanned: :infected
+      transition scanning: :infected
     end
 
     event :upload_success do

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -7,11 +7,13 @@ class VirusScanJob
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
+    initial_digest = asset.md5_hexdigest
     if asset.unscanned?
       begin
+        asset.begun_scan!
         Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
         Services.virus_scanner.scan(asset.file.path)
-        asset.scanned_clean!
+        asset.scanned_clean! if asset.reload.md5_hexdigest == initial_digest
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,10 +3,16 @@ FactoryBot.define do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset.png")) }
   end
   factory :clean_asset, parent: :asset do
-    after :create, &:scanned_clean!
+    after :create do |a|
+      a.begun_scan!
+      a.scanned_clean!
+    end
   end
   factory :infected_asset, parent: :asset do
-    after :create, &:scanned_infected!
+    after :create do |a|
+      a.begun_scan!
+      a.scanned_infected!
+    end
   end
   factory :uploaded_asset, parent: :clean_asset do
     after :create, &:upload_success!
@@ -26,7 +32,10 @@ FactoryBot.define do
   end
 
   factory :clean_whitehall_asset, parent: :whitehall_asset do
-    after :create, &:scanned_clean!
+    after :create do |a|
+      a.begun_scan!
+      a.scanned_clean!
+    end
   end
 
   factory :uploaded_whitehall_asset, parent: :clean_whitehall_asset do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -524,7 +524,13 @@ RSpec.describe Asset, type: :model do
       allow(SaveToCloudStorageJob).to receive(:perform_async)
     end
 
+    it "cannot transition asset state straight to scanned clean" do
+      expect { asset.scanned_clean! }
+         .to raise_error(StateMachines::InvalidTransition)
+    end
+
     it "sets the asset state to clean" do
+      asset.begun_scan!
       asset.scanned_clean!
 
       expect(asset.reload).to be_clean
@@ -533,6 +539,7 @@ RSpec.describe Asset, type: :model do
     it "schedules saving the asset to cloud storage" do
       expect(SaveToCloudStorageJob).to receive(:perform_async).with(asset.id)
 
+      asset.begun_scan!
       asset.scanned_clean!
     end
 
@@ -568,13 +575,20 @@ RSpec.describe Asset, type: :model do
     let(:state) { "unscanned" }
     let(:asset) { FactoryBot.build(:asset, state:) }
 
+    it "cannot transition asset state straight to scanned infected" do
+      expect { asset.scanned_infected! }
+         .to raise_error(StateMachines::InvalidTransition)
+    end
+
     it "does not schedule saving the asset to cloud storage" do
       expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
 
+      asset.begun_scan!
       asset.scanned_infected!
     end
 
     it "sets the asset state to infected" do
+      asset.begun_scan!
       asset.scanned_infected!
 
       expect(asset.reload).to be_infected

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe "Asset requests", type: :request do
         threads << Thread.new do
           sleep(0.5)
           asset = Asset.find(asset_id)
+          asset.begun_scan!
           asset.scanned_clean!
         end
       end


### PR DESCRIPTION
This is to prevent a possible race condition where a file could be uploaded to be scanned, then while scanning is still going on, the file is updated. Then despite the virus scan being queued again, the original scan would pass and flag the now updated asset as clean. This could be leveraged to pass infected assets through the clamAV scanning.

Implementing the 'scanning' state prevents this by having a transition rule in place that means every asset must have a 'scanning' state before having a 'clean' or 'infected' state. Then if an asset is updated mid-scan, it's state will be reset to 'unscanned' and the original scan will fail with a InvalidTransition Exception.

I've also included a change to the logic of the VirusScanWorker, where it will now check that the hex_digest of the file it's scanning has not changed during the course of the scan. As though the scanning state mostly closed this loophole and stopped infected assets that were still waiting on the queue from being uploaded, if the infected asset scan started while the initial clean asset was still being scanned, a race condition was still possible. This change prevents that by checking the file itself has not changed during the course of the scan.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
