### PR TITLE
Pp 7805 scan existing svg files for potentially malicious content

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -53,6 +53,10 @@ class Asset
 
   field :deleted_at, type: Time
 
+  field :svg_scanned_at, type: Time
+
+  field :svg_scanned_safe, type: Boolean
+
   validates :file, presence: true, if: :unscanned?
 
   validates :uuid,
@@ -239,6 +243,10 @@ class Asset
 
   def schedule_svg_scan
     Marcel::MimeType.for(Pathname.new(file.path)) == "image/svg+xml" ? SvgScanJob.perform_async(id.to_s) : svg_scan_skipped!
+  end
+
+  def schedule_svg_batch_scan
+    SvgScanBatchJob.perform_async(id.to_s)
   end
 
 protected

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -114,11 +114,11 @@ class Asset
       SaveToCloudStorageJob.perform_async(asset.id.to_s)
     end
 
-    event :scanned_infected do
+    event :virus_scanned_infected do
       transition unscanned: :infected
     end
 
-    event :scanned_infected do
+    event :svg_scanned_infected do
       transition virus_scanned_clean: :infected
     end
 
@@ -129,6 +129,21 @@ class Asset
     after_transition to: :uploaded do |asset, _|
       asset.save!
       DeleteAssetFileFromNfsJob.perform_in(5.minutes, asset.id.to_s)
+    end
+
+    after_transition on: :virus_scanned_infected do |asset, _|
+      Rails.logger.warn("#{asset.id} - Virus Scan - File #{asset.filename} marked as infected")
+    end
+
+    after_transition on: :svg_scanned_clean do |asset, _|
+      asset.set(svg_scanned_at: Time.zone.now)
+      asset.set(svg_scanned_safe: true)
+    end
+
+    after_transition on: :svg_scanned_infected do |asset, _|
+      asset.set(svg_scanned_safe: false)
+      asset.set(svg_scanned_at: Time.zone.now)
+      Rails.logger.warn("#{asset.id} - SVG Scan - File #{asset.filename} marked as unsafe")
     end
   end
 

--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -1,14 +1,12 @@
 module EnsureFile
   extend ActiveSupport::Concern
 
-  def ensure_file_is_same_after_scan(asset, job_name, next_state)
+  def ensure_file_is_same_after_scan(asset, job_name, success_callback)
     initial_digest = asset.md5_hexdigest
     Rails.logger.info("#{asset.id} - #{job_name}#perform - scan started")
     yield
     if asset.reload.md5_hexdigest == initial_digest
-      asset.send(next_state)
-      asset.set(svg_scanned_safe: true)
-      asset.set(svg_scanned_at: Time.zone.now)
+      success_callback.call
     else
       Rails.logger.info("#{asset.id} #{job_name} checksum failed")
     end

--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -5,6 +5,12 @@ module EnsureFile
     initial_digest = asset.md5_hexdigest
     Rails.logger.info("#{asset.id} - #{job_name}#perform - scan started")
     yield
-    asset.reload.md5_hexdigest == initial_digest ? asset.send(next_state) : Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+    if asset.reload.md5_hexdigest == initial_digest
+      asset.send(next_state)
+      asset.set(svg_scanned_safe: true)
+      asset.set(svg_scanned_at: Time.zone.now)
+    else
+      Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+    end
   end
 end

--- a/app/sidekiq/svg_scan_batch_job.rb
+++ b/app/sidekiq/svg_scan_batch_job.rb
@@ -31,7 +31,7 @@ private
     asset.set(svg_scanned_safe: true)
   rescue SvgDocument::UnsafeSvg => e
     asset.set(svg_scanned_safe: false)
-    Rails.logger.info("#{asset.id} - SvgScanBatchJob#perform - SVG unsafe")
+    Rails.logger.warn("#{asset.id} - SVG Scan - File #{asset.filename} marked as unsafe")
     GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
   ensure
     asset.set(svg_scanned_at: Time.zone.now)

--- a/app/sidekiq/svg_scan_batch_job.rb
+++ b/app/sidekiq/svg_scan_batch_job.rb
@@ -1,0 +1,39 @@
+require "services"
+
+class SvgScanBatchJob
+  include Sidekiq::Job
+
+  sidekiq_options lock: :until_executing, queue: "batch"
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+
+    file = Services.cloud_storage.download(asset)
+
+    if Marcel::MimeType.for(Pathname.new(file.path)) == "image/svg+xml"
+      scan_svg(asset, file.path)
+    end
+  rescue Aws::S3::Errors::NoSuchKey
+    # File doesn't exist in S3. Nothing to do.
+    Rails.logger.info("#{asset_id} - SvgScanBatchJob#perform - Asset missing from S3")
+  ensure
+    if file.respond_to?(:path) && File.exist?(file.path)
+      file.close
+      file.unlink
+    end
+  end
+
+private
+
+  def scan_svg(asset, file_path)
+    Rails.logger.info("#{asset.id} - SvgScanBatchJob#perform - SVG scan started")
+    Services.svg_scanner.scan(file_path)
+    asset.set(svg_scanned_safe: true)
+  rescue SvgDocument::UnsafeSvg => e
+    asset.set(svg_scanned_safe: false)
+    Rails.logger.info("#{asset.id} - SvgScanBatchJob#perform - SVG unsafe")
+    GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+  ensure
+    asset.set(svg_scanned_at: Time.zone.now)
+  end
+end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -11,15 +11,12 @@ class SvgScanJob
     if asset.virus_scanned_clean?
       begin
         Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
-        ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do
+        ensure_file_is_same_after_scan(asset, "SvgScanJob", -> { asset.svg_scanned_clean! }) do
           Services.svg_scanner.scan(asset.file.path)
         end
       rescue SvgDocument::UnsafeSvg
-        Rails.logger.warn("#{asset_id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe")
-        asset.scanned_infected!
-        asset.set(svg_scanned_safe: false)
+        asset.svg_scanned_infected!
       end
-      asset.set(svg_scanned_at: Time.zone.now)
     end
   end
 end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -17,7 +17,9 @@ class SvgScanJob
       rescue SvgDocument::UnsafeSvg
         Rails.logger.warn("#{asset_id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe")
         asset.scanned_infected!
+        asset.set(svg_scanned_safe: false)
       end
+      asset.set(svg_scanned_at: Time.zone.now)
     end
   end
 end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -13,12 +13,11 @@ class VirusScanJob
     if asset.unscanned?
       begin
         Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
-        ensure_file_is_same_after_scan(asset, "VirusScanJob", :virus_scanned_clean!) do
+        ensure_file_is_same_after_scan(asset, "VirusScanJob", -> { asset.virus_scanned_clean! }) do
           Services.virus_scanner.scan(asset.file.path)
         end
       rescue VirusScanner::InfectedFile
-        Rails.logger.warn("#{asset_id} - VirusScanJob#perform - File #{asset.filename} marked as infected")
-        asset.scanned_infected!
+        asset.virus_scanned_infected!
       end
     end
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
 :queues:
   - default
   - low_priority
+  - batch

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,3 +1,4 @@
+require "tempfile"
 require "s3_storage/fake"
 
 class S3Storage
@@ -32,6 +33,15 @@ class S3Storage
         raise ObjectUploadFailedError, error_message
       end
     end
+  end
+
+  def download(asset, file: Tempfile.new(asset.uuid))
+    client.get_object(
+      bucket: @bucket_name,
+      key: asset.uuid,
+      response_target: file.path,
+    )
+    file
   end
 
   def delete(asset)

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -12,6 +12,13 @@ class S3Storage
       File.write(target_path, File.read(source_path))
     end
 
+    def download(asset, **_args)
+      source_path = source_path_for(asset)
+      download_path = download_path_for(asset)
+      FileUtils.mkdir_p(File.dirname(download_path))
+      File.write(download_path, File.read(source_path))
+    end
+
     def delete(asset, **_args)
       target_path = target_path_for(asset)
       File.delete(target_path)
@@ -48,6 +55,10 @@ class S3Storage
     def target_path_for(asset)
       relative_path = relative_path_for(asset)
       @target_root.join(relative_path)
+    end
+
+    def download_path_for(asset)
+      Tempfile.new(asset.uuid).path
     end
 
     def relative_path_for(asset)

--- a/lib/svg_scanner.rb
+++ b/lib/svg_scanner.rb
@@ -31,6 +31,5 @@ class SvgScanner
     File.open(file_path) do |file|
       parser.parse_io(file)
     end
-    true
   end
 end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -119,6 +119,21 @@ namespace :assets do
         end
       end
     end
+
+    desc "Scan a batch of assets for SVG vulnerabilites that haven't yet been scanned"
+    task :scan_next_svg_batch, %i[batch_size] => :environment do |_t, args|
+      if SvgScanBatchJob.jobs.empty?
+        Rails.logger.info("Enqueuing next SVG scan batch")
+        puts "Enqueuing next SVG scan batch"
+        batch_size = args.fetch(:batch_size)
+        Asset.where(state: "uploaded", deleted_at: nil, redirect_url: nil, svg_scanned_at: nil)
+          .limit(batch_size)
+          .each(&:schedule_svg_batch_scan)
+      else
+        Rails.logger.info("Not enqueuing next SVG scan batch: previous batch still in progress")
+        puts "Not enqueuing next SVG scan batch: previous batch still in progress"
+      end
+    end
   end
 end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   end
 
   factory :infected_asset, parent: :asset do
-    after :create, &:scanned_infected!
+    after :create, &:virus_scanned_infected!
   end
 
   factory :uploaded_asset, parent: :clean_asset do
@@ -37,7 +37,7 @@ FactoryBot.define do
   end
 
   factory :svg_infected_asset, parent: :svg_asset_safe do
-    after :create, &:scanned_infected!
+    after :create, &:svg_scanned_infected!
   end
 
   factory :svg_uploaded_asset, parent: :svg_asset_clean do

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe S3Storage::Fake do
   let(:root_directory) { Dir.mktmpdir }
   let(:root_path) { Pathname.new(root_directory.to_s) }
   let(:relative_path_to_asset) { storage.relative_path_for(asset) }
+  let(:download_path_to_asset) { storage.download_path_for(asset) }
 
   after do
     FileUtils.remove_entry(root_directory)
@@ -23,6 +24,16 @@ RSpec.describe S3Storage::Fake do
 
     it "writes file to fake S3 storage directory" do
       storage.upload(asset)
+
+      expect(File).to exist(asset_path)
+    end
+  end
+
+  context "when downloading a file" do
+    let(:asset_path) { root_path.join(download_path_to_asset) }
+
+    it "writes file to local directory" do
+      storage.download(asset)
 
       expect(File).to exist(asset_path)
     end
@@ -108,6 +119,14 @@ RSpec.describe S3Storage::Fake do
   describe "#metadata_for" do
     it "raises exception to indicate method not implemented" do
       expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#download_path_for" do
+    it "returns a temporary file path containing the asset uuid" do
+      expect(download_path_to_asset).to be_a(String)
+      expect(download_path_to_asset).to include(asset.uuid)
+      expect(download_path_to_asset).to start_with(Dir.tmpdir)
     end
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe S3Storage do
     end
   end
 
+  describe "#download" do
+    it "downloads the file from the S3 bucket" do
+      allow(s3_client).to receive(:get_object)
+      file = storage.download(asset)
+      expect(s3_client).to have_received(:get_object)
+      expect(File).to exist(file.path)
+    end
+  end
+
   describe "#delete" do
     it "deletes the file from the S3 bucket" do
       allow(s3_object).to receive(:delete).and_return(true)

--- a/spec/lib/svg_scanner_spec.rb
+++ b/spec/lib/svg_scanner_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe SvgScanner, type: :file_handler do
     let(:unsafe_uri_file_path) { fixture_file_path("asset-unsafe-uri.svg") }
 
     context "when SVG is safe" do
-      it "returns true" do
-        expect(scanner.scan(safe_file_path)).to be true
+      it "does not raise an error" do
+        expect { scanner.scan(safe_file_path) }.not_to raise_error
       end
     end
 

--- a/spec/lib/tasks/assets_spec.rb
+++ b/spec/lib/tasks/assets_spec.rb
@@ -399,6 +399,34 @@ RSpec.describe "assets.rake" do
         task.invoke(filepath)
         expect(File.read(filepath)).to eq "6592008029c8c3e4dc76256c,DONE\n"
       end
+
+      describe "assets:bulk_fix:scan_next_svg_batch" do
+        let(:task) { Rake::Task["assets:bulk_fix:scan_next_svg_batch"] }
+
+        Sidekiq::Testing.fake! do
+          it "does nothing if the batch queue is not empty" do
+            SvgScanBatchJob.perform_async("a")
+            allow(Rails.logger).to receive(:info).at_least(:once)
+            task.invoke(1)
+            expect(Rails.logger).to have_received(:info).with("Not enqueuing next SVG scan batch: previous batch still in progress").once
+          end
+
+          it "schedules the next batch if the batch queue is empty" do
+            allow(Rails.logger).to receive(:info).at_least(:once)
+            task.invoke(1)
+            expect(Rails.logger).to have_received(:info).with("Enqueuing next SVG scan batch").once
+          end
+
+          it "limits the batch size to the given number" do
+            FactoryBot.create(:uploaded_asset)
+            FactoryBot.create(:uploaded_asset)
+            allow(Rails.logger).to receive(:info).at_least(:once)
+            task.invoke(1)
+            expect(Rails.logger).to have_received(:info).with("Enqueuing next SVG scan batch").once
+            expect(SvgScanBatchJob.jobs.size).to eq(1)
+          end
+        end
+      end
     end
   end
   # rubocop:enable RSpec/AnyInstance

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -586,27 +586,36 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "when an asset is marked as infected" do
+  describe "when an asset is marked as being infected by a virus" do
     let(:state) { "unscanned" }
     let(:asset) { FactoryBot.build(:asset, state:) }
 
     it "does not schedule saving the asset to cloud storage" do
       expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
 
-      asset.scanned_infected!
+      asset.virus_scanned_infected!
     end
 
     it "sets the asset state to infected" do
-      asset.scanned_infected!
+      asset.virus_scanned_infected!
 
       expect(asset.reload).to be_infected
+    end
+
+    context "when asset is clean of virus" do
+      let(:state) { "virus_scanned_clean" }
+
+      it "does not allow the state transition" do
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
     end
 
     context "when asset is clean" do
       let(:state) { "clean" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -615,7 +624,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "infected" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -624,7 +633,51 @@ RSpec.describe Asset, type: :model do
       let(:state) { "uploaded" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
+
+  describe "when an asset is marked as being an unsafe SVG" do
+    let(:state) { "virus_scanned_clean" }
+    let(:asset) { FactoryBot.build(:asset, state:) }
+
+    it "does not schedule saving the asset to cloud storage" do
+      expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
+
+      asset.svg_scanned_infected!
+    end
+
+    it "sets the asset state to infected" do
+      asset.svg_scanned_infected!
+
+      expect(asset.reload).to be_infected
+    end
+
+    context "when asset is safe" do
+      let(:state) { "clean" }
+
+      it "does not allow the state transition" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is already infected" do
+      let(:state) { "infected" }
+
+      it "does not allow the state transition" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is already uploaded" do
+      let(:state) { "uploaded" }
+
+      it "does not allow the state transition" do
+        expect { asset.svg_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end

--- a/spec/sidekiq/svg_scan_batch_job_spec.rb
+++ b/spec/sidekiq/svg_scan_batch_job_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe SvgScanBatchJob do
 
       before do
         allow(scanner).to receive(:scan).and_raise(exception)
-        allow(Rails.logger).to receive(:info).at_least(:once)
+        allow(Rails.logger).to receive(:warn).at_least(:once)
         allow(GovukError).to receive(:notify).at_least(:once)
       end
 
@@ -98,7 +98,7 @@ RSpec.describe SvgScanBatchJob do
       it "logs the failure" do
         worker.perform(asset.id)
 
-        expect(Rails.logger).to have_received(:info).with("#{asset.id} - SvgScanBatchJob#perform - SVG unsafe").once
+        expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SVG Scan - File #{asset.filename} marked as unsafe").once
         expect(GovukError).to have_received(:notify).with(exception, extra: { id: asset.id, filename: asset.filename })
       end
 

--- a/spec/sidekiq/svg_scan_batch_job_spec.rb
+++ b/spec/sidekiq/svg_scan_batch_job_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+require "services"
+require "sidekiq_unique_jobs/testing"
+
+RSpec.describe SvgScanBatchJob do
+  let(:worker) { described_class.new }
+  let(:asset) { FactoryBot.create(:svg_asset_safe) }
+  let(:scanner) { instance_double(SvgScanner) }
+  let(:storage) { instance_double(S3Storage) }
+  let(:file) { Tempfile.new }
+
+  before do
+    allow(Services).to receive_messages(svg_scanner: scanner, cloud_storage: storage)
+    allow(storage).to receive(:download).and_return(file)
+  end
+
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
+  it "does not permit multiple jobs to be enqueued for the same asset" do
+    SidekiqUniqueJobs.use_config(enabled: true) do
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.to enqueue_sidekiq_job(described_class)
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.not_to enqueue_sidekiq_job(described_class)
+    end
+  end
+
+  context "when the file doesn't exist in S3" do
+    before do
+      context = Seahorse::Client::RequestContext.new
+      error = Aws::S3::Errors::NoSuchKey.new(context, "The specified key does not exist.")
+      allow(storage).to receive(:download).and_raise(error)
+      allow(Rails.logger).to receive(:info).at_least(:once)
+    end
+
+    it "does nothing" do
+      worker.perform(asset.id)
+      expect(Rails.logger).to have_received(:info).with("#{asset.id} - SvgScanBatchJob#perform - Asset missing from S3").once
+    end
+  end
+
+  context "when the file's mimetype is not 'image/svg+xml'" do
+    before do
+      allow(Marcel::MimeType).to receive(:for).and_return("not-svg")
+    end
+
+    it "does nothing" do
+      expect(scanner).not_to receive(:scan)
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the file's mimetype is 'image/svg+xml'" do
+    before do
+      allow(Marcel::MimeType).to receive(:for).and_return("image/svg+xml")
+    end
+
+    it "calls out to the SvgScanner to scan the file" do
+      expect(scanner).to receive(:scan).with(file.path)
+      worker.perform(asset.id)
+    end
+
+    context "when the file is clean" do
+      before do
+        allow(scanner).to receive(:scan)
+      end
+
+      it "records that svg_scanned_safe is true" do
+        worker.perform(asset.id)
+
+        asset.reload
+        expect(asset.svg_scanned_safe).to be true
+      end
+
+      it "records the datetime of the scan" do
+        worker.perform(asset.id)
+
+        asset.reload
+        expect(asset.svg_scanned_at).not_to be_nil
+      end
+    end
+
+    context "when the SVG asset is unsafe" do
+      let(:exception_message) { "SVG: Unsafe element detected: <script>" }
+      let(:exception) { SvgDocument::UnsafeSvg.new(exception_message) }
+
+      before do
+        allow(scanner).to receive(:scan).and_raise(exception)
+        allow(Rails.logger).to receive(:info).at_least(:once)
+        allow(GovukError).to receive(:notify).at_least(:once)
+      end
+
+      it "records that svg_scanned_safe is false" do
+        worker.perform(asset.id)
+
+        asset.reload
+        expect(asset.svg_scanned_safe).to be false
+      end
+
+      it "logs the failure" do
+        worker.perform(asset.id)
+
+        expect(Rails.logger).to have_received(:info).with("#{asset.id} - SvgScanBatchJob#perform - SVG unsafe").once
+        expect(GovukError).to have_received(:notify).with(exception, extra: { id: asset.id, filename: asset.filename })
+      end
+
+      it "records the datetime of the scan" do
+        worker.perform(asset.id)
+
+        asset.reload
+        expect(asset.svg_scanned_at).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe SvgScanJob do
       asset.reload
       expect(asset).to be_clean
     end
+
+    it "records that svg_scanned_safe is true" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset.svg_scanned_safe).to be true
+    end
+
+    it "records the datetime of the scan" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset.svg_scanned_at).not_to be_nil
+    end
   end
 
   context "when the asset is already marked as clean" do
@@ -97,6 +111,20 @@ RSpec.describe SvgScanJob do
 
       asset.reload
       expect(asset).to be_infected
+    end
+
+    it "records that svg_scanned_safe is false" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset.svg_scanned_safe).to be false
+    end
+
+    it "records the datetime of the scan" do
+      worker.perform(asset.id)
+
+      asset.reload
+      expect(asset.svg_scanned_at).not_to be_nil
     end
 
     it "logs the failure" do

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe SvgScanJob do
     it "logs the failure" do
       worker.perform(asset.id)
 
-      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe").once
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SVG Scan - File #{asset.filename} marked as unsafe").once
     end
   end
 end

--- a/spec/sidekiq/virus_scan_job_spec.rb
+++ b/spec/sidekiq/virus_scan_job_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe VirusScanJob do
     it "logs the failure" do
       worker.perform(asset.id)
 
-      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - VirusScanJob#perform - File #{asset.filename} marked as infected").once
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - Virus Scan - File #{asset.filename} marked as infected").once
     end
   end
 end


### PR DESCRIPTION
This creates a rake task that will put a batch of already-uploaded assets into a new, lowest-priority queue, to be scanned for SVG vulnerabilities. If the queue isn't empty, then it will do nothing, so that the queue won't grow too big for redis.

This is intended to be used by a cron job, yet to be created in govuk-helm-charts.