### PR TITLE
[PP-7805] Tidy asset test factories and specs

### DIFF
--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -515,7 +515,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with a valid clean file" do
-      let(:asset) { FactoryBot.create(:clean_asset) }
+      let(:asset) { FactoryBot.create(:virus_free_asset) }
 
       it "responds with 404 Not Found" do
         get :download, **params
@@ -524,7 +524,7 @@ RSpec.describe MediaController, type: :controller do
     end
 
     context "with an infected file" do
-      let(:asset) { FactoryBot.create(:infected_asset) }
+      let(:asset) { FactoryBot.create(:virus_infected_asset) }
 
       it "responds with 404 Not Found" do
         get :download, **params

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -24,18 +24,6 @@ FactoryBot.define do
     after :create, &:svg_scanned_clean!
   end
 
-  factory :svg_asset_unsafe_element, parent: :asset do
-    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-element.svg")) }
-  end
-
-  factory :svg_asset_unsafe_event_handler, parent: :asset do
-    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-event-handler.svg")) }
-  end
-
-  factory :svg_asset_unsafe_uri, parent: :asset do
-    file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-unsafe-uri.svg")) }
-  end
-
   factory :svg_infected_asset, parent: :svg_asset_safe do
     after :create, &:svg_scanned_infected!
   end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,32 +3,31 @@ FactoryBot.define do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset.png")) }
   end
 
-  factory :clean_asset, parent: :asset do
+  factory :virus_free_asset, parent: :asset do
     after :create, &:virus_scanned_clean!
   end
 
-  factory :infected_asset, parent: :asset do
+  factory :virus_infected_asset, parent: :asset do
     after :create, &:virus_scanned_infected!
   end
 
-  factory :uploaded_asset, parent: :clean_asset do
+  factory :uploaded_asset, parent: :virus_free_asset do
     after :create, &:upload_success!
   end
 
-  factory :svg_asset_safe, parent: :asset do
+  factory :virus_free_svg_asset, parent: :virus_free_asset do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset-safe.svg")) }
-    after :create, &:virus_scanned_clean!
   end
 
-  factory :svg_asset_clean, parent: :svg_asset_safe do
+  factory :clean_svg_asset, parent: :virus_free_svg_asset do
     after :create, &:svg_scanned_clean!
   end
 
-  factory :svg_infected_asset, parent: :svg_asset_safe do
+  factory :svg_infected_asset, parent: :virus_free_svg_asset do
     after :create, &:svg_scanned_infected!
   end
 
-  factory :svg_uploaded_asset, parent: :svg_asset_clean do
+  factory :uploaded_svg_asset, parent: :clean_svg_asset do
     after :create, &:upload_success!
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe Asset, type: :model do
     end
 
     context "when updating an asset with a new file" do
-      let(:asset) { FactoryBot.create(:clean_asset) }
+      let(:asset) { FactoryBot.create(:virus_free_asset) }
 
       it "schedules a virus scan" do
         expect(VirusScanJob).to receive(:perform_async).with(asset.id)
@@ -513,7 +513,7 @@ RSpec.describe Asset, type: :model do
     end
 
     context "when updating an asset but the file is unchanged" do
-      let(:asset) { FactoryBot.create(:clean_asset) }
+      let(:asset) { FactoryBot.create(:virus_free_asset) }
 
       it "does not schedule a virus scan" do
         expect(VirusScanJob).not_to receive(:perform_async).with(asset.id)
@@ -593,7 +593,7 @@ RSpec.describe Asset, type: :model do
     context "when file passes SVG scan" do
       let(:asset) do
         FactoryBot.create(
-          :clean_asset,
+          :virus_free_asset,
           file: load_fixture_file("asset-safe.svg"),
         )
       end
@@ -614,7 +614,7 @@ RSpec.describe Asset, type: :model do
     context "when file fails SVG scan" do
       let(:asset) do
         FactoryBot.create(
-          :clean_asset,
+          :virus_free_asset,
           file: load_fixture_file("asset-safe.svg"),
         )
       end
@@ -635,7 +635,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#upload_success!" do
-    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:virus_free_asset) }
 
     it "changes asset state to uploaded" do
       asset.upload_success!
@@ -1366,7 +1366,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#save" do
-    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:virus_free_asset) }
 
     context "when asset has been uploaded to cloud storage" do
       before do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1264,7 +1264,7 @@ RSpec.describe Asset, type: :model do
     let(:asset_size) { 100 }
 
     before do
-      allow(asset).to receive(:size).and_return(asset_size)
+      allow(asset).to receive(:size_from_file).and_return(asset_size)
     end
 
     context "when asset is created" do
@@ -1283,7 +1283,7 @@ RSpec.describe Asset, type: :model do
         let(:new_asset_size) { 200 }
 
         before do
-          allow(asset).to receive(:size).and_return(new_asset_size)
+          allow(asset).to receive(:size_from_file).and_return(new_asset_size)
           asset.update!(file: new_file)
         end
 

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Asset requests", type: :request do
     end
 
     it "returns details about an infected asset" do
-      asset = FactoryBot.create(:infected_asset)
+      asset = FactoryBot.create(:virus_infected_asset)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)

--- a/spec/sidekiq/save_to_cloud_storage_job_spec.rb
+++ b/spec/sidekiq/save_to_cloud_storage_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SaveToCloudStorageJob, type: :worker do
   let(:worker) { described_class.new }
 
   describe "#perform" do
-    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:virus_free_asset) }
     let(:cloud_storage) { instance_double(S3Storage) }
 
     before do

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -4,7 +4,7 @@ require "sidekiq_unique_jobs/testing"
 
 RSpec.describe SvgScanJob do
   let(:worker) { described_class.new }
-  let(:asset) { FactoryBot.create(:svg_asset_safe) }
+  let(:asset) { FactoryBot.create(:virus_free_svg_asset) }
   let(:scanner) { instance_double(SvgScanner) }
 
   before do
@@ -54,7 +54,7 @@ RSpec.describe SvgScanJob do
   end
 
   context "when the asset is already marked as clean" do
-    let(:asset) { FactoryBot.create(:svg_asset_clean) }
+    let(:asset) { FactoryBot.create(:clean_svg_asset) }
 
     it "does not SVG scan file" do
       expect(scanner).not_to receive(:scan)
@@ -74,7 +74,7 @@ RSpec.describe SvgScanJob do
   end
 
   context "when the asset is already marked as uploaded" do
-    let(:asset) { FactoryBot.create(:svg_uploaded_asset) }
+    let(:asset) { FactoryBot.create(:uploaded_svg_asset) }
 
     it "does not SVG scan file" do
       expect(scanner).not_to receive(:scan)

--- a/spec/sidekiq/virus_scan_job_spec.rb
+++ b/spec/sidekiq/virus_scan_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe VirusScanJob do
   end
 
   context "when the asset is already marked as clean" do
-    let(:asset) { FactoryBot.create(:clean_asset) }
+    let(:asset) { FactoryBot.create(:virus_free_asset) }
 
     it "does not virus scan file" do
       expect(scanner).not_to receive(:scan)
@@ -64,7 +64,7 @@ RSpec.describe VirusScanJob do
   end
 
   context "when the asset is already marked as infected" do
-    let(:asset) { FactoryBot.create(:infected_asset) }
+    let(:asset) { FactoryBot.create(:virus_infected_asset) }
 
     it "does not virus scan file" do
       expect(scanner).not_to receive(:scan)


### PR DESCRIPTION
This removes factories that are no longer used, clarifies the remaining factory names so it's clear whether a clean or infected asset refers to a virus or an SVG scan, and fixes the `size`/`size_from_file` tests which were only asserting a stubbed value

Second of five stacked PRs reworking #1991
