### PR TITLE
Handle formatless requests with a 404

### DIFF
--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,6 +1,6 @@
 class WhitehallMediaController < MediaController
   def download
-    request.formats = [Mime::NullType] if params[:format].blank?
+    error_404 if params[:format].blank?
     super
   end
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           expect(request.fullpath).to eq(legacy_url_path)
           expect(request.query_parameters).to be_empty
-          expect(request.format).to be_an_instance_of(Mime::NullType)
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
 
           expect(request.fullpath).to eq("#{legacy_url_path}?format")
           expect(request.query_parameters).to match(hash_including(format: nil))
-          expect(request.format).to be_an_instance_of(Mime::NullType)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end


### PR DESCRIPTION
This is a reasonably quick fix for an issue that has cropped up since Rails 8.1, where formatless requests, which were intended to be handled as `NullType`, we're actually throwing 500's as `NullType` is not a registered MimeType, so subsequently `requests.formats` fails a lookup deeper in the rails code, then defaulting to `nil`. This `nil` then causes template rendering to fail, resulting in a 500 error.

The decision was made that given there are basically no assets without a format extension, and all the traffic causing these 500's since the upgrade are not legitimate users, that having this throw a 404 is more sensible response.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
