### PR TITLE
[PP-7805] Remove lock on SVG batch scan job

### DIFF
--- a/app/sidekiq/svg_scan_batch_job.rb
+++ b/app/sidekiq/svg_scan_batch_job.rb
@@ -3,7 +3,7 @@ require "services"
 class SvgScanBatchJob
   include Sidekiq::Job
 
-  sidekiq_options lock: :until_executing, queue: "batch"
+  sidekiq_options queue: "batch"
 
   def perform(asset_id)
     asset = Asset.find(asset_id)

--- a/spec/sidekiq/svg_scan_batch_job_spec.rb
+++ b/spec/sidekiq/svg_scan_batch_job_spec.rb
@@ -14,15 +14,6 @@ RSpec.describe SvgScanBatchJob do
     allow(storage).to receive(:download).and_return(file)
   end
 
-  specify { expect(described_class).to have_valid_sidekiq_options }
-
-  it "does not permit multiple jobs to be enqueued for the same asset" do
-    SidekiqUniqueJobs.use_config(enabled: true) do
-      expect { described_class.perform_in(1.minute, asset.id.to_s) }.to enqueue_sidekiq_job(described_class)
-      expect { described_class.perform_in(1.minute, asset.id.to_s) }.not_to enqueue_sidekiq_job(described_class)
-    end
-  end
-
   context "when the file doesn't exist in S3" do
     before do
       context = Seahorse::Client::RequestContext.new


### PR DESCRIPTION
Investigation suggests that this job is causing orphaned locks to accumulate. This is likely a bug with SidekiqUniqueJobs and the `:until_executing` strategy. The orphaned locks are the likely cause of gradually rising Redis memory. Also rising are:
- the disk usage floor. Disk usage is cleaned up whenever it reaches 0.8%, but the post-cleanup usage has been steadily rising
- the peak age of the oldest job - this has been growing, suggesting the jobs are gradually being worked through slower

We don't really need the lock here:
- the enqueueing Rake task checks that the `batch` queue is empty before queueing new jobs
- it only enqueues assets whose `svg_scan_state` is `nil` and the job will update this (except in the case of a genuine error, in which case we'd want to retry the job anyway), preventing the same asset being queued in multiple runs