### PR TITLE
[PP-7805] Refine scan job responsibilities and logging

### DIFF
--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -3,7 +3,6 @@ module EnsureFile
 
   def ensure_file_is_same_after_scan(asset, job_name, next_state)
     initial_digest = asset.md5_hexdigest
-    Rails.logger.info("#{asset.id} - #{job_name}#perform - scan started")
     yield
     asset.reload.md5_hexdigest == initial_digest ? asset.send(next_state) : Rails.logger.info("#{asset.id} #{job_name} checksum failed")
   end

--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -1,9 +1,13 @@
 module EnsureFile
   extend ActiveSupport::Concern
 
-  def ensure_file_is_same_after_scan(asset, job_name, next_state)
+  def ensure_file_is_same_after_scan(asset, job_name, success_callback)
     initial_digest = asset.md5_hexdigest
     yield
-    asset.reload.md5_hexdigest == initial_digest ? asset.send(next_state) : Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+    if asset.reload.md5_hexdigest == initial_digest
+      success_callback.call
+    else
+      Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+    end
   end
 end

--- a/app/sidekiq/concerns/ensure_file.rb
+++ b/app/sidekiq/concerns/ensure_file.rb
@@ -7,7 +7,7 @@ module EnsureFile
     if asset.reload.md5_hexdigest == initial_digest
       success_callback.call
     else
-      Rails.logger.info("#{asset.id} #{job_name} checksum failed")
+      Rails.logger.info("#{asset.id} - #{job_name} - Checksum failed")
     end
   end
 end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -10,8 +10,8 @@ class SvgScanJob
     asset = Asset.find(asset_id)
     if asset.virus_scanned_clean?
       begin
-        Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
         ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do
+          Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
           Services.svg_scanner.scan(asset.file.path)
         end
       rescue SvgDocument::UnsafeSvg

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -10,7 +10,11 @@ class SvgScanJob
     asset = Asset.find(asset_id)
     if asset.virus_scanned_clean?
       begin
-        ensure_file_is_same_after_scan(asset, "SvgScanJob", :svg_scanned_clean!) do
+        ensure_file_is_same_after_scan(
+          asset,
+          "SvgScanJob",
+          -> { asset.svg_scanned_clean! },
+        ) do
           Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
           Services.svg_scanner.scan(asset.file.path)
         end

--- a/app/sidekiq/svg_scan_job.rb
+++ b/app/sidekiq/svg_scan_job.rb
@@ -15,11 +15,11 @@ class SvgScanJob
           "SvgScanJob",
           -> { asset.svg_scanned_clean! },
         ) do
-          Rails.logger.info("#{asset_id} - SvgScanJob#perform - SVG scan started")
+          Rails.logger.info("#{asset_id} - SvgScanJob - SVG scan started")
           Services.svg_scanner.scan(asset.file.path)
         end
       rescue SvgDocument::UnsafeSvg
-        Rails.logger.warn("#{asset_id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe")
+        Rails.logger.warn("#{asset_id} - SvgScanJob - File #{asset.filename} marked as unsafe")
         asset.svg_scanned_infected!
       end
     end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -12,7 +12,11 @@ class VirusScanJob
     asset = Asset.find(asset_id)
     if asset.unscanned?
       begin
-        ensure_file_is_same_after_scan(asset, "VirusScanJob", :virus_scanned_clean!) do
+        ensure_file_is_same_after_scan(
+          asset,
+          "VirusScanJob",
+          -> { asset.virus_scanned_clean! },
+        ) do
           Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
           Services.virus_scanner.scan(asset.file.path)
         end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -17,11 +17,11 @@ class VirusScanJob
           "VirusScanJob",
           -> { asset.virus_scanned_clean! },
         ) do
-          Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
+          Rails.logger.info("#{asset_id} - VirusScanJob - Virus scan started")
           Services.virus_scanner.scan(asset.file.path)
         end
       rescue VirusScanner::InfectedFile
-        Rails.logger.warn("#{asset_id} - VirusScanJob#perform - File #{asset.filename} marked as infected")
+        Rails.logger.warn("#{asset_id} - VirusScanJob - File #{asset.filename} marked as infected")
         asset.virus_scanned_infected!
       end
     end

--- a/app/sidekiq/virus_scan_job.rb
+++ b/app/sidekiq/virus_scan_job.rb
@@ -12,8 +12,8 @@ class VirusScanJob
     asset = Asset.find(asset_id)
     if asset.unscanned?
       begin
-        Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
         ensure_file_is_same_after_scan(asset, "VirusScanJob", :virus_scanned_clean!) do
+          Rails.logger.info("#{asset_id} - VirusScanJob#perform - Virus scan started")
           Services.virus_scanner.scan(asset.file.path)
         end
       rescue VirusScanner::InfectedFile

--- a/lib/svg_scanner.rb
+++ b/lib/svg_scanner.rb
@@ -31,6 +31,5 @@ class SvgScanner
     File.open(file_path) do |file|
       parser.parse_io(file)
     end
-    true
   end
 end

--- a/spec/lib/svg_scanner_spec.rb
+++ b/spec/lib/svg_scanner_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe SvgScanner, type: :file_handler do
     let(:unsafe_uri_file_path) { fixture_file_path("asset-unsafe-uri.svg") }
 
     context "when SVG is safe" do
-      it "returns true" do
-        expect(scanner.scan(safe_file_path)).to be true
+      it "does not raise an error" do
+        expect { scanner.scan(safe_file_path) }.not_to raise_error
       end
     end
 

--- a/spec/sidekiq/svg_scan_job_spec.rb
+++ b/spec/sidekiq/svg_scan_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SvgScanJob do
 
       it "logs the job failure and does not update the asset's state" do
         worker.perform(asset.id)
-        expect(Rails.logger).to have_received(:info).with("#{asset.id} SvgScanJob checksum failed").once
+        expect(Rails.logger).to have_received(:info).with("#{asset.id} - SvgScanJob - Checksum failed").once
         expect(asset.reload).not_to be_clean
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe SvgScanJob do
     it "logs the failure" do
       worker.perform(asset.id)
 
-      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SvgScanJob#perform - File #{asset.filename} marked as unsafe").once
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - SvgScanJob - File #{asset.filename} marked as unsafe").once
     end
   end
 end

--- a/spec/sidekiq/virus_scan_job_spec.rb
+++ b/spec/sidekiq/virus_scan_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe VirusScanJob do
 
       it "logs the job failure and does not update the asset's state" do
         worker.perform(asset.id)
-        expect(Rails.logger).to have_received(:info).with("#{asset.id} VirusScanJob checksum failed").once
+        expect(Rails.logger).to have_received(:info).with("#{asset.id} - VirusScanJob - Checksum failed").once
         expect(asset.reload).not_to be_clean
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe VirusScanJob do
     it "logs the failure" do
       worker.perform(asset.id)
 
-      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - VirusScanJob#perform - File #{asset.filename} marked as infected").once
+      expect(Rails.logger).to have_received(:warn).with("#{asset.id} - VirusScanJob - File #{asset.filename} marked as infected").once
     end
   end
 end


### PR DESCRIPTION
This continues the refactor begun in the state machine work. The SVG scanner no longer returns an unused value, logging moves into the jobs themselves, and the `EnsureFile` concern is narrowed so each job injects its own on-success behaviour rather than the concern triggering a state change. Log lines are standardised on the format `asset_id - job_name - Sentence case event`

Third of five stacked PRs reworking #1991
