### PR TITLE
[PP-7805] Refactor the asset state machine and its tests

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -110,11 +110,11 @@ class Asset
       SaveToCloudStorageJob.perform_async(asset.id.to_s)
     end
 
-    event :scanned_infected do
+    event :virus_scanned_infected do
       transition unscanned: :infected
     end
 
-    event :scanned_infected do
+    event :svg_scanned_infected do
       transition virus_scanned_clean: :infected
     end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -90,6 +90,10 @@ class Asset
       block.call
     end
 
+    event :virus_scanned_infected do
+      transition unscanned: :infected
+    end
+
     event :virus_scanned_clean do
       transition unscanned: :virus_scanned_clean
     end
@@ -98,24 +102,20 @@ class Asset
       asset.schedule_svg_scan
     end
 
-    event :svg_scan_skipped do
-      transition virus_scanned_clean: :clean
+    event :svg_scanned_infected do
+      transition virus_scanned_clean: :infected
     end
 
     event :svg_scanned_clean do
       transition virus_scanned_clean: :clean
     end
 
+    event :svg_scan_skipped do
+      transition virus_scanned_clean: :clean
+    end
+
     after_transition to: :clean do |asset, _|
       SaveToCloudStorageJob.perform_async(asset.id.to_s)
-    end
-
-    event :virus_scanned_infected do
-      transition unscanned: :infected
-    end
-
-    event :svg_scanned_infected do
-      transition virus_scanned_clean: :infected
     end
 
     event :upload_success do

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -16,7 +16,7 @@ class SvgScanJob
         end
       rescue SvgDocument::UnsafeSvg
         Rails.logger.warn("#{asset_id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe")
-        asset.scanned_infected!
+        asset.svg_scanned_infected!
       end
     end
   end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -18,7 +18,7 @@ class VirusScanJob
         end
       rescue VirusScanner::InfectedFile
         Rails.logger.warn("#{asset_id} - VirusScanJob#perform - File #{asset.filename} marked as infected")
-        asset.scanned_infected!
+        asset.virus_scanned_infected!
       end
     end
   end

--- a/docs/asset_state_machine_overview.md
+++ b/docs/asset_state_machine_overview.md
@@ -24,13 +24,13 @@ flowchart TD
     TriggerVirusScan --> VirusScanPerformed["Virus scan performed"]
 
     VirusScanPerformed -->|virus_scanned_clean| VirusScannedClean("Virus Scanned Clean")
-    VirusScanPerformed -->|scanned_infected| Infected("Infected")
+    VirusScanPerformed -->|virus_scanned_infected| Infected("Infected")
 
     VirusScannedClean --> TriggerSvgScan["SvgScanJob triggered"]
     TriggerSvgScan --> SvgScanPerformed["SVG scan performed"]
 
     SvgScanPerformed -->|svg_scanned_clean| Clean("Clean")
-    SvgScanPerformed -->|scanned_infected| Infected("Infected")
+    SvgScanPerformed -->|svg_scanned_infected| Infected("Infected")
 
     Clean --> TriggerSaveToCloudStorageJob["SaveToCloudStorageJob triggered"]
     TriggerSaveToCloudStorageJob --> Upload["Asset uploaded to AWS S3 bucket"]

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   end
 
   factory :infected_asset, parent: :asset do
-    after :create, &:scanned_infected!
+    after :create, &:virus_scanned_infected!
   end
 
   factory :uploaded_asset, parent: :clean_asset do
@@ -37,7 +37,7 @@ FactoryBot.define do
   end
 
   factory :svg_infected_asset, parent: :svg_asset_safe do
-    after :create, &:scanned_infected!
+    after :create, &:svg_scanned_infected!
   end
 
   factory :svg_uploaded_asset, parent: :svg_asset_clean do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -808,166 +808,6 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "scheduling a virus scan" do
-    it "schedules a scan after create" do
-      a = described_class.new(file: load_fixture_file("asset.png"))
-
-      expect(VirusScanJob).to receive(:perform_async).with(a.id)
-
-      a.save!
-    end
-
-    it "schedules a scan after save if the file is changed" do
-      a = FactoryBot.create(:clean_asset)
-      a.file = load_fixture_file("lorem.txt")
-
-      expect(VirusScanJob).to receive(:perform_async).with(a.id)
-
-      a.save!
-    end
-
-    it "schedules a scan after save if the file is changed even if filename is unchanged" do
-      a = FactoryBot.create(:clean_asset)
-      original_filename = a.file.send(:original_filename)
-      a.file = load_fixture_file("lorem.txt", named: original_filename)
-
-      expect(VirusScanJob).to receive(:perform_async).with(a.id)
-
-      a.save!
-    end
-
-    it "does not schedule a scan after update if the file is unchanged" do
-      a = FactoryBot.create(:clean_asset)
-      a.created_at = 5.days.ago
-
-      expect(VirusScanJob).not_to receive(:perform_async)
-
-      a.save!
-    end
-
-    it "does not schedule a scan if a redirect url is present" do
-      a = FactoryBot.create(:asset, redirect_url: "/some-redirect")
-
-      expect(VirusScanJob).not_to receive(:perform_async)
-
-      a.save!
-    end
-  end
-
-  describe "scheduling an SVG scan" do
-    it "schedules a scan after a clean virus scan" do
-      a = described_class.new(file: load_fixture_file("asset-safe.svg"))
-
-      expect(SvgScanJob).to receive(:perform_async).with(a.id)
-
-      a.virus_scanned_clean!
-    end
-
-    it "schedules another scan after saving a file" do
-      a = FactoryBot.create(:svg_asset_clean)
-      a.file = load_fixture_file("asset-safe.svg")
-
-      expect(SvgScanJob).to receive(:perform_async).with(a.id)
-
-      a.save!
-
-      allow(Services.virus_scanner).to receive(:scan)
-      VirusScanJob.drain
-    end
-  end
-
-  describe "when an asset is marked as clean" do
-    let(:state) { "virus_scanned_clean" }
-    let(:asset) { FactoryBot.build(:asset, state:) }
-
-    before do
-      allow(SaveToCloudStorageJob).to receive(:perform_async)
-    end
-
-    it "sets the asset state to clean" do
-      asset.svg_scanned_clean!
-
-      expect(asset.reload).to be_clean
-    end
-
-    it "schedules saving the asset to cloud storage" do
-      expect(SaveToCloudStorageJob).to receive(:perform_async).with(asset.id)
-
-      asset.svg_scanned_clean!
-    end
-
-    context "when asset is already clean" do
-      let(:state) { "clean" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_clean! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-
-    context "when asset is already infected" do
-      let(:state) { "infected" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_clean! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-
-    context "when asset is already uploaded" do
-      let(:state) { "uploaded" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_clean! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-  end
-
-  describe "when an asset is marked as infected by a virus" do
-    let(:state) { "unscanned" }
-    let(:asset) { FactoryBot.build(:asset, state:) }
-
-    it "does not schedule saving the asset to cloud storage" do
-      expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
-
-      asset.virus_scanned_infected!
-    end
-
-    it "sets the asset state to infected" do
-      asset.virus_scanned_infected!
-
-      expect(asset.reload).to be_infected
-    end
-
-    context "when asset is clean" do
-      let(:state) { "clean" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_infected! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-
-    context "when asset is already infected" do
-      let(:state) { "infected" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_infected! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-
-    context "when asset is already uploaded" do
-      let(:state) { "uploaded" }
-
-      it "does not allow the state transition" do
-        expect { asset.virus_scanned_infected! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-  end
-
   describe "soft deletion" do
     let(:asset) { described_class.new(file: load_fixture_file("asset.png")) }
 
@@ -1511,47 +1351,18 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#upload_success!" do
-    context "when asset is unscanned" do
-      let(:asset) { FactoryBot.create(:asset) }
+    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:path) { asset.file.path }
 
-      it "does not allow asset state change to uploaded" do
-        expect { asset.upload_success! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
+    it "changes asset state to uploaded" do
+      asset.upload_success!
+
+      expect(asset.reload).to be_uploaded
     end
 
-    context "when asset is clean" do
-      let(:asset) { FactoryBot.create(:clean_asset) }
-      let(:path) { asset.file.path }
-
-      it "changes asset state to uploaded" do
-        asset.upload_success!
-
-        expect(asset.reload).to be_uploaded
-      end
-
-      it "triggers the delete asset file worker" do
-        expect(DeleteAssetFileFromNfsJob).to receive(:perform_in)
-        asset.upload_success!
-      end
-    end
-
-    context "when asset is infected" do
-      let(:asset) { FactoryBot.create(:infected_asset) }
-
-      it "does not allow asset state change to uploaded" do
-        expect { asset.upload_success! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
-    end
-
-    context "when asset is uploaded" do
-      let(:asset) { FactoryBot.create(:uploaded_asset) }
-
-      it "does not allow asset state change to uploaded" do
-        expect { asset.upload_success! }
-          .to raise_error(StateMachines::InvalidTransition)
-      end
+    it "triggers the delete asset file worker" do
+      expect(DeleteAssetFileFromNfsJob).to receive(:perform_in)
+      asset.upload_success!
     end
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -470,6 +470,344 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "scanning files" do
+    context "when creating an asset" do
+      let(:asset) { FactoryBot.build(:asset) }
+
+      it "schedules a virus scan" do
+        expect(VirusScanJob).to receive(:perform_async).with(asset.id)
+
+        asset.save!
+      end
+
+      context "but there's a redirect_url" do
+        before { asset.redirect_url = "/some-redirect" }
+
+        it "does not schedule a virus scan" do
+          expect(VirusScanJob).not_to receive(:perform_async).with(asset.id)
+
+          asset.save!
+        end
+      end
+    end
+
+    context "when updating an asset with a new file" do
+      let(:asset) { FactoryBot.create(:clean_asset) }
+
+      it "schedules a virus scan" do
+        expect(VirusScanJob).to receive(:perform_async).with(asset.id)
+
+        asset.update!(file: load_fixture_file("lorem.txt"))
+      end
+
+      context "but the filename is the same" do
+        it "schedules a virus scan" do
+          original_filename = asset.file.send(:original_filename)
+          expect(VirusScanJob).to receive(:perform_async).with(asset.id)
+
+          asset.update!(file: load_fixture_file(
+            "lorem.txt", named: original_filename
+          ))
+        end
+      end
+    end
+
+    context "when updating an asset but the file is unchanged" do
+      let(:asset) { FactoryBot.create(:clean_asset) }
+
+      it "does not schedule a virus scan" do
+        expect(VirusScanJob).not_to receive(:perform_async).with(asset.id)
+
+        asset.update!(created_at: 5.days.ago)
+      end
+    end
+
+    context "when file passes virus scan" do
+      let(:asset) { FactoryBot.build(:asset) }
+
+      context "and the file is not an SVG" do
+        it "schedules the file to be uploaded to cloud storage" do
+          expect(SaveToCloudStorageJob).to receive(:perform_async).with(asset.id)
+
+          asset.virus_scanned_clean!
+        end
+
+        it "marks the asset as clean" do
+          asset.virus_scanned_clean!
+
+          expect(asset).to be_clean
+        end
+      end
+
+      context "and the file is an SVG" do
+        before { asset.update!(file: load_fixture_file("asset-safe.svg")) }
+
+        it "schedules an SVG scan" do
+          expect(SvgScanJob).to receive(:perform_async).with(asset.id)
+
+          asset.virus_scanned_clean!
+        end
+
+        it "does not schedule the file to be uploaded to cloud storage" do
+          expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
+
+          asset.virus_scanned_clean!
+        end
+
+        it "marks the asset as virus scanned clean" do
+          asset.virus_scanned_clean!
+
+          expect(asset).to be_virus_scanned_clean
+        end
+      end
+    end
+
+    context "when file fails virus scan" do
+      let(:asset) { FactoryBot.build(:asset) }
+
+      context "and the file is not an SVG" do
+        it "does not schedule the file to be uploaded to cloud storage" do
+          expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
+
+          asset.virus_scanned_infected!
+        end
+
+        it "marks the asset as infected" do
+          asset.virus_scanned_infected!
+
+          expect(asset).to be_infected
+        end
+      end
+
+      context "and the file is an SVG" do
+        before { asset.update!(file: load_fixture_file("asset-safe.svg")) }
+
+        it "does not schedule an SVG scan" do
+          expect(SvgScanJob).not_to receive(:perform_async).with(asset.id)
+
+          asset.virus_scanned_infected!
+        end
+      end
+    end
+
+    context "when file passes SVG scan" do
+      let(:asset) do
+        FactoryBot.create(
+          :clean_asset,
+          file: load_fixture_file("asset-safe.svg"),
+        )
+      end
+
+      it "schedules the file to be uploaded to cloud storage" do
+        expect(SaveToCloudStorageJob).to receive(:perform_async).with(asset.id)
+
+        asset.svg_scanned_clean!
+      end
+
+      it "marks the file as clean" do
+        asset.svg_scanned_clean!
+
+        expect(asset).to be_clean
+      end
+    end
+
+    context "when file fails SVG scan" do
+      let(:asset) do
+        FactoryBot.create(
+          :clean_asset,
+          file: load_fixture_file("asset-safe.svg"),
+        )
+      end
+
+      it "does not schedule the file to be uploaded to cloud storage" do
+        expect(SaveToCloudStorageJob)
+          .not_to receive(:perform_async).with(asset.id)
+
+        asset.svg_scanned_infected!
+      end
+
+      it "marks the file as infected" do
+        asset.svg_scanned_infected!
+
+        expect(asset).to be_infected
+      end
+    end
+  end
+
+  describe "invalid events" do
+    let(:asset) { FactoryBot.build(:asset, state:) }
+
+    context "when asset is unscanned" do
+      let(:state) { "unscanned" }
+
+      it "allows recording a successful virus scan" do
+        expect { asset.virus_scanned_clean! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "allows recording an unsuccessful virus scan" do
+        expect { asset.virus_scanned_infected! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful SVG scan" do
+        expect { asset.svg_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful SVG scan" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a skipped SVG scan" do
+        expect { asset.svg_scan_skipped! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful upload" do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is infected" do
+      let(:state) { "infected" }
+
+      it "does not allow recording a successful virus scan" do
+        expect { asset.virus_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful virus scan" do
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful SVG scan" do
+        expect { asset.svg_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful SVG scan" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a skipped SVG scan" do
+        expect { asset.svg_scan_skipped! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful upload" do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is marked as virus scanned clean" do
+      let(:state) { "virus_scanned_clean" }
+
+      it "does not allow recording a successful virus scan" do
+        expect { asset.virus_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful virus scan" do
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "allows recording a successful SVG scan" do
+        expect { asset.svg_scanned_clean! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "allows recording an unsuccessful SVG scan" do
+        expect { asset.svg_scanned_infected! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "allows recording a skipped SVG scan" do
+        expect { asset.svg_scan_skipped! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful upload" do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is marked as clean" do
+      let(:state) { "clean" }
+
+      it "does not allow recording a successful virus scan" do
+        expect { asset.virus_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful virus scan" do
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful SVG scan" do
+        expect { asset.svg_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "dose not allow recording an unsuccessful SVG scan" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a skipped SVG scan" do
+        expect { asset.svg_scan_skipped! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "allows recording a successful upload" do
+        expect { asset.upload_success! }
+          .not_to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+
+    context "when asset is marked as uploaded" do
+      let(:state) { "uploaded" }
+
+      it "does not allow recording a successful virus scan" do
+        expect { asset.virus_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful virus scan" do
+        expect { asset.virus_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful SVG scan" do
+        expect { asset.svg_scanned_clean! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording an unsuccessful SVG scan" do
+        expect { asset.svg_scanned_infected! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a skipped SVG scan" do
+        expect { asset.svg_scan_skipped! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not allow recording a successful upload" do
+        expect { asset.upload_success! }
+          .to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
+
   describe "scheduling a virus scan" do
     it "schedules a scan after create" do
       a = described_class.new(file: load_fixture_file("asset.png"))

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1352,7 +1352,6 @@ RSpec.describe Asset, type: :model do
 
   describe "#upload_success!" do
     let(:asset) { FactoryBot.create(:clean_asset) }
-    let(:path) { asset.file.path }
 
     it "changes asset state to uploaded" do
       asset.upload_success!

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -586,18 +586,18 @@ RSpec.describe Asset, type: :model do
     end
   end
 
-  describe "when an asset is marked as infected" do
+  describe "when an asset is marked as infected by a virus" do
     let(:state) { "unscanned" }
     let(:asset) { FactoryBot.build(:asset, state:) }
 
     it "does not schedule saving the asset to cloud storage" do
       expect(SaveToCloudStorageJob).not_to receive(:perform_async).with(asset.id)
 
-      asset.scanned_infected!
+      asset.virus_scanned_infected!
     end
 
     it "sets the asset state to infected" do
-      asset.scanned_infected!
+      asset.virus_scanned_infected!
 
       expect(asset.reload).to be_infected
     end
@@ -606,7 +606,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "clean" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -615,7 +615,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "infected" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end
@@ -624,7 +624,7 @@ RSpec.describe Asset, type: :model do
       let(:state) { "uploaded" }
 
       it "does not allow the state transition" do
-        expect { asset.scanned_infected! }
+        expect { asset.virus_scanned_infected! }
           .to raise_error(StateMachines::InvalidTransition)
       end
     end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -634,6 +634,21 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#upload_success!" do
+    let(:asset) { FactoryBot.create(:clean_asset) }
+
+    it "changes asset state to uploaded" do
+      asset.upload_success!
+
+      expect(asset.reload).to be_uploaded
+    end
+
+    it "triggers the delete asset file worker" do
+      expect(DeleteAssetFileFromNfsJob).to receive(:perform_in)
+      asset.upload_success!
+    end
+  end
+
   describe "invalid events" do
     let(:asset) { FactoryBot.build(:asset, state:) }
 
@@ -1347,21 +1362,6 @@ RSpec.describe Asset, type: :model do
 
     it "cannot be called from outside the Asset class" do
       expect { asset.md5_hexdigest = "md5-value" }.to raise_error(NoMethodError)
-    end
-  end
-
-  describe "#upload_success!" do
-    let(:asset) { FactoryBot.create(:clean_asset) }
-
-    it "changes asset state to uploaded" do
-      asset.upload_success!
-
-      expect(asset.reload).to be_uploaded
-    end
-
-    it "triggers the delete asset file worker" do
-      expect(DeleteAssetFileFromNfsJob).to receive(:perform_in)
-      asset.upload_success!
     end
   end
 


### PR DESCRIPTION
This is groundwork for bulk-scanning previously-uploaded SVGs. It splits the `scanned_infected` event into separate virus and SVG events, the first step towards a later change of moving scan side effects out of the `EnsureFile` concern and into the jobs. It also orders the state machine events by their from-state, and restructures and colocates the scanning and state machine tests so the coverage is easier to follow

First of five stacked PRs reworking #1991
