### PR TITLE
Allow downloading of access-limited assets by Whitehall [WHIT-3751]

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -130,7 +130,7 @@ class Asset
   def accessible_by?(user)
     return true unless draft? && access_limited?
 
-    access_limited.include?(user.uid) || access_limited_organisation_ids.include?(user.organisation_content_id)
+    access_limited.include?(user.uid) || access_limited_organisation_ids.include?(user.organisation_content_id) || user.permissions.include?("Bypass access-limiting")
   end
 
   def manageable_by?(user)

--- a/spec/requests/access_limited_assets_spec.rb
+++ b/spec/requests/access_limited_assets_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Access limited assets", type: :request do
   let(:authorised_user) { FactoryBot.create(:user, uid: "user-1-id") }
   let(:unauthorised_user) { FactoryBot.create(:user, uid: "user-2-id") }
+  let(:api_user_with_special_permission) { FactoryBot.create(:user, uid: "api-user-id", permissions: ["Bypass access-limiting"]) }
   let(:user_from_authorised_organisation) { FactoryBot.create(:user, uid: "user-3-id", organisation_content_id: "org-a") }
   let(:user_from_unauthorised_organisation) { FactoryBot.create(:user, uid: "user-4-id", organisation_content_id: "org-b") }
   let(:asset) { FactoryBot.create(:uploaded_asset, draft: true, access_limited: ["user-1-id"], access_limited_organisation_ids: %w[org-a]) }
@@ -44,5 +45,13 @@ RSpec.describe "Access limited assets", type: :request do
     get download_media_path(id: asset, filename: asset.filename)
 
     expect(response).to be_forbidden
+  end
+
+  it "is accessible to API users with the 'Bypass access-limiting' permission" do
+    login_as api_user_with_special_permission
+
+    get download_media_path(id: asset, filename: asset.filename)
+
+    expect(response).to be_successful
   end
 end


### PR DESCRIPTION
## What

This relies on:

1. Adding a new "Bypass access-limiting" permission [to Asset Manager in Signon](https://signon.integration.publishing.service.gov.uk/doorkeeper_applications/15/supported_permissions)
2. Giving the permission to the [Whitehall API user](https://signon.integration.publishing.service.gov.uk/api_users/5654/edit).

Provided we ensure we send the Authorization header with Whitehall's request to Asset Manager ([described as necessary in the documentation](https://github.com/alphagov/asset-manager/blob/9aa25355788bf929d6db596604c6313143b984e0/docs/api.md#api)), then the API user's permissions should be visible to Asset Manager and it should allow downloading of the asset even if the given (API) user is not on the access-limited users/organisations list.

## Why

This is to enable access-limiting of images in Whitehall. whitehall#11667 does the work to put images on the draft stack and apply access-limiting to them, but additional work is needed for images because Whitehall's image upload journey includes a cropping step, which requires Whitehall to re-download the image from Asset Manager. Currently, this step causes a server error if the image was uploaded to an access-limited document, because the image download fails, because the request to Asset Manager is unauthorized.

### Alternatives considered

1. Setting up a proprietary new shared secret (PR raised in https://github.com/alphagov/asset-manager/pull/2039). It was rightly pointed out that using Signon's existing permissions tools would be the simpler approach.
3. Using the existing auth_bypass_token mechanism. We've taken steps to tighten automatic usage of the auth bypass token - in whitehall#11543 we made it possible to delete the token, and we no longer generate it on document creation - it is opt-in. We don't want to undo that good work. To try to bring it back for this use case feels like a misuse of the auth_bypass_token's intentions. What we want instead is a global bypass for Whitehall itself, not a per-asset bypass.
4. Proxying the user's asset manager cookie, to forward it to Asset Manager and download the asset 'as' the user. This relies on the user having accessed an Asset Manager asset already, which can't be guaranteed.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3751

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
