### PR TITLE
[PP-7886] Allow `auth_bypass_ids` to expire

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -71,6 +71,7 @@ private
       :replacement_id,
       :parent_document_url,
       :content_type,
+      :auth_bypass_ids_expiry,
       access_limited: [],
       access_limited_organisation_ids: [],
       auth_bypass_ids: [],

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -137,7 +137,7 @@ class Asset
   end
 
   def valid_auth_bypass_token?(auth_bypass_id)
-    auth_bypass_ids.include?(auth_bypass_id)
+    auth_bypass_ids.include?(auth_bypass_id) && (auth_bypass_ids_expiry.nil? || auth_bypass_ids_expiry > Time.zone.now)
   end
 
   def public_url_path

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -49,6 +49,8 @@ class Asset
 
   field :auth_bypass_ids, type: Array, default: []
 
+  field :auth_bypass_ids_expiry, type: Time
+
   field :parent_document_url, type: String
 
   field :deleted_at, type: Time

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).auth_bypass_ids).to eq(%w[id1 id2])
       end
 
+      it "stores auth_bypass_ids_expiry on asset" do
+        expiry_time = Time.zone.now + 30.days
+        attributes = valid_attributes.merge(auth_bypass_ids_expiry: expiry_time)
+        post :create, params: { asset: attributes }
+
+        expect(assigns(:asset).auth_bypass_ids_expiry.floor).to eq(expiry_time.floor)
+      end
+
       it "stores parent_document_url on asset" do
         attributes = valid_attributes.merge(parent_document_url: "http://parent-document-url")
         post :create, params: { asset: attributes }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -349,10 +349,22 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#valid_auth_bypass_token?" do
-    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids" do
+    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids and there is no auth_bypass_ids_expiry" do
       asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
       auth_bypass_id = "my-token"
       expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be true
+    end
+
+    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids and auth_bypass_ids_expiry is in the future" do
+      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token], auth_bypass_ids_expiry: Time.zone.now + 1.day)
+      auth_bypass_id = "my-token"
+      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be true
+    end
+
+    it "returns false when given an auth_bypass_id which is in the auth_bypass_ids and auth_bypass_ids_expiry is in the past" do
+      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token], auth_bypass_ids_expiry: Time.zone.now - 1.day)
+      auth_bypass_id = "my-token"
+      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be false
     end
 
     it "returns false when given an auth_bypass_id which is not in the auth_bypass_ids" do


### PR DESCRIPTION
In HMRC Manuals API, we are currently building functionality to allow upload of assets (https://github.com/alphagov/hmrc-manuals-api/pull/1316).  Part of this requires draft asset's `auth_bypass_ids` to expire after 30 days.

This PR adds that functionality into Asset Manager, so publishing applications can specify this value.

There is no change for assets that do not have an expiry date specified.