### PR TITLE
[PP-7805] Record asset MIME type and SVG scan details

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -54,6 +54,9 @@ class Asset
 
   field :parent_document_url, type: String
 
+  field :svg_scanned_at, type: Time
+  field :svg_scan_state, type: String
+
   field :deleted_at, type: Time
 
   validates :file, presence: true, if: :unscanned?
@@ -72,6 +75,14 @@ class Asset
               message: "must match the format defined in rfc6838",
               allow_nil: true,
             }
+
+  validates :svg_scan_state,
+            inclusion: {
+              in: %w[svg_clean svg_infected],
+              message: "%{value} is not a valid svg_scan_state",
+            },
+            allow_nil: true
+  validates :svg_scan_state, absence: true, if: :unscanned?
 
   validate :check_specified_replacement_exists
   validate :prevent_transition_from_published_to_draft_if_replaced
@@ -109,8 +120,16 @@ class Asset
       transition virus_scanned_clean: :infected
     end
 
+    after_transition on: :svg_scanned_infected do |asset, _|
+      asset.update!(svg_scanned_at: Time.zone.now, svg_scan_state: "svg_infected")
+    end
+
     event :svg_scanned_clean do
       transition virus_scanned_clean: :clean
+    end
+
+    after_transition on: :svg_scanned_clean do |asset, _|
+      asset.update!(svg_scanned_at: Time.zone.now, svg_scan_state: "svg_clean")
     end
 
     event :svg_scan_skipped do
@@ -263,6 +282,8 @@ protected
   end
 
   def reset_state
+    self.svg_scanned_at = nil
+    self.svg_scan_state = nil
     self.state = "unscanned"
   end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -172,7 +172,7 @@ class Asset
   end
 
   def etag_from_file
-    sprintf("%<mtime>x-%<size>x", mtime: last_modified_from_file, size: file_stat.size) if file_exists?
+    sprintf("%<mtime>x-%<size>x", mtime: last_modified_from_file, size: size_from_file) if file_exists?
   end
 
   def last_modified_from_file

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -180,7 +180,7 @@ class Asset
   end
 
   def md5_hexdigest_from_file
-    @md5_hexdigest_from_file ||= Digest::MD5.hexdigest(file.file.read) if file_exists?
+    Digest::MD5.hexdigest(file.file.read) if file_exists?
   end
 
   def size_from_file

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -256,8 +256,6 @@ protected
 
   def reset_state
     self.state = "unscanned"
-    @file_stat = nil
-    @md5_hexdigest = nil
   end
 
   def schedule_virus_scan

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -41,6 +41,9 @@ class Asset
   field :size, type: Integer
   protected :size=
 
+  field :mime_type, type: String
+  protected :mime_type=
+
   field :content_type, type: String
 
   field :access_limited, type: Array, default: []
@@ -187,6 +190,10 @@ class Asset
     file_stat.size if file_exists?
   end
 
+  def mime_type_from_file
+    Marcel::MimeType.for(Pathname.new(file.path)) if file_exists?
+  end
+
   def update_indirect_replacements_on_publish
     return unless saved_change_to_attribute(:draft) && !draft?
 
@@ -238,7 +245,7 @@ class Asset
   end
 
   def schedule_svg_scan
-    Marcel::MimeType.for(Pathname.new(file.path)) == "image/svg+xml" ? SvgScanJob.perform_async(id.to_s) : svg_scan_skipped!
+    mime_type == "image/svg+xml" ? SvgScanJob.perform_async(id.to_s) : svg_scan_skipped!
   end
 
 protected
@@ -248,6 +255,7 @@ protected
     self.last_modified = last_modified_from_file
     self.md5_hexdigest = md5_hexdigest_from_file
     self.size = size_from_file
+    self.mime_type = mime_type_from_file
   end
 
   def valid_filenames

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1611,4 +1611,45 @@ RSpec.describe Asset, type: :model do
       expect(asset.access_limited?).to be false
     end
   end
+
+  describe "#file=" do
+    let(:asset) { FactoryBot.create(:uploaded_asset) }
+
+    it "resets the scanning state" do
+      expect { asset.file = load_fixture_file("asset2.jpg") }
+        .to change(asset, :state).from("uploaded").to("unscanned")
+    end
+
+    context "when there was no previous file" do
+      let(:asset) { described_class.new }
+
+      it "leaves the filename history empty" do
+        asset.file = load_fixture_file("asset.png")
+
+        expect(asset.filename_history).to be_empty
+      end
+    end
+
+    context "when there was a previous file" do
+      let(:asset) { FactoryBot.build(:asset, file: load_fixture_file("asset.png")) }
+
+      it "records the old filename in the filename history" do
+        asset.file = load_fixture_file("asset2.jpg")
+
+        expect(asset.filename_history).to eq(["asset.png"])
+      end
+    end
+
+    context "when there were two previous files" do
+      let(:asset) { FactoryBot.build(:asset, file: load_fixture_file("asset.png")) }
+
+      before { asset.file = load_fixture_file("lorem.txt") }
+
+      it "appends the old filename to the filename history" do
+        asset.file = load_fixture_file("asset2.jpg")
+
+        expect(asset.filename_history).to eq(["asset.png", "lorem.txt"])
+      end
+    end
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -284,6 +284,54 @@ RSpec.describe Asset, type: :model do
         end
       end
     end
+
+    context "when asset is unscanned" do
+      before { asset.state = "unscanned" }
+
+      it "allows svg_scan_state to be nil" do
+        asset.svg_scan_state = nil
+
+        expect(asset).to be_valid
+      end
+
+      it "does not accept otherwise valid states" do
+        %w[svg_clean svg_infected].each do |svg_scan_state|
+          asset.svg_scan_state = svg_scan_state
+
+          expect(asset).to be_invalid
+        end
+      end
+
+      it "does not accept otherwise invalid states" do
+        asset.svg_scan_state = "something_fishy"
+
+        expect(asset).to be_invalid
+      end
+    end
+
+    context "when asset is not unscanned" do
+      before { asset.state = "uploaded" }
+
+      it "allows svg_scan_state to be nil" do
+        asset.svg_scan_state = nil
+
+        expect(asset).to be_valid
+      end
+
+      it "accept valid states" do
+        %w[svg_clean svg_infected].each do |svg_scan_state|
+          asset.svg_scan_state = svg_scan_state
+
+          expect(asset).to be_valid
+        end
+      end
+
+      it "does not accept invalid states" do
+        asset.svg_scan_state = "something_fishy"
+
+        expect(asset).to be_invalid
+      end
+    end
   end
 
   describe "creation" do
@@ -609,6 +657,20 @@ RSpec.describe Asset, type: :model do
 
         expect(asset).to be_clean
       end
+
+      it "records the time of the scan" do
+        travel_to Time.zone.parse("2026-07-20 16:10")
+
+        asset.svg_scanned_clean!
+
+        expect(asset.svg_scanned_at.to_s).to eq("2026-07-20 16:10:00 +0100")
+      end
+
+      it "records the result of the scan" do
+        asset.svg_scanned_clean!
+
+        expect(asset.svg_scan_state).to eq("svg_clean")
+      end
     end
 
     context "when file fails SVG scan" do
@@ -630,6 +692,20 @@ RSpec.describe Asset, type: :model do
         asset.svg_scanned_infected!
 
         expect(asset).to be_infected
+      end
+
+      it "records the time of the scan" do
+        travel_to Time.zone.parse("2026-07-20 16:10")
+
+        asset.svg_scanned_infected!
+
+        expect(asset.svg_scanned_at.to_s).to eq("2026-07-20 16:10:00 +0100")
+      end
+
+      it "records the result of the scan" do
+        asset.svg_scanned_infected!
+
+        expect(asset.svg_scan_state).to eq("svg_infected")
       end
     end
   end
@@ -1618,6 +1694,20 @@ RSpec.describe Asset, type: :model do
     it "resets the scanning state" do
       expect { asset.file = load_fixture_file("asset2.jpg") }
         .to change(asset, :state).from("uploaded").to("unscanned")
+    end
+
+    context "when the file was an SVG" do
+      let(:asset) { FactoryBot.create(:uploaded_svg_asset) }
+
+      it "resets SVG scan status" do
+        expect { asset.file = load_fixture_file("asset2.jpg") }
+          .to change(asset, :svg_scan_state).from("svg_clean").to(nil)
+      end
+
+      it "resets SVG scan time" do
+        expect { asset.file = load_fixture_file("asset2.jpg") }
+          .to change(asset, :svg_scanned_at).to(nil)
+      end
     end
 
     context "when there was no previous file" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1364,6 +1364,84 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#mime_type_from_file" do
+    let(:asset) { described_class.new(file: load_fixture_file("asset.png")) }
+    let(:mime_type) { "image/png" }
+
+    it "returns the MIME type of the file" do
+      expect(asset.mime_type_from_file).to eq(mime_type)
+    end
+
+    context "when the file has been updated" do
+      before do
+        asset.save!
+        asset.update!(file: load_fixture_file("asset2.jpg"))
+      end
+
+      let(:new_mime_type) { "image/jpeg" }
+
+      it "returns the new file's MIME type" do
+        expect(asset.mime_type_from_file).to eq(new_mime_type)
+      end
+    end
+
+    context "when the file has been deleted" do
+      let(:stat) { Errno::ENOENT }
+
+      before do
+        asset.file = nil
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(asset.mime_type_from_file).to be_nil
+      end
+    end
+  end
+
+  describe "#mime_type" do
+    let(:asset) { described_class.new(file: load_fixture_file("asset.png"), mime_type:) }
+    let(:asset_mime_type) { "image/png" }
+
+    before do
+      allow(asset).to receive(:mime_type_from_file).and_return(asset_mime_type)
+    end
+
+    context "when asset is created" do
+      let(:mime_type) { nil }
+
+      before do
+        asset.save!
+      end
+
+      it "stores the value generated from the file in the database" do
+        expect(asset.reload.mime_type).to eq(asset_mime_type)
+      end
+
+      context "when asset is updated with new file" do
+        let(:new_file) { load_fixture_file("asset2.jpg") }
+        let(:new_asset_mime_type) { "image/jpeg" }
+
+        before do
+          allow(asset).to receive(:mime_type_from_file).and_return(new_asset_mime_type)
+          asset.update!(file: new_file)
+        end
+
+        it "stores the value generated from the new file in the database" do
+          expect(asset.reload.mime_type).to eq(new_asset_mime_type)
+        end
+      end
+    end
+  end
+
+  describe "#mime_type=" do
+    let(:asset) { described_class.new }
+
+    it "cannot be called from outside the Asset class" do
+      expect { asset.mime_type = "application/pdf" }.to raise_error(NoMethodError)
+    end
+  end
+
   describe "#md5_hexdigest_from_file" do
     let(:asset) { described_class.new(file: load_fixture_file("asset.png")) }
     let(:md5_hexdigest) { "a0d8aa55f6db670e38a14962c0652776" }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1088,7 +1088,7 @@ RSpec.describe Asset, type: :model do
 
     before do
       asset.file = load_fixture_file("asset.png")
-      allow(File).to receive(:stat).and_return(stat)
+      allow(File).to receive(:stat).with(asset.file.path).and_return(stat)
     end
 
     it "returns string made up of 2 parts separated by a hyphen" do
@@ -1106,6 +1106,36 @@ RSpec.describe Asset, type: :model do
       size_hex = asset.etag_from_file.split("-").last
       asset_size = size_hex.to_i(16)
       expect(asset_size).to eq(size)
+    end
+
+    context "when the file has been updated" do
+      let(:new_size) { 2048 }
+      let(:new_mtime) { Time.zone.parse("2018-02-02") }
+      let(:new_stat) do
+        instance_double(File::Stat, size: new_size, mtime: new_mtime)
+      end
+
+      before do
+        allow(File).to receive(:stat).and_call_original
+        asset.save!
+        asset.update!(file: load_fixture_file("asset2.jpg"))
+        allow(File)
+          .to receive(:stat)
+          .with(asset.file.path)
+          .and_return(new_stat)
+      end
+
+      it "has 1st part as new file mtime" do
+        last_modified_hex = asset.etag_from_file.split("-").first
+        last_modified = last_modified_hex.to_i(16)
+        expect(last_modified).to eq(new_mtime.to_i)
+      end
+
+      it "has 2nd part as new file size" do
+        size_hex = asset.etag_from_file.split("-").last
+        asset_size = size_hex.to_i(16)
+        expect(asset_size).to eq(new_size)
+      end
     end
 
     context "when the file has been deleted" do
@@ -1171,11 +1201,30 @@ RSpec.describe Asset, type: :model do
 
     before do
       asset.file = load_fixture_file("asset.png")
-      allow(File).to receive(:stat).and_return(stat)
+      allow(File).to receive(:stat).with(asset.file.path).and_return(stat)
     end
 
     it "returns time file was last modified" do
       expect(asset.last_modified_from_file).to eq(mtime)
+    end
+
+    context "when the file has been updated" do
+      let(:new_mtime) { Time.zone.parse("2018-02-02") }
+      let(:new_stat) { instance_double(File::Stat, mtime: new_mtime) }
+
+      before do
+        allow(File).to receive(:stat).and_call_original
+        asset.save!
+        asset.update!(file: load_fixture_file("asset2.jpg"))
+        allow(File)
+          .to receive(:stat)
+          .with(asset.reload.file.path)
+          .and_return(new_stat)
+      end
+
+      it "returns when the new file was last modified" do
+        expect(asset.last_modified_from_file).to eq(new_mtime)
+      end
     end
 
     context "when the file has been deleted" do
@@ -1245,6 +1294,19 @@ RSpec.describe Asset, type: :model do
       expect(asset.size_from_file).to eq(size)
     end
 
+    context "when the file has been updated" do
+      before do
+        asset.save!
+        asset.update!(file: load_fixture_file("asset2.jpg"))
+      end
+
+      let(:new_size) { 82_328 }
+
+      it "returns the new file's size" do
+        expect(asset.size_from_file).to eq(new_size)
+      end
+    end
+
     context "when the file has been deleted" do
       let(:stat) { Errno::ENOENT }
 
@@ -1308,6 +1370,19 @@ RSpec.describe Asset, type: :model do
 
     it "returns MD5 hex digest for asset file content" do
       expect(asset.md5_hexdigest_from_file).to eq(md5_hexdigest)
+    end
+
+    context "when the file has been updated" do
+      before do
+        asset.save!
+        asset.update!(file: load_fixture_file("asset2.jpg"))
+      end
+
+      let(:new_md5_hexdigest) { "f99cbda3715ac4e52961855bbac8fc05" }
+
+      it "returns the new file's MD5 hex digest" do
+        expect(asset.md5_hexdigest_from_file).to eq(new_md5_hexdigest)
+      end
     end
 
     context "when the file has been deleted" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,4 +36,6 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   # config.infer_spec_type_from_file_location!
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
This records the extra asset metadata that bulk SVG scanning relies on. It persists the file's MIME type and stores the time and result of an SVG scan on the asset, so that a later change can skip assets which have already been scanned or whose files aren't SVGs. It also fixes and adds tests for how an asset's stored file metadata is updated on save

Fourth of five stacked PRs reworking #1991
