### PR TITLE
Do not notify Sentry when an asset is marked as infected

### DIFF
--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -14,8 +14,8 @@ class SvgScanJob
         ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do
           Services.svg_scanner.scan(asset.file.path)
         end
-      rescue SvgDocument::UnsafeSvg => e
-        GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+      rescue SvgDocument::UnsafeSvg
+        Rails.logger.warn("#{asset_id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe")
         asset.scanned_infected!
       end
     end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -16,8 +16,8 @@ class VirusScanJob
         ensure_file_is_same_after_scan(asset, "VirusScanJob", :virus_scanned_clean!) do
           Services.virus_scanner.scan(asset.file.path)
         end
-      rescue VirusScanner::InfectedFile => e
-        GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+      rescue VirusScanner::InfectedFile
+        Rails.logger.warn("#{asset_id} - VirusScanJob#perform - File #{asset.filename} marked as infected")
         asset.scanned_infected!
       end
     end

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe SvgScanJob do
 
     before do
       allow(scanner).to receive(:scan).and_raise(exception)
+      allow(Rails.logger).to receive(:warn).at_least(:once)
     end
 
     it "sets the state to infected if the SVG asset is unsafe" do
@@ -98,11 +99,10 @@ RSpec.describe SvgScanJob do
       expect(asset).to be_infected
     end
 
-    it "sends an exception notification" do
-      expect(GovukError).to receive(:notify)
-        .with(exception, extra: { id: asset.id, filename: asset.filename })
-
+    it "logs the failure" do
       worker.perform(asset.id)
+
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe").once
     end
   end
 end

--- a/spec/sidekiq/virus_scan_job_spec.rb
+++ b/spec/sidekiq/virus_scan_job_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe VirusScanJob do
 
     before do
       allow(scanner).to receive(:scan).and_raise(exception)
+      allow(Rails.logger).to receive(:warn).at_least(:once)
     end
 
     it "sets the state to infected if a virus is found" do
@@ -98,11 +99,10 @@ RSpec.describe VirusScanJob do
       expect(asset).to be_infected
     end
 
-    it "sends an exception notification" do
-      expect(GovukError).to receive(:notify)
-        .with(exception, extra: { id: asset.id, filename: asset.filename })
-
+    it "logs the failure" do
       worker.perform(asset.id)
+
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - VirusScanJob#perform - File #{asset.filename} marked as infected").once
     end
   end
 end


### PR DESCRIPTION
We currently have two routes that an asset is marked as infected: it fails the virus scan or it fails the SVG content check.

On both of these, we log the event to Sentry. However there is no action that GOV.UK developers can take on receipt of this alert.

Therefore removing the logging to Sentry and instead changing this to write to the standard Rails logs at `info` level.

These will be logged in production as the log level [is currently `warn`](https://github.com/alphagov/govuk-helm-charts/blob/f6d1c25436def7ec6a9ae21609f2b29290290a37/charts/app-config/values-production.yaml#L205-L206).

In an ideal world, we would alert the publishing app (and therefore the publisher) that the asset has been marked as infected. This [will be covered](https://gov-uk.atlassian.net/browse/PP-7799) under planned work to improve Asset Manager later.