### PR TITLE
[PP-7782] Add 'Payload Too Large' response for file uploads

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,5 +1,8 @@
 class AssetsController < ApplicationController
+  MAX_FILE_SIZE = Rails.configuration.max_file_size
+
   before_action :restrict_request_format
+  before_action :check_request_size, only: %i[create update]
 
   def show
     @asset = find_asset(include_deleted: true)
@@ -81,5 +84,11 @@ private
 
   def build_asset
     Asset.new(asset_params)
+  end
+
+  def check_request_size
+    if request.content_length.to_i > MAX_FILE_SIZE
+      head :payload_too_large
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,8 @@ module AssetManager
 
     config.assets.prefix = "/asset-manager"
 
+    config.max_file_size = ENV.fetch("MAX_FILE_SIZE", 20).to_i.megabytes
+
     unless Rails.application.config_for(:secrets).jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,12 @@ curl http://asset-manager.dev.gov.uk/assets --form "asset[file]=@tmp.txt"
 }
 ```
 
+### Error responses
+
+| Status                     | Description                           |
+| -------------------------- | ------------------------------------- |
+| `413 Payload Too Large`    | Uploaded file exceeds permitted size. |
+
 ## Get asset info
 
 `GET /assets/:id` returns information about the requested asset, but not the asset itself.
@@ -105,6 +111,12 @@ curl http://asset-manager.dev.gov.uk/media/597b098a759b743e0b759a96/tmp.txt
 curl http://assets-origin.dev.gov.uk/media/597b098a759b743e0b759a96/tmp123.txt
 Tue 18 Jul 2017 17:06:41 BST
 ```
+
+### Error responses
+
+| Status                     | Description                           |
+| -------------------------- | ------------------------------------- |
+| `413 Payload Too Large`    | Uploaded file exceeds permitted size. |
 
 ## Delete asset
 

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe "Asset requests", type: :request do
       expect(response).to have_http_status(:unprocessable_content)
       expect(body["_response_info"]["status"]).to eq(["File can't be blank"])
     end
+
+    it "rejects requests that are larger than the defined size" do
+      post "/assets", params: { asset: { file: load_fixture_file("asset.png") } },
+                      headers: {
+                        "CONTENT_LENGTH" => (AssetsController::MAX_FILE_SIZE + 1).to_s,
+                      }
+
+      expect(response).to have_http_status(:payload_too_large)
+    end
   end
 
   describe "updating an asset" do
@@ -58,6 +67,15 @@ RSpec.describe "Asset requests", type: :request do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(body["_response_info"]["status"]).to eq(["File can't be blank"])
+    end
+
+    it "rejects requests that are larger than the defined size" do
+      put "/assets/#{asset_id}", params: { asset: { file: load_fixture_file("asset.png") } },
+                                 headers: {
+                                   "CONTENT_LENGTH" => (AssetsController::MAX_FILE_SIZE + 1).to_s,
+                                 }
+
+      expect(response).to have_http_status(:payload_too_large)
     end
   end
 


### PR DESCRIPTION
Currently, files larger than the ClamAV scanning limit may be accepted by the API but cannot be processed or scanned correctly downstream. This can lead to inconsistent behaviour, failed virus scans, and users needing to contact us via Zendesk.

This updates Asset Manager file upload endpoints to return an HTTP 413 Payload Too Large response when an uploaded file exceeds the maximum allowed file size configured in ClamAV (`MaxFileSize`).

This will allow publishers to get immediate feedback that a file is too large, rather than waiting for the virus scan to run.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/4364.

Note: this does not expand ZIP files to check whether the `MaxScanSize` is exceeded. It would be very difficult to make this check, without reverse engineering how ClamAV works through documents.