### PR TITLE
Add state transition diagram to the docs

### DIFF
--- a/docs/asset_state_machine_overview.md
+++ b/docs/asset_state_machine_overview.md
@@ -15,9 +15,46 @@ Assets must be in draft for certain authorisation protocols to apply. See [docum
 2. `state`
 
 This is a representation of the internal Asset Manager processing of the asset, particularly around uploading and virus scanning status.
-The state machine includes `scanned_clean`, `clean`, `scanned_infected`, `upload_success`, `uploaded`.
+The state machine includes `scanned_clean`, `clean`, `scanned_infected`, `infected`, `upload_success`, `uploaded`.
 
 NB: There are some invalid remnants of a previous state machine, including state values such as `deleted`, in the database. These should be removed.
+
+```
+┌──────────────┐
+│  Unscanned   │
+│  (Initial)   │
+└──────┬───────┘
+       │
+       ▼
+[VirusScanJob triggered]
+       │
+       ▼
+[Virus scan performed]
+           │
+   ┌───────┴────────┐
+   │                │
+   ▼                ▼
+(scanned_clean)   (scanned_infected)
+   │                │
+   ▼                ▼
+┌──────────┐    ┌────────────┐
+│  Clean   │    │  Infected  │
+└────┬─────┘    └────────────┘
+     │
+     ▼
+[SaveToCloudStorageJob triggered]
+     │
+     ▼
+[Asset uploaded to AWS S3 bucket]
+     │
+     ▼
+(upload_success)
+     │
+     ▼
+┌──────────┐
+│ Uploaded │
+└──────────┘
+```
 
 3. `deleted_at`
 


### PR DESCRIPTION
To visualise states and transition events on POST /assets API call.

[✨  Rendered doc](https://github.com/alphagov/asset-manager/blob/47e98192df450f64880f986f7e6ea1eab44fb5ff/docs/asset_state_machine_overview.md)