### PR TITLE
Bump `concurrent-ruby` to 1.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       mongoid (>= 3.0, < 10.0)
       mongoid-grid_fs (>= 1.3, < 3.0)
     climate_control (1.2.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal


### PR DESCRIPTION
Dependabot didn't seem able to make this change, but I have been able to do so by manually running `bundle update concurrent-ruby`.

This resolves https://github.com/alphagov/asset-manager/security/dependabot/110, https://github.com/alphagov/asset-manager/security/dependabot/112 and https://github.com/alphagov/asset-manager/security/dependabot/111.