### PR TITLE
Add temporary rake task clearing access_limited values [WHIT-3767]

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -33,6 +33,14 @@ namespace :assets do
     puts "Asset ID for #{legacy_url_path} is #{asset.id}."
   end
 
+  desc "Clear legacy `access_limited` values ahead of us enabling individual access limiting in Whitehall"
+  task clear_legacy_access_limited: :environment do
+    Asset.collection.update_many(
+      { "access_limited.0" => { "$exists" => true } },
+      { "$set" => { access_limited: [] } },
+    )
+  end
+
   desc "Soft delete assets and check deleted invalid state"
   task :bulk_soft_delete, %i[csv_path] => :environment do |_t, args|
     csv_path = args.fetch(:csv_path)

--- a/spec/lib/tasks/assets_spec.rb
+++ b/spec/lib/tasks/assets_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe "assets.rake" do
     end
   end
 
+  describe "clear_legacy_access_limited" do
+    let(:task) { Rake::Task["assets:clear_legacy_access_limited"] }
+
+    before do
+      task.reenable
+    end
+
+    it "clears legacy access_limited values without changing any other attributes" do
+      asset = FactoryBot.create(:asset, access_limited: %w[user1 user2])
+      asset.reload
+
+      original_attributes = asset.attributes
+
+      expect {
+        task.invoke
+      }.not_to(change { asset.reload.updated_at })
+
+      expect(asset.reload.attributes).to eq(
+        original_attributes.merge("access_limited" => []),
+      )
+    end
+  end
+
   describe "assets:bulk_scan_svgs" do
     let(:task) { Rake::Task["assets:bulk_scan_svgs"] }
     let(:sidekiq_queue) { instance_double(Sidekiq::Queue) }


### PR DESCRIPTION
There are ~27k assets with a non-nil, non-empty-array value for `access_limited`, despite no publishing apps making use of the intended feature: to access-limit to named individuals. Where a value has been set, the values tend to correspond to Organisation UIDs, which should have been set under the `access_limited_organisation_ids` field intead.

We're about to enable individual access limiting in Whitehall, and before we do so, we want to clear the legacy values so that there is a clean slate.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3767

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
