### PR TITLE
Bump `websocket-driver` to 0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -768,7 +768,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
Dependabot was unable to raise this change for an unknown reason, so manually running `bundle update`.

This resolves https://github.com/alphagov/asset-manager/security/dependabot/114, https://github.com/alphagov/asset-manager/security/dependabot/115 and https://github.com/alphagov/asset-manager/security/dependabot/116.