### PR TITLE
Bump `faraday` to 2.14.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,11 +147,11 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)


### PR DESCRIPTION
Dependabot was unable to raise a PR for this, so doing it manually with `bundle update faraday`.

Resolves https://github.com/alphagov/asset-manager/security/dependabot/113.