### PR TITLE
[PP-7805] Scan existing SVG assets in bulk

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -267,6 +267,10 @@ class Asset
     mime_type == "image/svg+xml" ? SvgScanJob.perform_async(id.to_s) : svg_scan_skipped!
   end
 
+  def schedule_svg_batch_scan
+    SvgScanBatchJob.perform_async(id.to_s)
+  end
+
 protected
 
   def store_metadata

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -78,7 +78,7 @@ class Asset
 
   validates :svg_scan_state,
             inclusion: {
-              in: %w[svg_clean svg_infected],
+              in: %w[svg_clean svg_infected file_missing_from_s3],
               message: "%{value} is not a valid svg_scan_state",
             },
             allow_nil: true

--- a/app/sidekiq/svg_scan_batch_job.rb
+++ b/app/sidekiq/svg_scan_batch_job.rb
@@ -1,0 +1,45 @@
+require "services"
+
+class SvgScanBatchJob
+  include Sidekiq::Job
+
+  sidekiq_options lock: :until_executing, queue: "batch"
+
+  def perform(asset_id)
+    asset = Asset.find(asset_id)
+    file = Services.cloud_storage.download(asset)
+
+    ensure_mime_type_set(asset, file.path)
+
+    scan_svg(asset, file.path) if asset.mime_type == "image/svg+xml"
+  rescue Aws::S3::Errors::NoSuchKey
+    asset.update!(svg_scan_state: "file_missing_from_s3")
+    Rails.logger.info("#{asset_id} - SvgScanBatchJob - Asset missing from S3")
+  ensure
+    if file.respond_to?(:path) && File.exist?(file.path)
+      file.close
+      file.unlink
+    end
+  end
+
+private
+
+  def ensure_mime_type_set(asset, file_path)
+    if asset.mime_type.nil?
+      asset.set(mime_type: Marcel::MimeType.for(Pathname.new(file_path)))
+      asset.reload
+    end
+  end
+
+  def scan_svg(asset, file_path)
+    Rails.logger.info("#{asset.id} - SvgScanBatchJob - SVG scan started")
+    Services.svg_scanner.scan(file_path)
+    asset.update!(svg_scan_state: "svg_clean")
+  rescue SvgDocument::UnsafeSvg => e
+    asset.update!(svg_scan_state: "svg_infected")
+    Rails.logger.info("#{asset.id} - SvgScanBatchJob - SVG unsafe")
+    GovukError.notify(e, extra: { id: asset.id, filename: asset.filename })
+  ensure
+    asset.update!(svg_scanned_at: Time.zone.now)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
 :queues:
   - default
   - low_priority
+  - batch

--- a/lib/s3_storage.rb
+++ b/lib/s3_storage.rb
@@ -1,3 +1,4 @@
+require "tempfile"
 require "s3_storage/fake"
 
 class S3Storage
@@ -32,6 +33,15 @@ class S3Storage
         raise ObjectUploadFailedError, error_message
       end
     end
+  end
+
+  def download(asset, file: Tempfile.new(asset.uuid))
+    client.get_object(
+      bucket: @bucket_name,
+      key: asset.uuid,
+      response_target: file.path,
+    )
+    file
   end
 
   def delete(asset)

--- a/lib/s3_storage/fake.rb
+++ b/lib/s3_storage/fake.rb
@@ -12,6 +12,13 @@ class S3Storage
       File.write(target_path, File.read(source_path))
     end
 
+    def download(asset)
+      source_path = source_path_for(asset)
+      download_path = download_path_for(asset)
+      FileUtils.mkdir_p(File.dirname(download_path))
+      File.write(download_path, File.read(source_path))
+    end
+
     def delete(asset, **_args)
       target_path = target_path_for(asset)
       File.delete(target_path)
@@ -48,6 +55,10 @@ class S3Storage
     def target_path_for(asset)
       relative_path = relative_path_for(asset)
       @target_root.join(relative_path)
+    end
+
+    def download_path_for(asset)
+      Tempfile.new(asset.uuid).path
     end
 
     def relative_path_for(asset)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -51,6 +51,41 @@ namespace :assets do
     end
   end
 
+  desc "Scan a batch of files yet to be scanned for SVG vulnerabilites"
+  task :bulk_scan_svgs, %i[batch_size] => :environment do |_t, args|
+    if Sidekiq::Queue.new("batch").any?
+      message = "Not enqueuing assets for bulk SVG scanning: previous batch still in progress"
+      Rails.logger.info(message)
+      puts message
+
+      next
+    end
+
+    batch_size = args.fetch(:batch_size, nil)&.to_i
+
+    unless batch_size&.positive?
+      raise ArgumentError, "Invalid batch size for bulk SVG scanning: #{batch_size.inspect}"
+    end
+
+    message = "Enqueuing up to #{batch_size} assets for bulk SVG scanning"
+    Rails.logger.info(message)
+    puts message
+
+    scope = Asset
+      .where(
+        state: "uploaded",
+        deleted_at: nil,
+        redirect_url: nil,
+        svg_scan_state: nil,
+        :mime_type.in => [nil, "image/svg+xml"],
+      )
+      .limit(batch_size)
+
+    raise "No assets found to enqueue for bulk SVG scanning" unless scope.any?
+
+    scope.each(&:schedule_svg_batch_scan)
+  end
+
   namespace :bulk_fix do
     desc "Fix assets and draft replacements"
     task :fix_assets_and_draft_replacements, %i[csv_path] => :environment do |_t, args|

--- a/spec/lib/s3_storage/fake_spec.rb
+++ b/spec/lib/s3_storage/fake_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe S3Storage::Fake do
   let(:root_directory) { Dir.mktmpdir }
   let(:root_path) { Pathname.new(root_directory.to_s) }
   let(:relative_path_to_asset) { storage.relative_path_for(asset) }
+  let(:download_path_to_asset) { storage.download_path_for(asset) }
 
   after do
     FileUtils.remove_entry(root_directory)
@@ -23,6 +24,16 @@ RSpec.describe S3Storage::Fake do
 
     it "writes file to fake S3 storage directory" do
       storage.upload(asset)
+
+      expect(File).to exist(asset_path)
+    end
+  end
+
+  context "when downloading a file" do
+    let(:asset_path) { root_path.join(download_path_to_asset) }
+
+    it "writes file to local directory" do
+      storage.download(asset)
 
       expect(File).to exist(asset_path)
     end
@@ -108,6 +119,14 @@ RSpec.describe S3Storage::Fake do
   describe "#metadata_for" do
     it "raises exception to indicate method not implemented" do
       expect { storage.metadata_for(asset) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#download_path_for" do
+    it "returns a temporary file path containing the asset uuid" do
+      expect(download_path_to_asset).to be_a(String)
+      expect(download_path_to_asset).to include(asset.uuid)
+      expect(download_path_to_asset).to start_with(Dir.tmpdir)
     end
   end
 end

--- a/spec/lib/s3_storage_spec.rb
+++ b/spec/lib/s3_storage_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe S3Storage do
     end
   end
 
+  describe "#download" do
+    it "downloads the file from the S3 bucket" do
+      allow(s3_client).to receive(:get_object)
+      file = storage.download(asset)
+      expect(s3_client).to have_received(:get_object)
+      expect(File).to exist(file.path)
+    end
+  end
+
   describe "#delete" do
     it "deletes the file from the S3 bucket" do
       allow(s3_object).to receive(:delete).and_return(true)

--- a/spec/lib/tasks/assets_spec.rb
+++ b/spec/lib/tasks/assets_spec.rb
@@ -30,6 +30,106 @@ RSpec.describe "assets.rake" do
     end
   end
 
+  describe "assets:bulk_scan_svgs" do
+    let(:task) { Rake::Task["assets:bulk_scan_svgs"] }
+    let(:sidekiq_queue) { instance_double(Sidekiq::Queue) }
+    let(:queue_empty) { true }
+
+    before do
+      task.reenable
+
+      allow(Sidekiq::Queue)
+        .to receive(:new)
+        .with("batch")
+        .and_return(sidekiq_queue)
+      allow(sidekiq_queue).to receive(:any?).and_return(!queue_empty)
+    end
+
+    context "when there are no in-scope assets to scan" do
+      before do
+        FactoryBot.create(:asset) # not uploaded
+        FactoryBot.create(:uploaded_asset, deleted_at: Time.zone.now) # deleted
+        FactoryBot.create(
+          :uploaded_asset,
+          redirect_url: "https://www.gov.uk/somewhere",
+        ) # redirected
+        FactoryBot.create(:uploaded_svg_asset) # scanned
+        FactoryBot.create(:uploaded_asset).set(mime_type: "application/pdf") # wrong MIME type
+      end
+
+      it "raises an error without enqueuing any SVG scan" do
+        expect(SvgScanBatchJob).not_to receive(:perform_async)
+
+        expect { task.invoke("10") }
+          .to raise_error("No assets found to enqueue for bulk SVG scanning")
+      end
+    end
+
+    context "when there are in-scope assets to scan" do
+      let!(:nil_mime_type_asset) { FactoryBot.create(:uploaded_asset).set(mime_type: nil) }
+      let!(:unscanned_svg_asset) { FactoryBot.create(:uploaded_svg_asset).set(svg_scan_state: nil) }
+
+      it "enqueues the assets for scanning" do
+        expect(SvgScanBatchJob).to receive(:perform_async).with(nil_mime_type_asset.id.to_s)
+        expect(SvgScanBatchJob).to receive(:perform_async).with(unscanned_svg_asset.id.to_s)
+
+        task.invoke("10")
+      end
+
+      it "logs a info message" do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger)
+          .to receive(:info)
+          .with("Enqueuing up to 10 assets for bulk SVG scanning")
+
+        task.invoke("10")
+      end
+
+      context "but the batch size is smaller than the in-scope asset count" do
+        it "only enqueues assets up to the batch size" do
+          expect(SvgScanBatchJob).to receive(:perform_async).once
+
+          task.invoke("1")
+        end
+      end
+
+      context "but the batch size is missing" do
+        it "raises an error" do
+          expect { task.invoke }
+            .to raise_error(ArgumentError, "Invalid batch size for bulk SVG scanning: nil")
+        end
+      end
+
+      context "but the batch size is zero" do
+        it "raises an error" do
+          expect { task.invoke("0") }
+            .to raise_error(ArgumentError, "Invalid batch size for bulk SVG scanning: 0")
+        end
+      end
+
+      context "but there are jobs in the batch queue" do
+        let(:queue_empty) { false }
+
+        it "does not enqueue any SVG scan" do
+          expect(SvgScanBatchJob).not_to receive(:perform_async)
+
+          task.invoke("10")
+        end
+
+        it "logs a message" do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger)
+            .to receive(:info)
+            .with(
+              "Not enqueuing assets for bulk SVG scanning: previous batch still in progress",
+            )
+
+          task.invoke("10")
+        end
+      end
+    end
+  end
+
   # rubocop:disable RSpec/AnyInstance
   context "when running a bulk fix" do
     let(:asset_id) { BSON::ObjectId("6592008029c8c3e4dc76256c") }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Asset, type: :model do
       end
 
       it "does not accept otherwise valid states" do
-        %w[svg_clean svg_infected].each do |svg_scan_state|
+        %w[svg_clean svg_infected file_missing_from_s3].each do |svg_scan_state|
           asset.svg_scan_state = svg_scan_state
 
           expect(asset).to be_invalid
@@ -319,7 +319,7 @@ RSpec.describe Asset, type: :model do
       end
 
       it "accept valid states" do
-        %w[svg_clean svg_infected].each do |svg_scan_state|
+        %w[svg_clean svg_infected file_missing_from_s3].each do |svg_scan_state|
           asset.svg_scan_state = svg_scan_state
 
           expect(asset).to be_valid

--- a/spec/sidekiq/svg_scan_batch_job_spec.rb
+++ b/spec/sidekiq/svg_scan_batch_job_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+require "services"
+require "sidekiq_unique_jobs/testing"
+
+RSpec.describe SvgScanBatchJob do
+  let(:worker) { described_class.new }
+  let(:asset) { FactoryBot.create(:virus_free_svg_asset) }
+  let(:scanner) { instance_double(SvgScanner) }
+  let(:storage) { instance_double(S3Storage) }
+  let(:file) { Tempfile.new }
+
+  before do
+    allow(Services).to receive_messages(svg_scanner: scanner, cloud_storage: storage)
+    allow(storage).to receive(:download).and_return(file)
+  end
+
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
+  it "does not permit multiple jobs to be enqueued for the same asset" do
+    SidekiqUniqueJobs.use_config(enabled: true) do
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.to enqueue_sidekiq_job(described_class)
+      expect { described_class.perform_in(1.minute, asset.id.to_s) }.not_to enqueue_sidekiq_job(described_class)
+    end
+  end
+
+  context "when the file doesn't exist in S3" do
+    before do
+      context = Seahorse::Client::RequestContext.new
+      error = Aws::S3::Errors::NoSuchKey.new(context, "The specified key does not exist.")
+      allow(storage).to receive(:download).and_raise(error)
+      allow(Rails.logger).to receive(:info).at_least(:once)
+    end
+
+    it "updates the asset's SVG scan state" do
+      worker.perform(asset.id)
+
+      expect(asset.reload.svg_scan_state).to eq("file_missing_from_s3")
+    end
+
+    it "logs that the asset is missing" do
+      expect(Rails.logger).to receive(:info).with("#{asset.id} - SvgScanBatchJob - Asset missing from S3").once
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the asset doesn't yet know its file's mimetype" do
+    before do
+      asset.set(mime_type: nil)
+
+      allow(Marcel::MimeType).to receive(:for).and_return("image/svg+xml")
+      allow(scanner).to receive(:scan)
+    end
+
+    it "identifies and records it" do
+      worker.perform(asset.id)
+
+      expect(asset.reload.mime_type).to eq("image/svg+xml")
+    end
+  end
+
+  context "when the file's mimetype is not 'image/svg+xml'" do
+    before { asset.set(mime_type: "application/pdf") }
+
+    it "does not perform a scan" do
+      expect(scanner).not_to receive(:scan)
+
+      worker.perform(asset.id)
+    end
+  end
+
+  context "when the file's mimetype is 'image/svg+xml'" do
+    before { asset.set(mime_type: "image/svg+xml") }
+
+    it "calls out to the SvgScanner to scan the file" do
+      expect(scanner).to receive(:scan).with(file.path)
+
+      worker.perform(asset.id)
+    end
+
+    context "when the file is clean" do
+      before { allow(scanner).to receive(:scan) }
+
+      it "records that SVG scan state" do
+        worker.perform(asset.id)
+
+        expect(asset.reload.svg_scan_state).to eq("svg_clean")
+      end
+
+      it "records the time of the scan" do
+        travel_to Time.zone.parse("2026-07-20 16:35")
+
+        worker.perform(asset.id)
+
+        expect(asset.reload.svg_scanned_at.to_s).to eq("2026-07-20 16:35:00 +0100")
+      end
+    end
+
+    context "when the SVG asset is potentially unsafe" do
+      let(:exception_message) { "SVG: Unsafe element detected: <script>" }
+      let(:exception) { SvgDocument::UnsafeSvg.new(exception_message) }
+
+      before do
+        allow(scanner).to receive(:scan).and_raise(exception)
+        allow(Rails.logger).to receive(:info).at_least(:once)
+        allow(GovukError).to receive(:notify).at_least(:once)
+      end
+
+      it "records that SVG scan state" do
+        worker.perform(asset.id)
+
+        expect(asset.reload.svg_scan_state).to eq("svg_infected")
+      end
+
+      it "records the time of the scan" do
+        travel_to Time.zone.parse("2026-07-20 16:35")
+
+        worker.perform(asset.id)
+
+        expect(asset.reload.svg_scanned_at.to_s).to eq("2026-07-20 16:35:00 +0100")
+      end
+
+      it "logs the failure" do
+        expect(Rails.logger).to receive(:info).with("#{asset.id} - SvgScanBatchJob - SVG unsafe").once
+        expect(GovukError).to receive(:notify).with(exception, extra: { id: asset.id, filename: asset.filename })
+
+        worker.perform(asset.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds bulk SVG scanning for assets uploaded before scanning existed. S3 storage gains a download method, a new batch job downloads the file from S3 and scans it without altering the asset's state, and a temporary rake task enqueues unscanned in-scope assets up to a given batch size. The job runs on a low-priority "batch" queue, and the task is intended to run on a schedule until the backlog is cleared

Fifth of five stacked PRs reworking #1991

Closes #1991
