### PR TITLE
[PP-7805] Mount SidekiqUniqueJobs web UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 require "govuk_sidekiq/gds_sso_middleware"
 require "healthcheck/cloud_storage"
+require "sidekiq_unique_jobs/web"
 
 Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }


### PR DESCRIPTION
We use SidekiqUniqueJobs in this app, but the web UI was not required and therefore not mounted. I believe it needs requiring before we mount the `GovukSidekiq::GdsSsoMiddleware`