### PR TITLE
[PP-7782] Fix env var name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,7 @@ module AssetManager
 
     config.assets.prefix = "/asset-manager"
 
-    config.max_file_size = ENV.fetch("MAX_FILE_SIZE", 20).to_i.megabytes
+    config.max_file_size = ENV.fetch("MAX_FILE_SIZE_MB", 20).to_i.megabytes
 
     unless Rails.application.config_for(:secrets).jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"


### PR DESCRIPTION
This was incorrectly named as `MAX_FILE_SIZE` when it should have been `MAX_FILE_SIZE_MB`.

This has resulted in the application using the default size of 20MB, not 750MB.