### PR TITLE
[PP-7718] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.308.0
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -46,11 +46,11 @@ jobs:
       TEST_MONGODB_URI: "mongodb://localhost:27017/test-db"
       RAILS_ENV: test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: alphagov/asset-manager
           ref: ${{ inputs.ref }}
-      - uses: ruby/setup-ruby@v1.308.0
+      - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           bundler-cache: true
       - run: bundle exec rails db:setup
@@ -59,7 +59,7 @@ jobs:
         env:
           PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
       - if: inputs.pact_artifact != ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.pact_artifact }}
           path: tmp/pacts


### PR DESCRIPTION
Pins non-alphagov actions to a commit SHA.

As per [policy](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha).