### PR TITLE
[PP-7924] Add User based restrictions to Asset Manager API endpoints

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -14,6 +14,8 @@ class AssetsController < ApplicationController
   def create
     @asset = build_asset
 
+    @asset.user = current_user
+
     if @asset.save
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :created), status: :created
     else

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -7,6 +7,8 @@ class AssetsController < ApplicationController
   def show
     @asset = find_asset(include_deleted: true)
 
+    return error_403 unless @asset.manageable_by?(current_user)
+
     expires_now
     render json: AssetPresenter.new(@asset, view_context)
   end
@@ -26,6 +28,8 @@ class AssetsController < ApplicationController
   def update
     @asset = Asset.undeleted.or(Asset.where(draft: true)).find(params[:id])
 
+    return error_403 unless @asset.manageable_by?(current_user)
+
     if @asset.update(asset_params)
       render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
     else
@@ -35,12 +39,18 @@ class AssetsController < ApplicationController
 
   def destroy
     @asset = find_asset
+
+    return error_403 unless @asset.manageable_by?(current_user)
+
     @asset.destroy!
     render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
   end
 
   def restore
     @asset = find_asset(include_deleted: true)
+
+    return error_403 unless @asset.manageable_by?(current_user)
+
     @asset.restore
     render json: AssetPresenter.new(@asset, view_context).as_json(status: :success)
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -17,6 +17,7 @@ class Asset
   index deleted_at: 1
 
   belongs_to :replacement, class_name: "Asset", optional: true, index: true
+  belongs_to :user, optional: true
 
   field :state, type: String, default: "unscanned"
   field :filename_history, type: Array, default: -> { [] }

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -135,6 +135,10 @@ class Asset
     access_limited.include?(user.uid) || access_limited_organisation_ids.include?(user.organisation_content_id)
   end
 
+  def manageable_by?(user)
+    self.user == user || user.permissions.include?("Manage all Assets")
+  end
+
   def valid_auth_bypass_token?(auth_bypass_id)
     auth_bypass_ids.include?(auth_bypass_id) && (auth_bypass_ids_expiry.nil? || auth_bypass_ids_expiry > Time.zone.now)
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe AssetsController, type: :controller do
 
   let(:file) { load_fixture_file("asset.png") }
 
-  before do
-    login_as_stub_user
-  end
-
   describe "POST create" do
     let(:valid_attributes) { { file: } }
+
+    before do
+      login_as_stub_user
+    end
 
     context "when attributes are valid" do
       it "persists asset" do
@@ -227,304 +227,452 @@ RSpec.describe AssetsController, type: :controller do
   end
 
   describe "PUT update" do
-    context "with an existing asset" do
-      let(:asset) { FactoryBot.create(:asset) }
-      let(:file) { load_fixture_file("asset2.jpg") }
-      let(:valid_attributes) { { file: } }
+    let(:asset) { FactoryBot.create(:asset, user:) }
 
-      it "persists new attributes on existing asset" do
-        put :update, params: { id: asset.id, asset: valid_attributes }
-
-        expect(assigns(:asset)).to be_persisted
+    context "when authenticated as a regular user" do
+      before do
+        login_as_stub_user
       end
 
-      it "stores file on existing asset" do
-        put :update, params: { id: asset.id, asset: valid_attributes }
+      context "with an existing asset owned by that user" do
+        let(:user) { stub_user }
+        let(:file) { load_fixture_file("asset2.jpg") }
+        let(:valid_attributes) { { file: } }
 
-        expect(assigns(:asset).file.path).to match(/asset2\.jpg$/)
-      end
+        it "persists new attributes on existing asset" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
 
-      it "stores access_limited on existing asset" do
-        attributes = valid_attributes.merge(access_limited: %w[user-id])
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).access_limited).to eq(%w[user-id])
-      end
-
-      it "resets access_limits for an existing asset with a blank acess_limited_user_ids param" do
-        asset.update!(access_limited: %w[user-uid])
-
-        # We have to use an empty string as that is what gds-api-adapters/rest-client
-        # will generate instead of an empty array
-        attributes = valid_attributes.merge(access_limited_user_ids: "")
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).access_limited).to eq([])
-      end
-
-      it "resets access_limits for an existing asset with a blank acess_limited param" do
-        asset.update!(access_limited: %w[user-uid])
-
-        # We have to use an empty string as that is what gds-api-adapters/rest-client
-        # will generate instead of an empty array
-        attributes = valid_attributes.merge(access_limited: "")
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).access_limited).to eq([])
-      end
-
-      it "stores access_limited_organisation_ids on existing asset" do
-        attributes = valid_attributes.merge(access_limited_organisation_ids: %w[org-id])
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).access_limited_organisation_ids).to eq(%w[org-id])
-      end
-
-      it "resets access_limited_organisation_ids to an empty array for an existing asset with an access_limited_organisation_ids array" do
-        asset.update!(access_limited_organisation_ids: %w[org-id])
-
-        # We have to use an empty string as that is what gds-api-adapters/rest-client
-        # will generate instead of an empty array
-        attributes = valid_attributes.merge(access_limited_organisation_ids: "")
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).access_limited_organisation_ids).to eq([])
-      end
-
-      it "stores auth_bypass_ids on existing asset" do
-        attributes = valid_attributes.merge(auth_bypass_ids: %w[bypass-id])
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).auth_bypass_ids).to eq(%w[bypass-id])
-      end
-
-      it "copes when auth_bypass_ids are passed in as an empty string" do
-        asset.update!(auth_bypass_ids: %w[bypass-1 bypass-2])
-
-        # We have to use an empty string as that is what gds-api-adapters/rest-client
-        # will generate instead of an empty array
-        attributes = valid_attributes.merge(auth_bypass_ids: "")
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).auth_bypass_ids).to eq([])
-      end
-
-      it "stores redirect_url on existing asset" do
-        redirect_url = "https://example.com/path/file.ext"
-        attributes = valid_attributes.merge(redirect_url:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).redirect_url).to eq(redirect_url)
-      end
-
-      it "stores blank redirect_url as nil on existing asset" do
-        redirect_url = ""
-        attributes = valid_attributes.merge(redirect_url:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).redirect_url).to be_nil
-      end
-
-      it "removes existing redirect_url from existing asset if empty one is sent" do
-        redirect_url = "https://example.com/path/file.ext"
-        attributes = valid_attributes.merge(redirect_url:)
-        put :update, params: { id: asset.id, asset: attributes }
-        expect(assigns(:asset).redirect_url).to eq(redirect_url)
-
-        attributes = valid_attributes.merge(redirect_url: "")
-        put :update, params: { id: asset.id, asset: attributes }
-        expect(assigns(:asset).redirect_url).to be_nil
-      end
-
-      it "stores replacement on existing asset" do
-        replacement = FactoryBot.create(:asset)
-        replacement_id = replacement.id.to_s
-        attributes = valid_attributes.merge(replacement_id:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).replacement).to eq(replacement)
-      end
-
-      it "stores replacement_id as nil if replacement_id is blank" do
-        replacement_id = ""
-        attributes = valid_attributes.merge(replacement_id:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(assigns(:asset).replacement_id).to be_nil
-      end
-
-      it "responds with unprocessable entity status if replacement is not found" do
-        replacement_id = "non-existent-asset-id"
-        attributes = valid_attributes.merge(replacement_id:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        expect(response).to have_http_status(:unprocessable_content)
-      end
-
-      it "includes error message in response if replacement is not found" do
-        replacement_id = "non-existent-asset-id"
-        attributes = valid_attributes.merge(replacement_id:)
-        put :update, params: { id: asset.id, asset: attributes }
-
-        body = JSON.parse(response.body)
-        status = body["_response_info"]["status"]
-        expect(status).to include("Replacement not found")
-      end
-
-      it "responds with success status" do
-        put :update, params: { id: asset.id, asset: valid_attributes }
-
-        expect(response).to have_http_status(:success)
-      end
-
-      it "responds with the details of the existing asset" do
-        put :update, params: { id: asset.id, asset: valid_attributes }
-
-        asset = assigns(:asset)
-
-        body = JSON.parse(response.body)
-
-        expect(body["id"]).to eq("http://test.host/assets/#{asset.id}")
-        expect(body["name"]).to eq("asset2.jpg")
-        expect(body["content_type"]).to eq("image/jpeg")
-        expect(body["draft"]).to be_falsey
-      end
-
-      context "when attributes include draft status" do
-        let(:attributes) { valid_attributes.merge(draft: true) }
-
-        it "stores draft status on existing asset" do
-          put :update, params: { id: asset.id, asset: attributes }
-
-          expect(assigns(:asset)).to be_draft
+          expect(assigns(:asset)).to be_persisted
         end
 
-        it "includes the draft status in the response" do
+        it "stores file on existing asset" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
+
+          expect(assigns(:asset).file.path).to match(/asset2\.jpg$/)
+        end
+
+        it "stores access_limited on existing asset" do
+          attributes = valid_attributes.merge(access_limited: %w[user-id])
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).access_limited).to eq(%w[user-id])
+        end
+
+        it "resets access_limits for an existing asset with a blank acess_limited_user_ids param" do
+          asset.update!(access_limited: %w[user-uid])
+
+          # We have to use an empty string as that is what gds-api-adapters/rest-client
+          # will generate instead of an empty array
+          attributes = valid_attributes.merge(access_limited_user_ids: "")
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).access_limited).to eq([])
+        end
+
+        it "resets access_limits for an existing asset with a blank acess_limited param" do
+          asset.update!(access_limited: %w[user-uid])
+
+          # We have to use an empty string as that is what gds-api-adapters/rest-client
+          # will generate instead of an empty array
+          attributes = valid_attributes.merge(access_limited: "")
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).access_limited).to eq([])
+        end
+
+        it "stores access_limited_organisation_ids on existing asset" do
+          attributes = valid_attributes.merge(access_limited_organisation_ids: %w[org-id])
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).access_limited_organisation_ids).to eq(%w[org-id])
+        end
+
+        it "resets access_limited_organisation_ids to an empty array for an existing asset with an access_limited_organisation_ids array" do
+          asset.update!(access_limited_organisation_ids: %w[org-id])
+
+          # We have to use an empty string as that is what gds-api-adapters/rest-client
+          # will generate instead of an empty array
+          attributes = valid_attributes.merge(access_limited_organisation_ids: "")
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).access_limited_organisation_ids).to eq([])
+        end
+
+        it "stores auth_bypass_ids on existing asset" do
+          attributes = valid_attributes.merge(auth_bypass_ids: %w[bypass-id])
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).auth_bypass_ids).to eq(%w[bypass-id])
+        end
+
+        it "copes when auth_bypass_ids are passed in as an empty string" do
+          asset.update!(auth_bypass_ids: %w[bypass-1 bypass-2])
+
+          # We have to use an empty string as that is what gds-api-adapters/rest-client
+          # will generate instead of an empty array
+          attributes = valid_attributes.merge(auth_bypass_ids: "")
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).auth_bypass_ids).to eq([])
+        end
+
+        it "stores redirect_url on existing asset" do
+          redirect_url = "https://example.com/path/file.ext"
+          attributes = valid_attributes.merge(redirect_url:)
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).redirect_url).to eq(redirect_url)
+        end
+
+        it "stores blank redirect_url as nil on existing asset" do
+          redirect_url = ""
+          attributes = valid_attributes.merge(redirect_url:)
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).redirect_url).to be_nil
+        end
+
+        it "removes existing redirect_url from existing asset if empty one is sent" do
+          redirect_url = "https://example.com/path/file.ext"
+          attributes = valid_attributes.merge(redirect_url:)
+          put :update, params: { id: asset.id, asset: attributes }
+          expect(assigns(:asset).redirect_url).to eq(redirect_url)
+
+          attributes = valid_attributes.merge(redirect_url: "")
+          put :update, params: { id: asset.id, asset: attributes }
+          expect(assigns(:asset).redirect_url).to be_nil
+        end
+
+        it "stores replacement on existing asset" do
+          replacement = FactoryBot.create(:asset)
+          replacement_id = replacement.id.to_s
+          attributes = valid_attributes.merge(replacement_id:)
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).replacement).to eq(replacement)
+        end
+
+        it "stores replacement_id as nil if replacement_id is blank" do
+          replacement_id = ""
+          attributes = valid_attributes.merge(replacement_id:)
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(assigns(:asset).replacement_id).to be_nil
+        end
+
+        it "responds with unprocessable entity status if replacement is not found" do
+          replacement_id = "non-existent-asset-id"
+          attributes = valid_attributes.merge(replacement_id:)
+          put :update, params: { id: asset.id, asset: attributes }
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "includes error message in response if replacement is not found" do
+          replacement_id = "non-existent-asset-id"
+          attributes = valid_attributes.merge(replacement_id:)
           put :update, params: { id: asset.id, asset: attributes }
 
           body = JSON.parse(response.body)
-
-          expect(body["draft"]).to be_truthy
+          status = body["_response_info"]["status"]
+          expect(status).to include("Replacement not found")
         end
 
-        it "changes draft state for draft deleted asset" do
-          asset.update!(deleted_at: 1.hour.ago, draft: true)
+        it "responds with success status" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
 
-          put :update, params: { id: asset.id, asset: attributes.merge(draft: false) }
-
-          expect(asset.reload).not_to be_draft
+          expect(response).to have_http_status(:success)
         end
 
-        it "preserves draft state for live deleted asset" do
-          asset.update!(deleted_at: 1.hour.ago, draft: false)
+        it "responds with the details of the existing asset" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
 
-          put :update, params: { id: asset.id, asset: attributes.merge(draft: true) }
+          asset = assigns(:asset)
 
-          expect(asset.reload).not_to be_draft
+          body = JSON.parse(response.body)
+
+          expect(body["id"]).to eq("http://test.host/assets/#{asset.id}")
+          expect(body["name"]).to eq("asset2.jpg")
+          expect(body["content_type"]).to eq("image/jpeg")
+          expect(body["draft"]).to be_falsey
+        end
+
+        context "when attributes include draft status" do
+          let(:attributes) { valid_attributes.merge(draft: true) }
+
+          it "stores draft status on existing asset" do
+            put :update, params: { id: asset.id, asset: attributes }
+
+            expect(assigns(:asset)).to be_draft
+          end
+
+          it "includes the draft status in the response" do
+            put :update, params: { id: asset.id, asset: attributes }
+
+            body = JSON.parse(response.body)
+
+            expect(body["draft"]).to be_truthy
+          end
+
+          it "changes draft state for draft deleted asset" do
+            asset.update!(deleted_at: 1.hour.ago, draft: true)
+
+            put :update, params: { id: asset.id, asset: attributes.merge(draft: false) }
+
+            expect(asset.reload).not_to be_draft
+          end
+
+          it "preserves draft state for live deleted asset" do
+            asset.update!(deleted_at: 1.hour.ago, draft: false)
+
+            put :update, params: { id: asset.id, asset: attributes.merge(draft: true) }
+
+            expect(asset.reload).not_to be_draft
+          end
+        end
+      end
+
+      context "with an existing asset not owned by that user" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:file) { load_fixture_file("asset2.jpg") }
+        let(:valid_attributes) { { file: } }
+
+        it "responds with http forbidden" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context "when authenticated as a managing user" do
+      before do
+        login_as_stub_managing_user
+      end
+
+      context "with an existing asset not owned by that user" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:file) { load_fixture_file("asset2.jpg") }
+        let(:valid_attributes) { { file: } }
+
+        it "responds with http success" do
+          put :update, params: { id: asset.id, asset: valid_attributes }
+
+          expect(response).to have_http_status(:success)
         end
       end
     end
   end
 
   describe "DELETE destroy" do
-    context "with an existing asset" do
-      let(:asset) { FactoryBot.create(:asset) }
+    let(:asset) { FactoryBot.create(:asset, user:) }
 
-      it "deletes the asset" do
-        delete :destroy, params: { id: asset.id }
-
-        expect(Asset.where(id: asset.id).first.deleted_at).not_to be_nil
+    context "when authenticated as a regular user" do
+      before do
+        login_as_stub_user
       end
 
-      it "responds with a success status" do
-        delete :destroy, params: { id: asset.id }
+      context "with no existing asset" do
+        it "responds with not found status" do
+          delete :destroy, params: { id: "12345" }
 
-        expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "with an asset owned by that user" do
+        let(:user) { stub_user }
+
+        it "deletes the asset" do
+          delete :destroy, params: { id: asset.id }
+
+          expect(Asset.where(id: asset.id).first.deleted_at).not_to be_nil
+        end
+
+        it "responds with a success status" do
+          delete :destroy, params: { id: asset.id }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "with an asset not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
+
+        it "responds with a forbidden status" do
+          delete :destroy, params: { id: asset.id }
+
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 
-    context "with no existing asset" do
-      it "responds with not found status" do
-        delete :destroy, params: { id: "12345" }
-        expect(response).to have_http_status(:not_found)
+    context "when authenticated as a managing user" do
+      before do
+        login_as_stub_managing_user
+      end
+
+      context "when the asset is not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
+
+        it "responds with a success status" do
+          delete :destroy, params: { id: asset.id }
+
+          expect(response).to have_http_status(:success)
+        end
       end
     end
   end
 
   describe "GET show" do
-    context "with an asset which exists" do
-      let(:asset) { FactoryBot.create(:asset) }
+    context "when authenticated as a regular user" do
+      let(:asset) { FactoryBot.create(:asset, user:) }
 
-      it "responds with success status" do
-        get :show, params: { id: asset.id }
-
-        expect(response).to be_successful
+      before do
+        login_as_stub_user
       end
 
-      it "makes the asset available to the view template" do
-        get :show, params: { id: asset.id }
+      context "with an asset owned by the user" do
+        let(:user) { stub_user }
 
-        expect(assigns(:asset)).to be_a(Asset)
-        expect(assigns(:asset).id).to eq(asset.id)
+        it "responds with success status" do
+          get :show, params: { id: asset.id }
+
+          expect(response).to be_successful
+        end
+
+        it "makes the asset available to the view template" do
+          get :show, params: { id: asset.id }
+
+          expect(assigns(:asset)).to be_a(Asset)
+          expect(assigns(:asset).id).to eq(asset.id)
+        end
+
+        it "includes the draft status in the response" do
+          get :show, params: { id: asset.id }
+
+          body = JSON.parse(response.body)
+
+          expect(body["draft"]).to be_falsey
+        end
+
+        it "sets the Cache-Control header to no-cache" do
+          get :show, params: { id: asset.id }
+
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
       end
 
-      it "includes the draft status in the response" do
-        get :show, params: { id: asset.id }
+      context "with an asset not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
 
-        body = JSON.parse(response.body)
+        it "responds with forbidden status" do
+          get :show, params: { id: asset.id }
 
-        expect(body["draft"]).to be_falsey
+          expect(response).to have_http_status(:forbidden)
+        end
       end
 
-      it "sets the Cache-Control header to no-cache" do
-        get :show, params: { id: asset.id }
+      context "with an asset that has been deleted" do
+        let(:user) { stub_user }
+        let(:asset) { FactoryBot.create(:deleted_asset, user:) }
 
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        it "responds with success status" do
+          get :show, params: { id: asset.id }
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "with no existing asset" do
+        it "responds with not found status" do
+          get :show, params: { id: "some-gif-or-other" }
+
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "responds with not found message" do
+          get :show, params: { id: "some-gif-or-other" }
+
+          body = JSON.parse(response.body)
+          expect(body["_response_info"]["status"]).to eq("not found")
+        end
       end
     end
 
-    context "with an asset that has been deleted" do
-      let(:asset) { FactoryBot.create(:deleted_asset) }
-
-      it "responds with success status" do
-        get :show, params: { id: asset.id }
-
-        expect(response).to be_successful
-      end
-    end
-
-    context "with no existing asset" do
-      it "responds with not found status" do
-        get :show, params: { id: "some-gif-or-other" }
-
-        expect(response).to have_http_status(:not_found)
+    context "when authenticated as a managing user" do
+      before do
+        login_as_stub_managing_user
       end
 
-      it "responds with not found message" do
-        get :show, params: { id: "some-gif-or-other" }
+      context "with an asset not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:asset) { FactoryBot.create(:deleted_asset, user:) }
 
-        body = JSON.parse(response.body)
-        expect(body["_response_info"]["status"]).to eq("not found")
+        it "responds with success status" do
+          get :show, params: { id: asset.id }
+
+          expect(response).to be_successful
+        end
       end
     end
   end
 
   describe "POST restore" do
-    context "with an asset marked as deleted" do
-      let(:asset) { FactoryBot.create(:asset, deleted_at: 10.minutes.ago) }
-
+    context "when authenticated as a regular user" do
       before do
-        post :restore, params: { id: asset.id }
+        login_as_stub_user
       end
 
-      it "responds with success status" do
-        expect(response).to be_successful
+      let(:asset) { FactoryBot.create(:asset, deleted_at: 10.minutes.ago, user:) }
+
+      context "with an asset marked as deleted" do
+        let(:user) { stub_user }
+
+        before do
+          post :restore, params: { id: asset.id }
+        end
+
+        it "responds with success status" do
+          expect(response).to be_successful
+        end
+
+        it "marks the asset as not deleted" do
+          restored_asset = assigns(:asset)
+          expect(restored_asset).not_to be_nil
+          expect(restored_asset.deleted_at).to be_nil
+        end
       end
 
-      it "marks the asset as not deleted" do
-        restored_asset = assigns(:asset)
-        expect(restored_asset).not_to be_nil
-        expect(restored_asset.deleted_at).to be_nil
+      context "with an asset marked as deleted that is not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
+
+        before do
+          post :restore, params: { id: asset.id }
+        end
+
+        it "responds with forbidden status" do
+          expect(response).to be_forbidden
+        end
+      end
+    end
+
+    context "when authenticated as a managing user" do
+      before do
+        login_as_stub_managing_user
+      end
+
+      context "with an asset marked as deleted that is not owned by the user" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:asset) { FactoryBot.create(:asset, deleted_at: 10.minutes.ago, user:) }
+
+        before do
+          post :restore, params: { id: asset.id }
+        end
+
+        it "responds with success status" do
+          expect(response).to be_successful
+        end
       end
     end
   end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset)).to be_persisted
       end
 
+      it "associates current user to asset" do
+        post :create, params: { asset: valid_attributes }
+
+        expect(assigns(:asset).user).to match(stub_user)
+      end
+
       it "stores file on asset" do
         post :create, params: { asset: valid_attributes }
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :asset do
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/asset.png")) }
+    user
   end
 
   factory :virus_free_asset, parent: :asset do

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -54,4 +54,8 @@ FactoryBot.define do
     sequence(:name) { |n| "Winston #{n}" }
     permissions { %w[signin] }
   end
+
+  factory :managing_user, parent: :user do
+    permissions { ["signin", "Manage all Assets"] }
+  end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -350,6 +350,50 @@ RSpec.describe Asset, type: :model do
     end
   end
 
+  describe "#manageable_by?" do
+    let(:asset) { FactoryBot.build(:asset, user: asset_owner) }
+
+    context "when the user is a managing user" do
+      let(:user) { FactoryBot.build(:managing_user) }
+
+      context "and the asset is owned by the user" do
+        let(:asset_owner) { user }
+
+        it "returns true" do
+          expect(asset).to be_manageable_by(user)
+        end
+      end
+
+      context "and the asset is not owned by the user" do
+        let(:asset_owner) { FactoryBot.build(:user) }
+
+        it "returns true" do
+          expect(asset).to be_manageable_by(user)
+        end
+      end
+    end
+
+    context "when the user is a regular user" do
+      let(:user) { FactoryBot.build(:user) }
+
+      context "and the asset is owned by the user" do
+        let(:asset_owner) { user }
+
+        it "returns true" do
+          expect(asset).to be_manageable_by(user)
+        end
+      end
+
+      context "and the asset is not owned by the user" do
+        let(:asset_owner) { FactoryBot.build(:user) }
+
+        it "returns false" do
+          expect(asset).not_to be_manageable_by(user)
+        end
+      end
+    end
+  end
+
   describe "#accessible_by?" do
     context "when the asset is live" do
       let(:asset) { FactoryBot.build(:asset, draft: false) }

--- a/spec/requests/asset_requests_spec.rb
+++ b/spec/requests/asset_requests_spec.rb
@@ -80,8 +80,10 @@ RSpec.describe "Asset requests", type: :request do
   end
 
   describe "retrieving an asset" do
+    let(:user) { stub_user }
+
     it "retreives details about an existing asset" do
-      asset = FactoryBot.create(:uploaded_asset)
+      asset = FactoryBot.create(:uploaded_asset, user:)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -97,7 +99,7 @@ RSpec.describe "Asset requests", type: :request do
     end
 
     it "returns details about an infected asset" do
-      asset = FactoryBot.create(:virus_infected_asset)
+      asset = FactoryBot.create(:virus_infected_asset, user:)
 
       get "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -122,8 +124,10 @@ RSpec.describe "Asset requests", type: :request do
   end
 
   describe "deleting an asset" do
+    let(:user) { stub_user }
+
     it "soft deletes an existing asset" do
-      asset = FactoryBot.create(:uploaded_asset)
+      asset = FactoryBot.create(:uploaded_asset, user:)
 
       delete "/assets/#{asset.id}"
       body = JSON.parse(response.body)
@@ -145,8 +149,10 @@ RSpec.describe "Asset requests", type: :request do
   end
 
   describe "restoring an asset" do
+    let(:user) { stub_user }
+
     it "restores a soft deleted asset" do
-      asset = FactoryBot.create(:uploaded_asset)
+      asset = FactoryBot.create(:uploaded_asset, user:)
 
       post "/assets/#{asset.id}/restore"
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -45,31 +45,31 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "an asset exists with identifier 4dca570c2975bc0d6d437491" do
     set_up do
-      FactoryBot.create(:uploaded_asset, id: "4dca570c2975bc0d6d437491")
+      FactoryBot.create(:uploaded_asset, id: "4dca570c2975bc0d6d437491", user: GDS::SSO.test_user)
     end
   end
 
   provider_state "a soft deleted asset exists with identifier 4dca570c2975bc0d6d437491" do
     set_up do
-      FactoryBot.create(:deleted_asset, id: "4dca570c2975bc0d6d437491")
+      FactoryBot.create(:deleted_asset, id: "4dca570c2975bc0d6d437491", user: GDS::SSO.test_user)
     end
   end
 
   provider_state "an asset exists with id 4dca570c2975bc0d6d437491 and filename asset.png" do
     set_up do
-      FactoryBot.create(:uploaded_asset, id: "4dca570c2975bc0d6d437491")
+      FactoryBot.create(:uploaded_asset, id: "4dca570c2975bc0d6d437491", user: GDS::SSO.test_user)
     end
   end
 
   provider_state "a whitehall asset exists with legacy url path /government/uploads/some-edition/hello.txt and id 4dca570c2975bc0d6d437491" do
     set_up do
-      FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: "/government/uploads/some-edition/hello.txt", id: "4dca570c2975bc0d6d437491")
+      FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: "/government/uploads/some-edition/hello.txt", id: "4dca570c2975bc0d6d437491", user: GDS::SSO.test_user)
     end
   end
 
   provider_state "a soft deleted whitehall asset exists with legacy url path /government/uploads/some-edition/hello.txt and id 4dca570c2975bc0d6d437491" do
     set_up do
-      FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: "/government/uploads/some-edition/hello.txt", id: "4dca570c2975bc0d6d437491", deleted_at: Time.zone.now)
+      FactoryBot.create(:uploaded_whitehall_asset, legacy_url_path: "/government/uploads/some-edition/hello.txt", id: "4dca570c2975bc0d6d437491", deleted_at: Time.zone.now, user: GDS::SSO.test_user)
     end
   end
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -23,8 +23,16 @@ module AuthenticationControllerHelpers
     @stub_user ||= FactoryBot.create(:user)
   end
 
+  def stub_managing_user
+    @stub_managing_user ||= FactoryBot.create(:managing_user)
+  end
+
   def login_as_stub_user
     login_as stub_user
+  end
+
+  def login_as_stub_managing_user
+    login_as stub_managing_user
   end
 end
 RSpec.configuration.include AuthenticationControllerHelpers, type: :controller
@@ -39,7 +47,7 @@ module AuthenticationFeatureHelpers
   end
 
   def stub_user
-    FactoryBot.create(:user)
+    @stub_user ||= FactoryBot.create(:user)
   end
 
   def login_as_stub_user

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -20,7 +20,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    FactoryBot.create(:user)
+    @stub_user ||= FactoryBot.create(:user)
   end
 
   def login_as_stub_user


### PR DESCRIPTION
This is being added to support the integration of HMRC-Manuals-API with Asset Manager

Without these controls HMRC Manuals API would have full management rights with all Assets stored on Asset manager, so we thought it prudent to add restrictions to how publishing apps and API users can manage assets. 

This PR means only API users with the "Manage all Assets" permission in Signon can use #show, #update, #delete and #restore endpoints in asset manager. Otherwise use of those endpoints will be restricted to the original Api user. 

This permission has already been created in Signon, and granted to every Publishing App with an active API user for Asset Manager, so merging this PR should cause no issues.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
