### PR TITLE
[PP-7851] Resolve double render error

### DIFF
--- a/app/controllers/whitehall_media_controller.rb
+++ b/app/controllers/whitehall_media_controller.rb
@@ -1,6 +1,7 @@
 class WhitehallMediaController < MediaController
   def download
-    error_404 if params[:format].blank?
+    return error_404 if params[:format].blank?
+
     super
   end
 

--- a/spec/controllers/whitehall_media_controller_spec.rb
+++ b/spec/controllers/whitehall_media_controller_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
       context "and legacy_url_path has no format key or value" do
         let(:legacy_url_path) { "/government/uploads/#{path}" }
 
-        it "proxies asset to S3 via Nginx" do
-          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
+        it "returns a 404 response" do
           get :download, params: { path: }
 
           expect(request.fullpath).to eq(legacy_url_path)
@@ -74,9 +72,7 @@ RSpec.describe WhitehallMediaController, type: :controller do
       context "and legacy_url_path has no format value" do
         let(:legacy_url_path) { "/government/uploads/#{path}" }
 
-        it "proxies asset to S3 via Nginx" do
-          expect(controller).to receive(:proxy_to_s3_via_nginx).with(asset)
-
+        it "returns a 404 response" do
           get :download, params: { path:, format: nil }
 
           expect(request.fullpath).to eq("#{legacy_url_path}?format")


### PR DESCRIPTION
In 83c4dafc8a49face30f0e2eb5cd0268c2bd031cf, we added a quick fix for requests for files without a valid format.

This renders a 404 error, but failed to return. As a result, we are seeing `AbstractController::DoubleRenderError` errors, because we attempt to render twice.

Adding a `return` here, to fix the issue by not continuing with the remainder of the method if we are to return a 404 error.

Also updating the tests to reflect the new behaviour, as we are no longer needed to access S3 to see if the file exists (because `super` never gets called).