### PR TITLE
[PP-7726] Fix possible race condition is Asset virus scanning

### DIFF
--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -3,15 +3,18 @@ require "services"
 class VirusScanJob
   include Sidekiq::Job
 
-  sidekiq_options lock: :until_and_while_executing
+  sidekiq_options lock: :until_executing
+
+  class AssetReplaced < StandardError; end
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
     if asset.unscanned?
       begin
+        initial_digest = asset.md5_hexdigest
         Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
         Services.virus_scanner.scan(asset.file.path)
-        asset.scanned_clean!
+        asset.reload.md5_hexdigest == initial_digest ? asset.scanned_clean! : Rails.logger.info("#{asset.id} VirusScanJob checksum failed")
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!

--- a/spec/sidekiq/virus_scan_job_spec.rb
+++ b/spec/sidekiq/virus_scan_job_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe VirusScanJob do
       allow(scanner).to receive(:scan).and_return(true)
     end
 
+    context "but no longer matches the file associated with the asset" do
+      before do
+        allow(asset).to receive(:md5_hexdigest).twice.and_return("foo", "bar")
+        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(Rails.logger).to receive(:info).at_least(:once)
+      end
+
+      it "logs the job failure and does not update the asset's state" do
+        worker.perform(asset.id)
+        expect(Rails.logger).to have_received(:info).with("#{asset.id} VirusScanJob checksum failed").once
+        expect(asset.reload).not_to be_clean
+      end
+    end
+
     it "sets the state to clean" do
       worker.perform(asset.id)
 


### PR DESCRIPTION
This fixes a possible race condition in the asset_manager virus scanning where an Asset could be updated shortly after it was initially uploaded, and while the initial virus scan is taking place. Theoretically an infected file could then replace the original, as when the original virus scan reports success (these are run asyncronously), the asset will be marked as clean and uploaded, despite having been altered.

This change prevents that by saving the original hex_digest at the start of the job, then verifying it's the same before granting `clean` status. If not it raises an `AssetReplaced` exception.

Previous approach [here](https://github.com/alphagov/asset-manager/pull/1948) for context 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
