### PR TITLE
Allow downloading of access-limited assets by Whitehall [WHIT-3751]

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -65,8 +65,17 @@ protected
     asset.valid_auth_bypass_token?(@token_payload["sub"])
   end
 
+  def is_being_requested_from_whitehall_server?
+    shared_api_key = ENV.fetch("WHITEHALL_ASSET_MANAGER_SHARED_API_KEY", nil)
+    return false if shared_api_key.nil?
+
+    request.headers["X-Whitehall-Asset-Manager-Shared-API-Key"] == shared_api_key
+  end
+
   def authorized_for_asset?(asset)
     return true unless requested_from_draft_assets_host? || requested_from_internal_host?
+
+    return true if is_being_requested_from_whitehall_server?
 
     return true if has_bypass_id_for_asset?(asset)
 

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -45,4 +45,26 @@ RSpec.describe "Access limited assets", type: :request do
 
     expect(response).to be_forbidden
   end
+
+  it "is accessible to Whitehall server via the shared API key" do
+    login_as unauthorised_user
+
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("WHITEHALL_ASSET_MANAGER_SHARED_API_KEY", nil).and_return("shared-api-key")
+
+    get download_media_path(id: asset, filename: asset.filename), headers: { "X-Whitehall-Asset-Manager-Shared-API-Key" => "shared-api-key" }
+
+    expect(response).to be_successful
+  end
+
+  it "is not accessible to Whitehall server if the shared API key is incorrect" do
+    login_as unauthorised_user
+
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("WHITEHALL_ASSET_MANAGER_SHARED_API_KEY", nil).and_return("shared-api-key")
+
+    get download_media_path(id: asset, filename: asset.filename), headers: { "X-Whitehall-Asset-Manager-Shared-API-Key" => "incorrect-shared-api-key" }
+
+    expect(response).to be_forbidden
+  end
 end


### PR DESCRIPTION
## What

Defines a new `WHITEHALL_ASSET_MANAGER_SHARED_API_KEY` ENV variable which, if set, defines a shared key that can be used to bypass the usual access-limiting controls if sent as the `X-Whitehall-Asset-Manager-Shared-API-Key` header. (We can't use the Authorization header since it's [already used for general Asset Manager authorisation](https://github.com/alphagov/asset-manager/blob/9aa25355788bf929d6db596604c6313143b984e0/docs/api.md#api).)

We will include the WHITEHALL_ASSET_MANAGER_SHARED_API_KEY in requests to Asset Manager from Whitehall, as a proxy for "this request is coming from the Whitehall controller, which has its own access limiting controls in place, so please just give us the asset."

## Why

This is to enable access-limiting of images in Whitehall. [whitehall#11667](https://github.com/alphagov/whitehall/pull/11667) does the work to put images on the draft stack and apply access-limiting to them, but additional work is needed for images because Whitehall's image upload journey includes a cropping step, which requires Whitehall to re-download the image from Asset Manager. Currently, this step causes a server error if the image was uploaded to an access-limited document, because the image download fails, because the request to Asset Manager is unauthorized.

### Alternatives considered

1. Using the existing auth_bypass_token mechanism. We've taken steps to tighten automatic usage of the auth bypass token - in [whitehall#11543](https://github.com/alphagov/whitehall/pull/11543) we made it possible to delete the token, and we no longer generate it on document creation - it is opt-in. We don't want to undo that good work. To try to bring it back for this use case feels like a misuse of the auth_bypass_token's intentions. What we want instead is a global bypass for Whitehall itself, not a per-asset bypass, which would require us to set up a bypass token for the entire document (and all of its assets) - an unnecessary risk. We only intend to include the custom authorization header during the image cropping workflow, so the 'global bypass' shouldn't apply to attachments etc.
2. Proxying the user's asset manager cookie, to forward it to Asset Manager and download the asset 'as' the user. This relies on the user having accessed an Asset Manager asset already, which can't be guaranteed.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3751

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
