### PR TITLE
[PP-7941] Revert "[PP-7886] Allow `auth_bypass_ids` to expire"

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -83,7 +83,6 @@ private
       :replacement_id,
       :parent_document_url,
       :content_type,
-      :auth_bypass_ids_expiry,
       access_limited: [],
       access_limited_organisation_ids: [],
       auth_bypass_ids: [],

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -53,8 +53,6 @@ class Asset
 
   field :auth_bypass_ids, type: Array, default: []
 
-  field :auth_bypass_ids_expiry, type: Time
-
   field :parent_document_url, type: String
 
   field :svg_scanned_at, type: Time
@@ -140,7 +138,7 @@ class Asset
   end
 
   def valid_auth_bypass_token?(auth_bypass_id)
-    auth_bypass_ids.include?(auth_bypass_id) && (auth_bypass_ids_expiry.nil? || auth_bypass_ids_expiry > Time.zone.now)
+    auth_bypass_ids.include?(auth_bypass_id)
   end
 
   def public_url_path

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -73,14 +73,6 @@ RSpec.describe AssetsController, type: :controller do
         expect(assigns(:asset).auth_bypass_ids).to eq(%w[id1 id2])
       end
 
-      it "stores auth_bypass_ids_expiry on asset" do
-        expiry_time = Time.zone.now + 30.days
-        attributes = valid_attributes.merge(auth_bypass_ids_expiry: expiry_time)
-        post :create, params: { asset: attributes }
-
-        expect(assigns(:asset).auth_bypass_ids_expiry.floor).to eq(expiry_time.floor)
-      end
-
       it "stores parent_document_url on asset" do
         attributes = valid_attributes.merge(parent_document_url: "http://parent-document-url")
         post :create, params: { asset: attributes }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -441,22 +441,10 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "#valid_auth_bypass_token?" do
-    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids and there is no auth_bypass_ids_expiry" do
+    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids" do
       asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token])
       auth_bypass_id = "my-token"
       expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be true
-    end
-
-    it "returns true when given an auth_bypass_id which is in the auth_bypass_ids and auth_bypass_ids_expiry is in the future" do
-      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token], auth_bypass_ids_expiry: Time.zone.now + 1.day)
-      auth_bypass_id = "my-token"
-      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be true
-    end
-
-    it "returns false when given an auth_bypass_id which is in the auth_bypass_ids and auth_bypass_ids_expiry is in the past" do
-      asset = FactoryBot.build(:asset, auth_bypass_ids: %w[my-token], auth_bypass_ids_expiry: Time.zone.now - 1.day)
-      auth_bypass_id = "my-token"
-      expect(asset.valid_auth_bypass_token?(auth_bypass_id)).to be false
     end
 
     it "returns false when given an auth_bypass_id which is not in the auth_bypass_ids" do


### PR DESCRIPTION
When testing in integration, I found the preview tokens returned in the `file_url` don't work, and you are sent to Signon even when using a token to access a draft asset.

We are currently returning the `auth_bypass_id` to clients in plain text in the URL. Using this to access the asset doesn't work, as it is not the right thing to use.

According to [the documentation](https://docs.publishing.service.gov.uk/manual/content-preview.html#authentication-and-authorisationa), we should be turning this into a JWT, like the way it has been [done in Whitehall](https://github.com/alphagov/whitehall/blob/9f7ea0a4273f7499a19e5778ac9e66e64779c0aa/app/models/edition.rb#L383-L396).

Using a JWT, the token deals with the expiry, so we no longer need this logic to be included in Asset Manager.  This is resolved in https://github.com/alphagov/hmrc-manuals-api/pull/1332.

Reverts alphagov/asset-manager#2012