### PR TITLE
[PP-7719] Add svg scanning to Asset manager

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -90,8 +90,20 @@ class Asset
       block.call
     end
 
-    event :scanned_clean do
-      transition unscanned: :clean
+    event :virus_scanned_clean do
+      transition unscanned: :virus_scanned_clean
+    end
+
+    after_transition to: :virus_scanned_clean do |asset, _|
+      asset.schedule_svg_scan
+    end
+
+    event :svg_scan_skipped do
+      transition virus_scanned_clean: :clean
+    end
+
+    event :svg_scanned_clean do
+      transition virus_scanned_clean: :clean
     end
 
     after_transition to: :clean do |asset, _|
@@ -100,6 +112,10 @@ class Asset
 
     event :scanned_infected do
       transition unscanned: :infected
+    end
+
+    event :scanned_infected do
+      transition virus_scanned_clean: :infected
     end
 
     event :upload_success do
@@ -219,6 +235,10 @@ class Asset
   def initialize_dup(other)
     @_mounters = nil
     super
+  end
+
+  def schedule_svg_scan
+    Marcel::MimeType.for(Pathname.new(file.path)) == "image/svg+xml" ? SvgScanJob.perform_async(id.to_s) : svg_scan_skipped!
   end
 
 protected

--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -1,0 +1,10 @@
+module EnsureFile
+  extend ActiveSupport::Concern
+
+  def ensure_file_is_same_after_scan(asset, job_name, next_state)
+    initial_digest = asset.md5_hexdigest
+    Rails.logger.info("#{asset.id} - #{job_name}#perform - scan started")
+    yield
+    asset.reload.md5_hexdigest == initial_digest ? asset.send(next_state) : Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+  end
+end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -1,0 +1,23 @@
+require "services"
+
+class SvgScanJob
+  include Sidekiq::Job
+  include EnsureFile
+
+  sidekiq_options lock: :until_executing
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    if asset.scanned_clean?
+      begin
+        Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
+        ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do
+          Services.svg_scanner.scan(asset.file.path)
+        end
+      rescue SvgDocument::UnsafeSvg => e
+        GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+        asset.scanned_infected!
+      end
+    end
+  end
+end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -8,7 +8,7 @@ class SvgScanJob
 
   def perform(asset_id)
     asset = Asset.find(asset_id)
-    if asset.scanned_clean?
+    if asset.virus_scanned_clean?
       begin
         Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
         ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -22,5 +22,3 @@ class VirusScanJob
     end
   end
 end
-
-VirusScanWorker = VirusScanJob

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -13,7 +13,7 @@ class VirusScanJob
     if asset.unscanned?
       begin
         Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
-        ensure_file_is_same_after_scan(asset, "VirusScanJob", :scanned_clean!) do
+        ensure_file_is_same_after_scan(asset, "VirusScanJob", :virus_scanned_clean!) do
           Services.virus_scanner.scan(asset.file.path)
         end
       rescue VirusScanner::InfectedFile => e

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -2,6 +2,7 @@ require "services"
 
 class VirusScanJob
   include Sidekiq::Job
+  include EnsureFile
 
   sidekiq_options lock: :until_executing
 
@@ -11,10 +12,10 @@ class VirusScanJob
     asset = Asset.find(asset_id)
     if asset.unscanned?
       begin
-        initial_digest = asset.md5_hexdigest
         Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
-        Services.virus_scanner.scan(asset.file.path)
-        asset.reload.md5_hexdigest == initial_digest ? asset.scanned_clean! : Rails.logger.info("#{asset.id} VirusScanJob checksum failed")
+        ensure_file_is_same_after_scan(asset, "VirusScanJob", :scanned_clean!) do
+          Services.virus_scanner.scan(asset.file.path)
+        end
       rescue VirusScanner::InfectedFile => e
         GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
         asset.scanned_infected!

--- a/docs/asset_state_machine_overview.md
+++ b/docs/asset_state_machine_overview.md
@@ -15,45 +15,26 @@ Assets must be in draft for certain authorisation protocols to apply. See [docum
 2. `state`
 
 This is a representation of the internal Asset Manager processing of the asset, particularly around uploading and virus scanning status.
-The state machine includes `scanned_clean`, `clean`, `scanned_infected`, `infected`, `upload_success`, `uploaded`.
 
 NB: There are some invalid remnants of a previous state machine, including state values such as `deleted`, in the database. These should be removed.
 
-```
-┌──────────────┐
-│  Unscanned   │
-│  (Initial)   │
-└──────┬───────┘
-       │
-       ▼
-[VirusScanJob triggered]
-       │
-       ▼
-[Virus scan performed]
-           │
-   ┌───────┴────────┐
-   │                │
-   ▼                ▼
-(scanned_clean)   (scanned_infected)
-   │                │
-   ▼                ▼
-┌──────────┐    ┌────────────┐
-│  Clean   │    │  Infected  │
-└────┬─────┘    └────────────┘
-     │
-     ▼
-[SaveToCloudStorageJob triggered]
-     │
-     ▼
-[Asset uploaded to AWS S3 bucket]
-     │
-     ▼
-(upload_success)
-     │
-     ▼
-┌──────────┐
-│ Uploaded │
-└──────────┘
+```mermaid
+flowchart TD
+    Unscanned("Unscanned\n(Initial)") --> TriggerVirusScan["VirusScanJob triggered"]
+    TriggerVirusScan --> VirusScanPerformed["Virus scan performed"]
+
+    VirusScanPerformed -->|virus_scanned_clean| VirusScannedClean("Virus Scanned Clean")
+    VirusScanPerformed -->|scanned_infected| Infected("Infected")
+
+    VirusScannedClean --> TriggerSvgScan["SvgScanJob triggered"]
+    TriggerSvgScan --> SvgScanPerformed["SVG scan performed"]
+
+    SvgScanPerformed -->|svg_scanned_clean| Clean("Clean")
+    SvgScanPerformed -->|scanned_infected| Infected("Infected")
+
+    Clean --> TriggerSaveToCloudStorageJob["SaveToCloudStorageJob triggered"]
+    TriggerSaveToCloudStorageJob --> Upload["Asset uploaded to AWS S3 bucket"]
+    Upload -->|upload_success| Uploaded("Uploaded")
 ```
 
 3. `deleted_at`
@@ -63,14 +44,14 @@ A `nil` value means the asset has not been deleted (default).
 
 4. `replacement_id`
 
-This is a BSON object ID, set by the publishing app when the user uploads a new file in the place of an old one, typically with the intention of preserving some contextual document metadata. 
+This is a BSON object ID, set by the publishing app when the user uploads a new file in the place of an old one, typically with the intention of preserving some contextual document metadata.
 Default is `nil`. The replaced asset redirects to its replacement, provided the replacement is not in draft.
 
 Whilst deletion and replacements are mutually exclusive (an asset should not logically have both), they do coexist in the database.
 Deletion, replacement, and draft work together to support previewing of draft content. An asset will not redirect to its replacement if the replacement is in draft.
 This ensures that until the publish event is fired, the users can preview images and documents on the draft stack.
 
-Publishing applications only send the next-in-line `replacement_id`. 
+Publishing applications only send the next-in-line `replacement_id`.
 It is Asset Manager that deals with backpropagating the replacement - see the `update_indirect_replacements_on_publish` [callback](https://github.com/alphagov/asset-manager/blob/13d68aee4d0c8cf2c81be7fafef309dc36436ca3/app/models/asset.rb#L174).
 This ensures that all assets in a chain of replacements redirect to the latest one.
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -6,6 +6,10 @@ module Services
     @cloud_storage ||= S3Storage.build
   end
 
+  def self.svg_scanner
+    @svg_scanner ||= SvgScanner.new
+  end
+
   def self.virus_scanner
     @virus_scanner ||= VirusScanner.new
   end

--- a/lib/svg_scanner.rb
+++ b/lib/svg_scanner.rb
@@ -1,0 +1,36 @@
+class SvgDocument < Nokogiri::XML::SAX::Document
+  class UnsafeSvg < StandardError; end
+
+  UNSAFE_ELEMENTS = %w[script foreignobject iframe object].freeze
+
+  def start_element(name, attrs = [])
+    element_name = name.downcase
+
+    if UNSAFE_ELEMENTS.include?(element_name)
+      raise UnsafeSvg, "SVG: Unsafe element detected: <#{name}>"
+    end
+
+    attrs.each do |attr_name, attr_value|
+      attr_name_lower = attr_name.downcase
+
+      if attr_name_lower.start_with?("on") # e.g. onload, onerror, onclick
+        raise UnsafeSvg, "SVG: Unsafe event handler detected: '#{attr_name}' on <#{name}>"
+      end
+
+      if attr_value.to_s.strip.downcase.start_with?("javascript:") # e.g., href="javascript:alert(1)"
+        raise UnsafeSvg, "SVG: Unsafe javascript URI detected in '#{attr_name}' attribute on <#{name}>"
+      end
+    end
+  end
+end
+
+class SvgScanner
+  def scan(file_path)
+    parser = Nokogiri::XML::SAX::Parser.new(SvgDocument.new)
+
+    File.open(file_path) do |file|
+      parser.parse_io(file)
+    end
+    true
+  end
+end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -2,13 +2,45 @@ FactoryBot.define do
   factory :asset do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset.png")) }
   end
+
   factory :clean_asset, parent: :asset do
-    after :create, &:scanned_clean!
+    after :create, &:virus_scanned_clean!
   end
+
   factory :infected_asset, parent: :asset do
     after :create, &:scanned_infected!
   end
+
   factory :uploaded_asset, parent: :clean_asset do
+    after :create, &:upload_success!
+  end
+
+  factory :svg_asset_safe, parent: :asset do
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-safe.svg")) }
+    after :create, &:virus_scanned_clean!
+  end
+
+  factory :svg_asset_clean, parent: :svg_asset_safe do
+    after :create, &:svg_scanned_clean!
+  end
+
+  factory :svg_asset_unsafe_element, parent: :asset do
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-element.svg")) }
+  end
+
+  factory :svg_asset_unsafe_event_handler, parent: :asset do
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-event-handler.svg")) }
+  end
+
+  factory :svg_asset_unsafe_uri, parent: :asset do
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-uri.svg")) }
+  end
+
+  factory :svg_infected_asset, parent: :svg_asset_safe do
+    after :create, &:scanned_infected!
+  end
+
+  factory :svg_uploaded_asset, parent: :svg_asset_clean do
     after :create, &:upload_success!
   end
 
@@ -26,7 +58,7 @@ FactoryBot.define do
   end
 
   factory :clean_whitehall_asset, parent: :whitehall_asset do
-    after :create, &:scanned_clean!
+    after :create, &:virus_scanned_clean!
   end
 
   factory :uploaded_whitehall_asset, parent: :clean_whitehall_asset do

--- a/spec/fixtures/files/asset-safe.svg
+++ b/spec/fixtures/files/asset-safe.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"/>

--- a/spec/fixtures/files/asset-unsafe-element.svg
+++ b/spec/fixtures/files/asset-unsafe-element.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <script type="text/javascript">
+    <![CDATA[
+      alert("<script> element");
+    ]]>
+  </script>
+</svg>

--- a/spec/fixtures/files/asset-unsafe-event-handler.svg
+++ b/spec/fixtures/files/asset-unsafe-event-handler.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" onload="alert('onload attribute')"/>

--- a/spec/fixtures/files/asset-unsafe-uri.svg
+++ b/spec/fixtures/files/asset-unsafe-uri.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <a href="javascript:alert('javascript URI')">
+    <rect width="100" height="100" fill="blue" />
+  </a>
+</svg>

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "cli"
 
-RSpec.describe CLI, type: :model do
+RSpec.describe CLI, type: :file_handler do
   subject(:cli) { described_class.new(output, kernel) }
 
   let(:output) { StringIO.new }

--- a/spec/lib/svg_scanner_spec.rb
+++ b/spec/lib/svg_scanner_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+require "svg_scanner"
+
+RSpec.describe SvgScanner, type: :file_handler do
+  describe "scanning an SVG file" do
+    subject(:scanner) { described_class.new }
+
+    let(:safe_file_path) { fixture_file_path("asset-safe.svg") }
+    let(:unsafe_element_file_path) { fixture_file_path("asset-unsafe-element.svg") }
+    let(:unsafe_event_handler_file_path) { fixture_file_path("asset-unsafe-event-handler.svg") }
+    let(:unsafe_uri_file_path) { fixture_file_path("asset-unsafe-uri.svg") }
+
+    context "when SVG is safe" do
+      it "returns true" do
+        expect(scanner.scan(safe_file_path)).to be true
+      end
+    end
+
+    context "when SVG contains an unsafe element" do
+      it "raises a relevant error" do
+        expect {
+          scanner.scan(unsafe_element_file_path)
+        }.to raise_error(
+          SvgDocument::UnsafeSvg, "SVG: Unsafe element detected: <script>"
+        )
+      end
+    end
+
+    context "when SVG contains an unsafe event handler" do
+      it "raises a relevant error" do
+        expect {
+          scanner.scan(unsafe_event_handler_file_path)
+        }.to raise_error(
+          SvgDocument::UnsafeSvg, "SVG: Unsafe event handler detected: 'onload' on <svg>"
+        )
+      end
+    end
+
+    context "when SVG contains an unsafe URI" do
+      it "raises a relevant error" do
+        expect {
+          scanner.scan(unsafe_uri_file_path)
+        }.to raise_error(
+          SvgDocument::UnsafeSvg, "SVG: Unsafe javascript URI detected in 'href' attribute on <a>"
+        )
+      end
+    end
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -516,8 +516,30 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "scheduling an SVG scan" do
+    it "schedules a scan after a clean virus scan" do
+      a = described_class.new(file: load_fixture_file("asset-safe.svg"))
+
+      expect(SvgScanJob).to receive(:perform_async).with(a.id)
+
+      a.virus_scanned_clean!
+    end
+
+    it "schedules another scan after saving a file" do
+      a = FactoryBot.create(:svg_asset_clean)
+      a.file = load_fixture_file("asset-safe.svg")
+
+      expect(SvgScanJob).to receive(:perform_async).with(a.id)
+
+      a.save!
+
+      allow(Services.virus_scanner).to receive(:scan)
+      VirusScanJob.drain
+    end
+  end
+
   describe "when an asset is marked as clean" do
-    let(:state) { "unscanned" }
+    let(:state) { "virus_scanned_clean" }
     let(:asset) { FactoryBot.build(:asset, state:) }
 
     before do
@@ -525,7 +547,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it "sets the asset state to clean" do
-      asset.scanned_clean!
+      asset.svg_scanned_clean!
 
       expect(asset.reload).to be_clean
     end
@@ -533,14 +555,14 @@ RSpec.describe Asset, type: :model do
     it "schedules saving the asset to cloud storage" do
       expect(SaveToCloudStorageJob).to receive(:perform_async).with(asset.id)
 
-      asset.scanned_clean!
+      asset.svg_scanned_clean!
     end
 
     context "when asset is already clean" do
       let(:state) { "clean" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_clean! }
+        expect { asset.virus_scanned_clean! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -549,7 +571,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "infected" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_clean! }
+        expect { asset.virus_scanned_clean! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -558,7 +580,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "uploaded" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_clean! }
+        expect { asset.virus_scanned_clean! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Asset requests", type: :request do
         threads << Thread.new do
           sleep(0.5)
           asset = Asset.find(asset_id)
-          asset.scanned_clean!
+          asset.virus_scanned_clean!
         end
       end
 

--- a/spec/requests/virus_scanning_spec.rb
+++ b/spec/requests/virus_scanning_spec.rb
@@ -36,4 +36,35 @@ RSpec.describe "Virus scanning of uploaded images", :disable_cloud_storage_stub,
     get redirect_url
     expect(response).to have_http_status(:success)
   end
+
+  specify "a clean SVG asset is available after virus scanning & uploading to cloud storage" do
+    post "/assets", params: { asset: { file: load_fixture_file("asset-safe.svg") } }
+    expect(response).to have_http_status(:created)
+
+    asset = Asset.last
+
+    asset_details = JSON.parse(response.body)
+    expect(asset_details["id"]).to match(%r{http://www.example.com/assets/#{asset.id}})
+
+    get download_media_path(id: asset, filename: "asset-safe.svg")
+    expect(response).to have_http_status(:not_found)
+
+    allow(Services.virus_scanner).to receive(:scan)
+    VirusScanJob.drain
+
+    allow(Services.svg_scanner).to receive(:scan)
+    SvgScanJob.drain
+
+    get download_media_path(id: asset, filename: "asset-safe.svg")
+    expect(response).to have_http_status(:not_found)
+
+    SaveToCloudStorageJob.drain
+
+    get download_media_path(id: asset, filename: "asset-safe.svg")
+    expect(response).to have_http_status(:found)
+
+    redirect_url = headers["location"]
+    get redirect_url
+    expect(response).to have_http_status(:success)
+  end
 end

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+require "services"
+require "sidekiq_unique_jobs/testing"
+
+RSpec.describe SvgScanJob do
+  let(:worker) { described_class.new }
+  let(:asset) { FactoryBot.create(:svg_asset_safe) }
+  let(:scanner) { instance_double(SvgScanner) }
+
+  before do
+    allow(Services).to receive(:svg_scanner).and_return(scanner)
+  end
+
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
+  it "does not permit multiple jobs to be enqueued for the same asset" do
+    SidekiqUniqueJobs.use_config(enabled: true) do
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.to enqueue_sidekiq_job(described_class)
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.not_to enqueue_sidekiq_job(described_class)
+    end
+  end
+
+  it "calls out to the SvgScanner to scan the file" do
+    expect(scanner).to receive(:scan).with(asset.file.path)
+
+    worker.perform(asset.id)
+  end
+
+  context "when the file is clean" do
+    before do
+      allow(scanner).to receive(:scan).and_return(true)
+    end
+
+    context "but no longer matches the file associated with the asset" do
+      before do
+        allow(asset).to receive(:md5_hexdigest).twice.and_return("foo", "bar")
+        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(Rails.logger).to receive(:info).at_least(:once)
+      end
+
+      it "logs the job failure and does not update the asset's state" do
+        worker.perform(asset.id)
+        expect(Rails.logger).to have_received(:info).with("#{asset.id} SvgScanJob checksum failed").once
+        expect(asset.reload).not_to be_clean
+      end
+    end
+
+    it "sets the state to clean" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset).to be_clean
+    end
+  end
+
+  context "when the asset is already marked as clean" do
+    let(:asset) { FactoryBot.create(:svg_asset_clean) }
+
+    it "does not SVG scan file" do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the asset is already marked as infected" do
+    let(:asset) { FactoryBot.create(:svg_infected_asset) }
+
+    it "does not SVG scan file" do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the asset is already marked as uploaded" do
+    let(:asset) { FactoryBot.create(:svg_uploaded_asset) }
+
+    it "does not SVG scan file" do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the SVG asset is unsafe" do
+    let(:exception_message) { "SVG: Unsafe element detected: <script>" }
+    let(:exception) { SvgDocument::UnsafeSvg.new(exception_message) }
+
+    before do
+      allow(scanner).to receive(:scan).and_raise(exception)
+    end
+
+    it "sets the state to infected if the SVG asset is unsafe" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset).to be_infected
+    end
+
+    it "sends an exception notification" do
+      expect(GovukError).to receive(:notify)
+        .with(exception, extra: { id: asset.id, filename: asset.filename })
+
+      worker.perform(asset.id)
+    end
+  end
+end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -14,3 +14,4 @@ end
 RSpec.configuration.include FileHelpers, type: :model
 RSpec.configuration.include FileHelpers, type: :controller
 RSpec.configuration.include FileHelpers, type: :request
+RSpec.configuration.include FileHelpers, type: :file_handler


### PR DESCRIPTION
The PR adds the functionality to Asset Manager to scan SVG's for undesirable elements, mainly, but not limited to, script tags. 

The scanning itself relies on the Nokogiri Parser, to which we can pass in undesirable elements, in this case those are defined as `script foreignobject iframe object`.

The new scanner integrates with the existing state machine for each Asset, that was previously used just to check virus scanning and upload status. In addition, we've implemented Mimetype checking for the SVG scanner, so that files that are not SVG's are not unnecessarily scanned. The scanning job itself is run asynchronously in a similar fashion to the existing Virus Scanning job, and includes the hex_digest checksum validation, to ensure it's not vulnerable to a concurrent run/update race condition. 

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
