### PR TITLE
Bump `msgpack` from 1.8.1 to 1.8.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
     mongoid-grid_fs (2.6.0)
       mime-types (>= 1.0, < 4.0)
       mongoid (>= 3.0, < 10.0)
-    msgpack (1.8.1)
+    msgpack (1.8.4)
     multi_json (1.19.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)


### PR DESCRIPTION
Dependabot wasn't able to do this, so manually raising a PR after running `bundle update msgpack`.

Resolves https://github.com/alphagov/asset-manager/security/dependabot/124.